### PR TITLE
fix: adapt endpoints to include api/vX and add api/v3/call support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1889,7 +1889,7 @@ dependencies = [
 [[package]]
 name = "discower_bowndary"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic.git#2bdfdc54ccc7ef27dd7b4f37aaea172198dce6ab"
+source = "git+https://github.com/dfinity/ic.git#29e7b09ed6b317f67b83aff463e9fe3ad6bf5449"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4664,9 +4664,13 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.17"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+checksum = "2288c0e17cc8d342c712bb43a257a80ebffce59cdb33d5000d8348f3ec02528b"
+dependencies = [
+ "zerocopy",
+ "zerocopy-derive",
+]
 
 [[package]]
 name = "precomputed-hash"
@@ -6760,21 +6764,21 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.16"
+version = "0.8.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81967dd0dd2c1ab0bc3468bd7caecc32b8a4aa47d0c8c695d8c2b2108168d62c"
+checksum = "7a44eede9b727419af8095cb2d72fab15487a541f54647ad4414b34096ee4631"
 dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.22.17",
+ "toml_edit 0.22.18",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.7"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8fb9f64314842840f1d940ac544da178732128f1c78c21772e876579e0da1db"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
 dependencies = [
  "serde",
 ]
@@ -6803,9 +6807,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.17"
+version = "0.22.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d9f8729f5aea9562aac1cc0441f5d6de3cff1ee0c5d67293eeca5eb36ee7c16"
+checksum = "1490595c74d930da779e944f5ba2ecdf538af67df1a9848cbd156af43c1b7cf0"
 dependencies = [
  "indexmap 2.2.6",
  "serde",
@@ -8066,6 +8070,7 @@ version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
+ "byteorder",
  "zerocopy-derive",
 ]
 

--- a/src/routing/middleware/denylist.rs
+++ b/src/routing/middleware/denylist.rs
@@ -10,7 +10,6 @@ use prometheus::Registry;
 use reqwest::Url;
 
 use crate::{
-    cli::Cli,
     http::Client,
     policy::denylist::Denylist,
     routing::{middleware::geoip::CountryCode, CanisterId, ErrorCause},


### PR DESCRIPTION
This is supposed to copy over the changes from the agent reqwest transport ([commit 203467cb1e3bac96290061ad573d8de1b9f697e3](https://github.com/dfinity/agent-rs/commit/203467cb1e3bac96290061ad573d8de1b9f697e3#diff-051f3853aa3eb2747ef68a79ccfb21e74fb3057064e6f89c3bd418d7dfcd0232)) to the custom transport.