### PR TITLE
chore: add response verification version to metrics

### DIFF
--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -34,7 +34,7 @@ use crate::{
     },
     routing::{
         error_cause::ErrorCause,
-        ic::{BNResponseMetadata, IcResponseStatus, ResponseVerificationVersion},
+        ic::{BNResponseMetadata, IcResponseStatus},
         middleware::{cache::CacheStatus, geoip::CountryCode, request_id::RequestId},
         CanisterId, RequestCtx, RequestType, RequestTypeApi,
     },
@@ -260,11 +260,12 @@ pub async fn middleware(
         _ => "none",
     };
 
-    let response_verification_version = response
-        .extensions_mut()
-        .remove::<ResponseVerificationVersion>();
+    let response_verification_version = ic_status
+        .as_ref()
+        .map(|x| x.metadata.response_verification_version)
+        .flatten();
     let response_verification_version_str = match response_verification_version {
-        Some(ResponseVerificationVersion(v)) => v.to_string(),
+        Some(v) => v.to_string(),
         _ => "none".to_string(),
     };
 

--- a/src/routing/ic/handler.rs
+++ b/src/routing/ic/handler.rs
@@ -20,7 +20,7 @@ use crate::routing::{
     CanisterId, RequestCtx,
 };
 
-use super::{BNResponseMetadata, ResponseVerificationVersion};
+use super::BNResponseMetadata;
 
 const MAX_REQUEST_BODY_SIZE: usize = 10 * 1_048_576;
 
@@ -92,11 +92,6 @@ pub async fn handler(
     let mut response = resp.canister_response.into_response();
     response.extensions_mut().insert(ic_status);
     response.extensions_mut().insert(bn_metadata);
-    if let Some(response_verification_version) = resp.metadata.response_verification_version {
-        response
-            .extensions_mut()
-            .insert(ResponseVerificationVersion(response_verification_version));
-    }
 
     Ok(response)
 }

--- a/src/routing/ic/mod.rs
+++ b/src/routing/ic/mod.rs
@@ -80,15 +80,6 @@ impl From<&mut HeaderMap> for BNResponseMetadata {
     }
 }
 
-#[derive(Clone, Copy, Eq, PartialEq, PartialOrd, Ord)]
-pub struct ResponseVerificationVersion(pub u16);
-
-impl From<ResponseVerificationVersion> for u16 {
-    fn from(value: ResponseVerificationVersion) -> Self {
-        value.0
-    }
-}
-
 #[derive(Clone)]
 pub struct IcResponseStatus {
     pub streaming: bool,


### PR DESCRIPTION
This PR:
* adds the response verification version as a label to the metrics
* updates to the changed method name of the HTTP gateway library: `unsafe_set_allow_skip_verification` --> `unsafe_set_skip_verification`