### PR TITLE
fix(BOUN-1209): fix vector, log backend, disable signed queries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -229,9 +229,9 @@ checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.4"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "ascii-canvas"
@@ -266,7 +266,7 @@ checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.75",
  "synstructure",
 ]
 
@@ -278,7 +278,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -371,7 +371,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -393,7 +393,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -410,7 +410,7 @@ checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -683,7 +683,7 @@ dependencies = [
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
- "syn 2.0.74",
+ "syn 2.0.75",
  "which",
 ]
 
@@ -744,7 +744,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afb15541e888071f64592c0b4364fdff21b7cb0a247f984296699351963a8721"
 dependencies = [
  "quote",
- "syn 2.0.74",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -838,7 +838,7 @@ dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.75",
  "syn_derive",
 ]
 
@@ -995,7 +995,7 @@ dependencies = [
  "lazy_static",
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -1015,9 +1015,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.12"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68064e60dbf1f17005c2fde4d07c16d8baa506fd7ffed8ccab702d93617975c7"
+checksum = "72db2f7947ecee9b03b510377e8bb9077afa27176fdbff55c51027e976fdcc48"
 dependencies = [
  "jobserver",
  "libc",
@@ -1225,9 +1225,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.15"
+version = "4.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11d8838454fda655dafd3accb2b6e2bea645b9e4078abe84a22ceb947235c5cc"
+checksum = "ed6719fffa43d0d87e5fd8caeab59be1554fb028cd30edc88fc4369b17971019"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1254,7 +1254,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -1295,7 +1295,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.74",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -1708,7 +1708,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.74",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -1730,7 +1730,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core 0.20.10",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -1818,7 +1818,7 @@ checksum = "d150dea618e920167e5973d70ae6ece4385b7164e0d799fe7c122dd0a5d912ad"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -1829,7 +1829,7 @@ checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -1842,7 +1842,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.74",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -1895,7 +1895,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -2058,7 +2058,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -2078,7 +2078,7 @@ checksum = "de0d48a183585823424a4ce1aa132d174a6a81bd540895822eb4c8373a8e49e8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -2316,7 +2316,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -2850,7 +2850,7 @@ dependencies = [
  "hyper 0.14.30",
  "log",
  "rustls 0.22.4",
- "rustls-native-certs 0.7.1",
+ "rustls-native-certs 0.7.2",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.25.0",
@@ -2978,7 +2978,7 @@ dependencies = [
 [[package]]
 name = "ic-cbor"
 version = "2.6.0"
-source = "git+https://github.com/dfinity/response-verification#060d7bf4ae26534592c088f20ad39508c278a389"
+source = "git+https://github.com/dfinity/response-verification#da70db93832f88ecc556ae082612aedec47d3816"
 dependencies = [
  "candid",
  "ic-certification 2.6.0 (git+https://github.com/dfinity/response-verification)",
@@ -2990,7 +2990,7 @@ dependencies = [
 [[package]]
 name = "ic-certificate-verification"
 version = "2.6.0"
-source = "git+https://github.com/dfinity/response-verification#060d7bf4ae26534592c088f20ad39508c278a389"
+source = "git+https://github.com/dfinity/response-verification#da70db93832f88ecc556ae082612aedec47d3816"
 dependencies = [
  "cached 0.47.0",
  "candid",
@@ -3020,7 +3020,7 @@ dependencies = [
 [[package]]
 name = "ic-certification"
 version = "2.6.0"
-source = "git+https://github.com/dfinity/response-verification#060d7bf4ae26534592c088f20ad39508c278a389"
+source = "git+https://github.com/dfinity/response-verification#da70db93832f88ecc556ae082612aedec47d3816"
 dependencies = [
  "hex",
  "sha2 0.10.8",
@@ -3123,7 +3123,7 @@ dependencies = [
 [[package]]
 name = "ic-http-certification"
 version = "2.6.0"
-source = "git+https://github.com/dfinity/response-verification#060d7bf4ae26534592c088f20ad39508c278a389"
+source = "git+https://github.com/dfinity/response-verification#da70db93832f88ecc556ae082612aedec47d3816"
 dependencies = [
  "candid",
  "http 0.2.12",
@@ -3155,7 +3155,7 @@ dependencies = [
 [[package]]
 name = "ic-representation-independent-hash"
 version = "2.6.0"
-source = "git+https://github.com/dfinity/response-verification#060d7bf4ae26534592c088f20ad39508c278a389"
+source = "git+https://github.com/dfinity/response-verification#da70db93832f88ecc556ae082612aedec47d3816"
 dependencies = [
  "leb128",
  "sha2 0.10.8",
@@ -3164,7 +3164,7 @@ dependencies = [
 [[package]]
 name = "ic-response-verification"
 version = "2.6.0"
-source = "git+https://github.com/dfinity/response-verification#060d7bf4ae26534592c088f20ad39508c278a389"
+source = "git+https://github.com/dfinity/response-verification#da70db93832f88ecc556ae082612aedec47d3816"
 dependencies = [
  "base64 0.21.7",
  "candid",
@@ -3610,9 +3610,9 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
-version = "0.2.155"
+version = "0.2.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
 
 [[package]]
 name = "libflate"
@@ -3826,7 +3826,7 @@ checksum = "38b4faf00617defe497754acde3024865bc143d44a86799b24e191ecff91354f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -3933,7 +3933,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -4122,7 +4122,7 @@ dependencies = [
  "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -4452,7 +4452,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -4540,7 +4540,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -4717,7 +4717,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f12335488a2f3b0a83b14edad48dca9879ce89b2edd10e80237e4e852dd645e"
 dependencies = [
  "proc-macro2",
- "syn 2.0.74",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -4835,7 +4835,7 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn 2.0.74",
+ "syn 2.0.75",
  "tempfile",
 ]
 
@@ -4849,7 +4849,7 @@ dependencies = [
  "itertools 0.12.1",
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -5110,7 +5110,7 @@ version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5379b720091e4bf4a9f118eb46f4ffb67bb8b7551649528c89e265cf880e748"
 dependencies = [
- "arrayvec 0.7.4",
+ "arrayvec 0.7.6",
  "bitvec",
  "bitvec-nom2",
  "bytes",
@@ -5486,7 +5486,7 @@ version = "1.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1790d1c4c0ca81211399e0e0af16333276f375209e71a37b67698a373db5b47a"
 dependencies = [
- "arrayvec 0.7.4",
+ "arrayvec 0.7.6",
  "borsh",
  "bytes",
  "num-traits",
@@ -5629,9 +5629,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a88d6d420651b496bdd98684116959239430022a115c1240e6c3993be0b15fba"
+checksum = "04182dffc9091a404e0fc069ea5cd60e5b866c3adf881eff99a32d048242dffa"
 dependencies = [
  "openssl-probe",
  "rustls-pemfile 2.1.3",
@@ -5677,7 +5677,7 @@ dependencies = [
  "log",
  "once_cell",
  "rustls 0.23.12",
- "rustls-native-certs 0.7.1",
+ "rustls-native-certs 0.7.2",
  "rustls-platform-verifier-android",
  "rustls-webpki 0.102.6",
  "security-framework",
@@ -5803,7 +5803,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -5852,9 +5852,9 @@ checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
-version = "1.0.207"
+version = "1.0.208"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5665e14a49a4ea1b91029ba7d3bca9f299e1f7cfa194388ccc20f14743e784f2"
+checksum = "cff085d2cb684faa248efb494c39b68e522822ac0de72ccf08109abde717cfb2"
 dependencies = [
  "serde_derive",
 ]
@@ -5890,13 +5890,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.207"
+version = "1.0.208"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aea2634c86b0e8ef2cfdc0c340baede54ec27b1e46febd7f80dffb2aa44a00e"
+checksum = "24008e81ff7613ed8e5ba0cfaf24e2c2f1e5b8a0495711e44fcd4882fca62bcf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -5907,7 +5907,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -5940,7 +5940,7 @@ checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -6007,7 +6007,7 @@ dependencies = [
  "darling 0.20.10",
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -6019,7 +6019,7 @@ dependencies = [
  "darling 0.20.10",
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -6225,7 +6225,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -6364,7 +6364,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.74",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -6377,7 +6377,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.74",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -6405,9 +6405,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.74"
+version = "2.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fceb41e3d546d0bd83421d3409b1460cc7444cd389341a4c880fe7a042cb3d7"
+checksum = "f6af063034fc1935ede7be0122941bafa9bacb949334d090b77ca98b5817c7d9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6423,7 +6423,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -6446,7 +6446,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -6548,7 +6548,7 @@ checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -6659,9 +6659,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.39.2"
+version = "1.39.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daa4fb1bc778bd6f04cbfc4bb2d06a7396a8f299dc33ea1900cedaa316f467b1"
+checksum = "9babc99b9923bfa4804bd74722ff02c0381021eafa4db9949217e3be8e84fff5"
 dependencies = [
  "backtrace",
  "bytes",
@@ -6693,7 +6693,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -6925,7 +6925,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -7058,14 +7058,14 @@ checksum = "f03ca4cb38206e2bef0700092660bb74d696f808514dae47fa1467cbfe26e96e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.75",
 ]
 
 [[package]]
 name = "typeid"
-version = "1.0.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "059d83cc991e7a42fc37bd50941885db0888e34209f8cfd9aab07ddec03bc9cf"
+checksum = "0e13db2e0ccd5e14a544e8a246ba2312cd25223f616442d7f2cb0e3db614236e"
 
 [[package]]
 name = "typenum"
@@ -7094,7 +7094,7 @@ checksum = "70b20a22c42c8f1cd23ce5e34f165d4d37038f5b663ad20fb6adbdf029172483"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -7348,7 +7348,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "syn 2.0.74",
+ "syn 2.0.75",
  "tracing",
 ]
 
@@ -7361,7 +7361,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.74",
+ "syn 2.0.75",
  "vector-config-common",
 ]
 
@@ -7635,7 +7635,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.75",
  "wasm-bindgen-shared",
 ]
 
@@ -7669,7 +7669,7 @@ checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.75",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -8119,7 +8119,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -8139,7 +8139,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.75",
 ]
 
 [[package]]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.79.0"
+channel = "1.80.0"
 targets = ["x86_64-unknown-linux-musl"]
 profile = "minimal"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -178,12 +178,13 @@ pub struct Ic {
     pub ic_max_request_retries: u32,
 
     /// Disable response verification for the IC requests.
-    #[clap(env, long, default_value = "false")]
+    #[clap(env, long)]
     pub ic_unsafe_disable_response_verification: bool,
 
-    /// Disable replica-signed queries in the agent.
-    #[clap(env, long, default_value = "false")]
-    pub ic_unsafe_disable_replica_signed_queries: bool,
+    /// Enable replica-signed queries in the agent.
+    /// Since the responses' certificates are anyway validated - it makes the signed queries redundant.
+    #[clap(env, long)]
+    pub ic_enable_replica_signed_queries: bool,
 }
 
 #[derive(Args)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -397,6 +397,10 @@ pub struct Vector {
     /// If the buffer is full then new events will be dropped.
     #[clap(env, long, default_value = "131072")]
     pub log_vector_buffer: usize,
+
+    /// Vector HTTP request timeout for a batch flush
+    #[clap(env, long, default_value = "30s", value_parser = parse_duration)]
+    pub log_vector_timeout: Duration,
 }
 
 #[derive(Args)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -173,7 +173,7 @@ pub struct Ic {
     #[clap(env, long)]
     pub ic_root_key: Option<PathBuf>,
 
-    /// Maximum mumber of request retries in the transport layer for both network- and http-related failures.
+    /// Maximum number of request retries for connection failures.
     #[clap(env, long, default_value = "5")]
     pub ic_max_request_retries: u32,
 

--- a/src/core.rs
+++ b/src/core.rs
@@ -26,8 +26,8 @@ pub async fn main(cli: &Cli) -> Result<(), Error> {
     ENV.set(cli.misc.env.clone()).unwrap();
     HOSTNAME.set(cli.misc.hostname.clone()).unwrap();
 
-    if cli.ic.ic_unsafe_disable_replica_signed_queries {
-        warn!("Replica-signed queries are disabled");
+    if cli.ic.ic_enable_replica_signed_queries {
+        warn!("Replica-signed queries are enabled");
     }
 
     if cli.ic.ic_unsafe_disable_response_verification {

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -446,48 +446,6 @@ pub async fn middleware(
         if let Some(v) = &state.vector {
             // TODO use proper names when the DB is updated
 
-            // let val = json!({
-            //     "env": ENV.get().unwrap().as_str(),
-            //     "hostname": HOSTNAME.get().unwrap().as_str(),
-            //     "date": timestamp.unix_timestamp(),
-            //     "request_id": request_id.to_string(),
-            //     "conn_id": conn_info.id.to_string(),
-            //     "method": method,
-            //     "http_version": http_version,
-            //     "request_type": request_type,
-            //     "geo_country_code": country_code,
-            //     "status": status,
-            //     "domain": domain,
-            //     "host": host,
-            //     "path": path,
-            //     "canister_id": canister_id,
-            //     "ic_streaming": ic_streaming,
-            //     "ic_upgrade": ic_upgrade,
-            //     "ic_node_id": meta.node_id,
-            //     "ic_subnet_id": meta.subnet_id,
-            //     "ic_subnet_type": meta.subnet_type,
-            //     "ic_method_name": meta.method_name,
-            //     "ic_sender": meta.sender,
-            //     "ic_canister_id_cbor": meta.canister_id_cbor,
-            //     "ic_error_cause": meta.error_cause,
-            //     "ic_retries": meta.retries,
-            //     "ic_cache_status": meta.cache_status,
-            //     "ic_cache_bypass_reason": meta.cache_bypass_reason,
-            //     "error_cause": error_cause,
-            //     "tls_version": tls_version,
-            //     "tls_cipher": tls_cipher,
-            //     "remote_addr": conn_info.remote_addr.to_string(),
-            //     "req_rcvd": request_size,
-            //     "req_sent": response_size,
-            //     "conn_rcvd": conn_rcvd,
-            //     "conn_sent": conn_sent,
-            //     "duration": duration.as_secs_f64(),
-            //     "duration_full": duration_full.as_secs_f64(),
-            //     "duration_conn": conn_info.accepted_at.elapsed().as_secs_f64(),
-            //     "cache_status": cache_status_str,
-            //     "cache_bypass_reason": cache_bypass_reason_str,
-            // });
-
             // Nginx-compatible log entry
             let val = json!({
                 "env": ENV.get().unwrap().as_str(),

--- a/src/metrics/vector.rs
+++ b/src/metrics/vector.rs
@@ -180,7 +180,7 @@ impl VectorActor {
         let mut encoder = self.encoder.clone();
         let Ok(body) = encoder.encode_batch(&mut self.batch) else {
             self.batch.clear();
-            return Err(anyhow!("unable to encode batch, flushing it"));
+            return Err(anyhow!("unable to encode batch, dropping it"));
         };
 
         // Retry
@@ -189,6 +189,7 @@ impl VectorActor {
         let mut retries = 5;
 
         while retries > 0 {
+            // Bytes is cheap to clone
             if let Err(e) = self.send(body.clone()).await {
                 warn!("Vector: unable to flush batch: {e:#}");
             } else {

--- a/src/routing/ic/health_check.rs
+++ b/src/routing/ic/health_check.rs
@@ -22,7 +22,7 @@ pub struct HealthChecker {
 
 impl HealthChecker {
     /// Creates a new `HealthChecker` instance.
-    pub fn new(http_client: Client, timeout: Duration) -> Self {
+    pub const fn new(http_client: Client, timeout: Duration) -> Self {
         Self {
             http_client,
             timeout,

--- a/src/routing/ic/mod.rs
+++ b/src/routing/ic/mod.rs
@@ -106,9 +106,10 @@ pub fn setup(
         http_client,
         cli.ic.ic_max_request_retries,
     );
+
     let agent = ic_agent::Agent::builder()
         .with_transport(transport)
-        .with_verify_query_signatures(!cli.ic.ic_unsafe_disable_replica_signed_queries)
+        .with_verify_query_signatures(cli.ic.ic_enable_replica_signed_queries)
         .build()?;
 
     if let Some(v) = &cli.ic.ic_root_key {

--- a/src/routing/ic/mod.rs
+++ b/src/routing/ic/mod.rs
@@ -27,7 +27,13 @@ use crate::{
     Cli,
 };
 
-/// Metadata about the request by a Boundary Node (ic-boundary)
+/// Metadata about the request to a Boundary Node (ic-boundary)
+#[derive(Clone, Default)]
+pub struct BNRequestMetadata {
+    pub backend: Option<String>,
+}
+
+/// Metadata about the response from a Boundary Node (ic-boundary)
 #[derive(Clone)]
 pub struct BNResponseMetadata {
     pub node_id: String,

--- a/src/routing/ic/nodes_fetcher.rs
+++ b/src/routing/ic/nodes_fetcher.rs
@@ -27,7 +27,7 @@ pub struct NodesFetcher {
 
 impl NodesFetcher {
     /// Creates a new `NodesFetcher` instance.
-    pub fn new(http_client: Client, subnet_id: Principal, root_key: Option<Vec<u8>>) -> Self {
+    pub const fn new(http_client: Client, subnet_id: Principal, root_key: Option<Vec<u8>>) -> Self {
         Self {
             http_client,
             subnet_id,

--- a/src/routing/ic/transport.rs
+++ b/src/routing/ic/transport.rs
@@ -24,14 +24,16 @@ type AgentFuture<'a, V> = Pin<Box<dyn Future<Output = Result<V, AgentError>> + S
 
 const MAX_RESPONSE_SIZE: usize = 2 * 1_048_576;
 
-pub struct PassHeaders {
+pub struct Context {
+    pub hostname: Option<String>,
     pub headers_in: HeaderMap<HeaderValue>,
     pub headers_out: HeaderMap<HeaderValue>,
 }
 
-impl PassHeaders {
+impl Context {
     pub fn new() -> RefCell<Self> {
         RefCell::new(Self {
+            hostname: None,
             headers_in: HeaderMap::new(),
             headers_out: HeaderMap::new(),
         })
@@ -39,7 +41,7 @@ impl PassHeaders {
 }
 
 task_local! {
-    pub static PASS_HEADERS: RefCell<PassHeaders>;
+    pub static CONTEXT: RefCell<Context>;
 }
 
 /// A [`Transport`] using [`HttpClient`] to make HTTP calls to the Internet Computer.
@@ -115,18 +117,29 @@ impl ReqwestTransport {
         body: Option<Vec<u8>>,
     ) -> Result<(StatusCode, Vec<u8>), AgentError> {
         let url = self.route_provider.route()?.join(endpoint)?;
+        let hostname = url.authority().to_string();
+
         let mut http_request = Request::new(method, url);
         http_request
             .headers_mut()
             .insert(CONTENT_TYPE, CONTENT_TYPE_CBOR);
 
-        // Add HTTP headers if requested
-        let _ = PASS_HEADERS.try_with(|x| {
-            let mut pass = x.borrow_mut();
-            for (k, v) in &pass.headers_out {
+        // Add hostname & HTTP headers
+        let _ = CONTEXT.try_with(|x| {
+            let mut ctx = x.borrow_mut();
+
+            // Certain agent calls map to several underlying HTTP calls,
+            // e.g. read_state + query.
+            // Set hostname only from the initial call.
+            if ctx.hostname.is_none() {
+                ctx.hostname = Some(hostname);
+            }
+
+            for (k, v) in &ctx.headers_out {
                 http_request.headers_mut().append(k, v.clone());
             }
-            pass.headers_out.clear();
+
+            ctx.headers_out.clear();
         });
 
         *http_request.body_mut() = body.map(Body::from);
@@ -158,12 +171,12 @@ impl ReqwestTransport {
         // the agent can do several outgoing requests (e.g. read_state to get keys and then query)
         // and we need only one set of response headers.
         if !endpoint.ends_with("/read_state") {
-            let _ = PASS_HEADERS.try_with(|x| {
-                let mut pass = x.borrow_mut();
-                pass.headers_in.clear();
+            let _ = CONTEXT.try_with(|x| {
+                let mut ctx = x.borrow_mut();
+                ctx.headers_in.clear();
 
                 for (k, v) in &headers {
-                    pass.headers_in.insert(k, v.clone());
+                    ctx.headers_in.insert(k, v.clone());
                 }
             });
         }

--- a/src/routing/mod.rs
+++ b/src/routing/mod.rs
@@ -113,6 +113,7 @@ pub async fn redirect_to_https(
     )
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn setup_router(
     cli: &Cli,
     custom_domain_providers: Vec<Arc<dyn ProvidesCustomDomains>>,


### PR DESCRIPTION
Sorry for a bit of mixup of different things in one PR :)

- Rework a bit Vector metric sink to try to avoid rare lockups
- Add `BNRequestMetadata` to track request fields. Currently holds only the IC backend that was used by the agent-rs. Also log this field to console and Vector.
- Disable signed queries by default since they're redundant and require `read_state` calls to fetch subnet keys
- Improve retries in `Transport` - create request only once and then clone it while updating the URL
- Update a few deps
- Update Rust to 1.80