### PR TITLE
chore: bump ic-agent to v0.37

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -673,7 +673,7 @@ dependencies = [
  "bitflags 2.6.0",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
+ "itertools 0.11.0",
  "lazy_static",
  "lazycell",
  "log",
@@ -819,20 +819,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bls12_381"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3c196a77437e7cc2fb515ce413a6401291578b5afc8ecb29a3c7ab957f05941"
-dependencies = [
- "digest 0.9.0",
- "ff 0.12.1",
- "group 0.12.1",
- "pairing",
- "rand_core",
- "subtle",
-]
-
-[[package]]
 name = "borsh"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -933,11 +919,13 @@ dependencies = [
 
 [[package]]
 name = "cached"
-version = "0.46.1"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7c8c50262271cdf5abc979a5f76515c234e764fa025d1ba4862c0f0bcda0e95"
+checksum = "69b0116662497bc24e4b177c90eaf8870e39e2714c3fcfa296327a93f593fc21"
 dependencies = [
  "ahash 0.8.11",
+ "cached_proc_macro",
+ "cached_proc_macro_types",
  "hashbrown 0.14.5",
  "instant",
  "once_cell",
@@ -946,13 +934,11 @@ dependencies = [
 
 [[package]]
 name = "cached"
-version = "0.47.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69b0116662497bc24e4b177c90eaf8870e39e2714c3fcfa296327a93f593fc21"
+checksum = "a8466736fe5dbcaf8b8ee24f9bbefe43c884dc3e9ff7178da70f55bffca1133c"
 dependencies = [
  "ahash 0.8.11",
- "cached_proc_macro",
- "cached_proc_macro_types",
  "hashbrown 0.14.5",
  "instant",
  "once_cell",
@@ -1904,7 +1890,7 @@ dependencies = [
 [[package]]
 name = "discower_bowndary"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic.git#735dc20beeec4823be5f21bd5a0b038ff121986d"
+source = "git+https://github.com/dfinity/ic.git#dd2fe60925dd40ed9522710cb1aaefebc4483590"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2031,9 +2017,9 @@ dependencies = [
  "base16ct",
  "crypto-bigint",
  "digest 0.10.7",
- "ff 0.13.0",
+ "ff",
  "generic-array",
- "group 0.13.0",
+ "group",
  "pem-rfc7468",
  "pkcs8",
  "rand_core",
@@ -2190,16 +2176,6 @@ name = "fastrand"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
-
-[[package]]
-name = "ff"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
-dependencies = [
- "rand_core",
- "subtle",
-]
 
 [[package]]
 name = "ff"
@@ -2479,22 +2455,11 @@ dependencies = [
 
 [[package]]
 name = "group"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
-dependencies = [
- "ff 0.12.1",
- "rand_core",
- "subtle",
-]
-
-[[package]]
-name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
- "ff 0.13.0",
+ "ff",
  "rand_core",
  "subtle",
 ]
@@ -2925,26 +2890,6 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0bea761b46ae2b24eb4aef630d8d1c398157b6fc29e6350ecf090a0b70c952c"
-dependencies = [
- "futures-util",
- "http 1.1.0",
- "hyper 1.4.1",
- "hyper-util",
- "log",
- "rustls 0.22.4",
- "rustls-native-certs 0.7.1",
- "rustls-pki-types",
- "tokio",
- "tokio-rustls 0.25.0",
- "tower-service",
- "webpki-roots 0.26.3",
-]
-
-[[package]]
-name = "hyper-rustls"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ee4be2c948921a1a5320b629c4193916ed787a7f7f293fd3f7f5a6c9de74155"
@@ -3018,13 +2963,13 @@ dependencies = [
 
 [[package]]
 name = "ic-agent"
-version = "0.35.0"
+version = "0.37.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f08d1b54f1834fb9637a57855f1d87bb9dbec7a9dec09499737580692829cb0"
+checksum = "3fd3fdf5e5c4f4a9fe5ca612f0febd22dcb161d2f2b75b0142326732be5e4978"
 dependencies = [
  "async-lock",
  "backoff",
- "cached 0.46.1",
+ "cached 0.52.0",
  "candid",
  "ed25519-consensus",
  "futures-util",
@@ -3034,21 +2979,21 @@ dependencies = [
  "http-body-to-bytes",
  "http-body-util",
  "hyper 1.4.1",
- "hyper-rustls 0.26.0",
+ "hyper-rustls 0.27.2",
  "hyper-util",
- "ic-certification 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-certification 2.5.0",
  "ic-transport-types",
  "ic-verify-bls-signature",
  "k256",
  "leb128",
  "p256",
- "pem 2.0.1",
+ "pem",
  "pkcs8",
  "rand",
  "rangemap",
  "reqwest 0.12.5",
  "ring 0.17.8",
- "rustls-webpki 0.101.7",
+ "rustls-webpki 0.102.5",
  "sec1",
  "serde",
  "serde_bytes",
@@ -3065,11 +3010,11 @@ dependencies = [
 
 [[package]]
 name = "ic-cbor"
-version = "2.5.0"
-source = "git+https://github.com/dfinity/response-verification#600b3d5339381bbfe3454ce870a04afa79005c3d"
+version = "2.6.0"
+source = "git+https://github.com/dfinity/response-verification#5aa4f1f5533216e9536142c09b249635401999a4"
 dependencies = [
  "candid",
- "ic-certification 2.5.0 (git+https://github.com/dfinity/response-verification)",
+ "ic-certification 2.6.0",
  "leb128",
  "nom",
  "thiserror",
@@ -3077,13 +3022,13 @@ dependencies = [
 
 [[package]]
 name = "ic-certificate-verification"
-version = "2.5.0"
-source = "git+https://github.com/dfinity/response-verification#600b3d5339381bbfe3454ce870a04afa79005c3d"
+version = "2.6.0"
+source = "git+https://github.com/dfinity/response-verification#5aa4f1f5533216e9536142c09b249635401999a4"
 dependencies = [
  "cached 0.47.0",
  "candid",
  "ic-cbor",
- "ic-certification 2.5.0 (git+https://github.com/dfinity/response-verification)",
+ "ic-certification 2.6.0",
  "lazy_static",
  "leb128",
  "miracl_core_bls12381",
@@ -3107,8 +3052,8 @@ dependencies = [
 
 [[package]]
 name = "ic-certification"
-version = "2.5.0"
-source = "git+https://github.com/dfinity/response-verification#600b3d5339381bbfe3454ce870a04afa79005c3d"
+version = "2.6.0"
+source = "git+https://github.com/dfinity/response-verification#5aa4f1f5533216e9536142c09b249635401999a4"
 dependencies = [
  "hex",
  "sha2 0.10.8",
@@ -3212,12 +3157,12 @@ dependencies = [
 
 [[package]]
 name = "ic-http-certification"
-version = "2.5.0"
-source = "git+https://github.com/dfinity/response-verification#600b3d5339381bbfe3454ce870a04afa79005c3d"
+version = "2.6.0"
+source = "git+https://github.com/dfinity/response-verification#5aa4f1f5533216e9536142c09b249635401999a4"
 dependencies = [
  "candid",
  "http 0.2.12",
- "ic-certification 2.5.0 (git+https://github.com/dfinity/response-verification)",
+ "ic-certification 2.6.0",
  "ic-representation-independent-hash",
  "serde",
  "thiserror",
@@ -3227,7 +3172,7 @@ dependencies = [
 [[package]]
 name = "ic-http-gateway"
 version = "0.0.0"
-source = "git+https://github.com/dfinity/http-gateway#1615ec4bc68b631a0f518857e6254b5093b37571"
+source = "git+https://github.com/dfinity/http-gateway#a1f63eb17b0a89f7fadcab67b3a0afe1720ef9b3"
 dependencies = [
  "bytes",
  "candid",
@@ -3244,8 +3189,8 @@ dependencies = [
 
 [[package]]
 name = "ic-representation-independent-hash"
-version = "2.5.0"
-source = "git+https://github.com/dfinity/response-verification#600b3d5339381bbfe3454ce870a04afa79005c3d"
+version = "2.6.0"
+source = "git+https://github.com/dfinity/response-verification#5aa4f1f5533216e9536142c09b249635401999a4"
 dependencies = [
  "leb128",
  "sha2 0.10.8",
@@ -3253,8 +3198,8 @@ dependencies = [
 
 [[package]]
 name = "ic-response-verification"
-version = "2.5.0"
-source = "git+https://github.com/dfinity/response-verification#600b3d5339381bbfe3454ce870a04afa79005c3d"
+version = "2.6.0"
+source = "git+https://github.com/dfinity/response-verification#5aa4f1f5533216e9536142c09b249635401999a4"
 dependencies = [
  "base64 0.21.7",
  "candid",
@@ -3263,7 +3208,7 @@ dependencies = [
  "http 0.2.12",
  "ic-cbor",
  "ic-certificate-verification",
- "ic-certification 2.5.0 (git+https://github.com/dfinity/response-verification)",
+ "ic-certification 2.6.0",
  "ic-http-certification",
  "ic-representation-independent-hash",
  "leb128",
@@ -3276,13 +3221,13 @@ dependencies = [
 
 [[package]]
 name = "ic-transport-types"
-version = "0.35.0"
+version = "0.37.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1c68959f501cfcb79319b6720fd1903a661d77b503e6128bfce31f91ad87aca"
+checksum = "875dc4704780383112e8e8b5063a1b98de114321d0c7d3e7f635dcf360a57fba"
 dependencies = [
  "candid",
  "hex",
- "ic-certification 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-certification 2.5.0",
  "leb128",
  "serde",
  "serde_bytes",
@@ -3293,9 +3238,9 @@ dependencies = [
 
 [[package]]
 name = "ic-utils"
-version = "0.35.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61fd20379ac2d86f85e177e75e72b27eaa595a9561891d5be0e7d0ca37604bbb"
+checksum = "2fa832296800758c9c921dd1704985ded6b3e6fbc3aee409727eb1f00d69a595"
 dependencies = [
  "async-trait",
  "candid",
@@ -3306,8 +3251,8 @@ dependencies = [
  "serde",
  "serde_bytes",
  "sha2 0.10.8",
- "strum 0.24.1",
- "strum_macros 0.24.3",
+ "strum 0.26.3",
+ "strum_macros 0.26.4",
  "thiserror",
  "time",
  "tokio",
@@ -3315,14 +3260,30 @@ dependencies = [
 
 [[package]]
 name = "ic-verify-bls-signature"
-version = "0.1.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "583b1c03380cf86059160cc6c91dcbf56c7b5f141bf3a4f06bc79762d775fac4"
+checksum = "d420b25c0091059f6c3c23a21427a81915e6e0aca3b79e0d403ed767f286a3b9"
 dependencies = [
- "bls12_381",
+ "hex",
+ "ic_bls12_381",
  "lazy_static",
  "pairing",
- "sha2 0.9.9",
+ "rand",
+ "sha2 0.10.8",
+]
+
+[[package]]
+name = "ic_bls12_381"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22c65787944f32af084dffd0c68c1e544237b76e215654ddea8cd9f527dd8b69"
+dependencies = [
+ "digest 0.10.7",
+ "ff",
+ "group",
+ "pairing",
+ "rand_core",
+ "subtle",
 ]
 
 [[package]]
@@ -4386,11 +4347,11 @@ dependencies = [
 
 [[package]]
 name = "pairing"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "135590d8bdba2b31346f9cd1fb2a912329f5135e832a4f422942eb6ead8b6b3b"
+checksum = "81fec4625e73cf41ef4bb6846cafa6d44736525f442ba45e407c4a000a13996f"
 dependencies = [
- "group 0.12.1",
+ "group",
 ]
 
 [[package]]
@@ -4448,16 +4409,6 @@ name = "peeking_take_while"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e9ed2178b0575fff8e1b83b58ba6f75e727aafac2e1b6c795169ad3b17eb518"
-
-[[package]]
-name = "pem"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b13fe415cdf3c8e44518e18a7c95a13431d9bdf6d15367d82b23c377fdd441a"
-dependencies = [
- "base64 0.21.7",
- "serde",
-]
 
 [[package]]
 name = "pem"
@@ -4886,7 +4837,7 @@ checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
 dependencies = [
  "bytes",
  "heck 0.5.0",
- "itertools 0.12.1",
+ "itertools 0.11.0",
  "log",
  "multimap",
  "once_cell",
@@ -4906,7 +4857,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.70",
@@ -5265,7 +5216,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54077e1872c46788540de1ea3d7f4ccb1983d12f9aa909b234468676c1a36779"
 dependencies = [
  "aws-lc-rs",
- "pem 3.0.4",
+ "pem",
  "ring 0.17.8",
  "rustls-pki-types",
  "time",
@@ -5659,7 +5610,7 @@ dependencies = [
  "futures-rustls",
  "http 1.1.0",
  "log",
- "pem 3.0.4",
+ "pem",
  "rcgen",
  "serde",
  "serde_json",
@@ -6393,12 +6344,6 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
-
-[[package]]
-name = "strum"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
@@ -6410,19 +6355,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
 dependencies = [
  "strum_macros 0.26.4",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.24.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
-dependencies = [
- "heck 0.4.1",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn 1.0.109",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,9 +57,9 @@ itertools = "0.12"
 humantime = "2.1"
 hyper = "1.3"
 hyper-util = "0.1"
-ic-agent = { version = "0.35", features = ["reqwest"] }
+ic-agent = { version = "0.37", features = ["reqwest"] }
 ic-http-gateway = { git = "https://github.com/dfinity/http-gateway" }
-ic-transport-types = "0.35"
+ic-transport-types = "0.37"
 instant-acme = "0.4"
 tikv-jemallocator = "0.5"
 tikv-jemalloc-ctl = "0.5"

--- a/src/routing/ic/transport.rs
+++ b/src/routing/ic/transport.rs
@@ -12,7 +12,7 @@ use ic_agent::{
         Transport,
     },
     export::Principal,
-    AgentError, RequestId,
+    AgentError,
 };
 use ic_transport_types::RejectResponse;
 use reqwest::{
@@ -203,13 +203,12 @@ impl Transport for ReqwestTransport {
         &self,
         effective_canister_id: Principal,
         envelope: Vec<u8>,
-        _request_id: RequestId,
-    ) -> AgentFuture<()> {
+    ) -> AgentFuture<ic_agent::TransportCallResponse> {
         Box::pin(async move {
             let endpoint = format!("canister/{}/call", effective_canister_id.to_text());
             self.execute(Method::POST, &endpoint, Some(envelope))
                 .await?;
-            Ok(())
+            Ok(ic_agent::TransportCallResponse::Accepted)
         })
     }
 


### PR DESCRIPTION
This PR bumps ic-agent and ic-transport-types to v0.37.