### PR TITLE
fix: log api/v3/call as call_v3 instead of unknown

### DIFF
--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -168,6 +168,7 @@ fn infer_request_type(path: &str) -> RequestType {
     match path {
         "/api/v2/canister/:principal/query" => RequestType::Api(RequestTypeApi::Query),
         "/api/v2/canister/:principal/call" => RequestType::Api(RequestTypeApi::Call),
+        "/api/v3/canister/:principal/call" => RequestType::Api(RequestTypeApi::CallV3),
         "/api/v2/canister/:principal/read_state" => RequestType::Api(RequestTypeApi::ReadState),
         "/api/v2/subnet/:principal/read_state" => RequestType::Api(RequestTypeApi::ReadStateSubnet),
         "/api/v2/status" => RequestType::Api(RequestTypeApi::Status),

--- a/src/routing/mod.rs
+++ b/src/routing/mod.rs
@@ -66,6 +66,7 @@ pub enum RequestTypeApi {
     Status,
     Query,
     Call,
+    CallV3,
     ReadState,
     ReadStateSubnet,
 }


### PR DESCRIPTION
Back when we added support for `api/v3/canister/:principal/call`, we forgot to properly log it. Until now, it defaulted to `unknown`. With this change, it will be logged as `call_v3` to show the difference between v2 and v3.