### PR TITLE
feat(BOUN-1214): add client timeouts

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -129,6 +129,15 @@ pub struct HttpServer {
     #[clap(env, long, default_value = "2048")]
     pub http_server_backlog: u32,
 
+    /// For how long to wait for the client to send headers
+    /// Currently applies only to HTTP1 connections.
+    #[clap(env, long, default_value = "15s", value_parser = parse_duration)]
+    pub http_server_http1_header_read_timeout: Duration,
+
+    /// For how long to wait for the client to send request body.
+    #[clap(env, long, default_value = "60s", value_parser = parse_duration)]
+    pub http_server_body_read_timeout: Duration,
+
     /// Maximum number of HTTP2 streams that the client is allowed to create in a single connection
     #[clap(env, long, default_value = "128")]
     pub http_server_http2_max_streams: u32,
@@ -492,6 +501,7 @@ impl From<&HttpServer> for crate::http::server::Options {
     fn from(c: &HttpServer) -> Self {
         Self {
             backlog: c.http_server_backlog,
+            http1_header_read_timeout: c.http_server_http1_header_read_timeout,
             http2_keepalive_interval: c.http_server_http2_keepalive_interval,
             http2_keepalive_timeout: c.http_server_http2_keepalive_timeout,
             http2_max_streams: c.http_server_http2_max_streams,

--- a/src/http/server.rs
+++ b/src/http/server.rs
@@ -157,7 +157,7 @@ pub struct ConnInfo {
     pub remote_addr: SocketAddr,
     pub traffic: Arc<Stats>,
     pub req_count: AtomicU64,
-    close: CancellationToken,
+    pub close: CancellationToken,
 }
 
 impl ConnInfo {

--- a/src/http/server.rs
+++ b/src/http/server.rs
@@ -112,6 +112,7 @@ impl Metrics {
 #[derive(Clone, Copy)]
 pub struct Options {
     pub backlog: u32,
+    pub http1_header_read_timeout: Duration,
     pub http2_max_streams: u32,
     pub http2_keepalive_interval: Duration,
     pub http2_keepalive_timeout: Duration,
@@ -399,6 +400,8 @@ impl Server {
         let mut builder = Builder::new(TokioExecutor::new());
         builder
             .http1()
+            .timer(TokioTimer::new())
+            .header_read_timeout(Some(self.options.http1_header_read_timeout))
             .keep_alive(true)
             .http2()
             .adaptive_window(true)

--- a/src/routing/middleware/rate_limiter.rs
+++ b/src/routing/middleware/rate_limiter.rs
@@ -80,6 +80,7 @@ mod tests {
         sync::{atomic::AtomicU64, Arc},
         time::Duration,
     };
+    use tokio_util::sync::CancellationToken;
 
     use tokio::time::sleep;
     use tower::Service;
@@ -106,6 +107,7 @@ mod tests {
             remote_addr: "127.0.0.1:8080".parse().unwrap(),
             traffic: Arc::new(Stats::new()),
             req_count: AtomicU64::new(0),
+            close: CancellationToken::new(),
         };
         let mut request = Request::post("/").body(Body::from("".to_string())).unwrap();
         request.extensions_mut().insert(Arc::new(conn_info));

--- a/src/routing/mod.rs
+++ b/src/routing/mod.rs
@@ -223,6 +223,7 @@ pub async fn setup_router(
     let state_handler = Arc::new(handler::HandlerState::new(
         client,
         !cli.ic.ic_unsafe_disable_response_verification,
+        cli.http_server.http_server_body_read_timeout,
     ));
     let state_api = Arc::new(proxy::ApiProxyState::new(
         http_client.clone(),

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -30,7 +30,7 @@ impl TaskManager {
         self.tasks.push(Task(name.into(), task));
     }
 
-    pub fn start(&mut self, token: &CancellationToken) {
+    pub fn start(&self, token: &CancellationToken) {
         warn!("TaskManager: starting {} tasks", self.tasks.len());
 
         for task in self.tasks.clone() {


### PR DESCRIPTION
- Add header timeout for HTTP1 connections (no support for HTTP2 it seems)
- Add body read timeout to limit the time we wait for the client to send body. Otherwise it can be stalled forever.
- Add the `close()` method on `ConnInfo` that allows us to close the connection from Axum
- Close the connection if body timeout was detected