### PR TITLE
feat(BOUN-1216): use system and sharded load shedders from ic-bn-lib

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,9 +102,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.15"
+version = "0.6.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
+checksum = "23a1e53f0f5d86382dafe1cf314783b2044280f406e7e1506368220ad11b1338"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -117,43 +117,43 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
+checksum = "8365de52b16c035ff4fcafe0092ba9390540e3e352870ac09933bebcaa2c8c56"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a"
+checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.4"
+version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
+checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
 dependencies = [
  "anstyle",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.89"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
+checksum = "c042108f3ed77fd83760a5fd79b53be043192bb3b9dba91d8c574c0ada7850c8"
 
 [[package]]
 name = "arc-swap"
@@ -206,7 +206,7 @@ checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.85",
  "synstructure",
 ]
 
@@ -218,7 +218,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -235,9 +235,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.14"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "998282f8f49ccd6116b0ed8a4de0fbd3151697920e7c7533416d6e25e76434a7"
+checksum = "0cb8f1d480b0ea3783ab015936d2a55c87e219676f0c0b7dec61494043f21857"
 dependencies = [
  "brotli",
  "flate2",
@@ -322,7 +322,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -339,7 +339,7 @@ checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -412,7 +412,7 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.4.1",
+ "hyper 1.5.0",
  "hyper-util",
  "itoa",
  "matchit",
@@ -554,7 +554,7 @@ dependencies = [
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
- "syn 2.0.79",
+ "syn 2.0.85",
  "which",
 ]
 
@@ -707,9 +707,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.7.2"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
+checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
 
 [[package]]
 name = "bytesize"
@@ -795,7 +795,7 @@ dependencies = [
  "lazy_static",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -806,9 +806,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.1.29"
+version = "1.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58e804ac3194a48bb129643eb1d62fcc20d18c6b8c181704489353d13120bcd1"
+checksum = "c2e7962b54006dcfcc61cb72735f4d89bb97061dd6a7ed882ec6b8ee53714c6f"
 dependencies = [
  "jobserver",
  "libc",
@@ -967,7 +967,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -989,7 +989,7 @@ dependencies = [
  "futures",
  "futures-channel",
  "http-body-util",
- "hyper 1.4.1",
+ "hyper 1.5.0",
  "hyper-rustls 0.27.3",
  "hyper-util",
  "lz4_flex",
@@ -1014,7 +1014,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.79",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -1046,9 +1046,9 @@ dependencies = [
 
 [[package]]
 name = "colorchoice"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "combine"
@@ -1071,9 +1071,9 @@ dependencies = [
 
 [[package]]
 name = "console-api"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86ed14aa9c9f927213c6e4f3ef75faaad3406134efe84ba2cb7983431d5f0931"
+checksum = "8030735ecb0d128428b64cd379809817e620a40e5001c54465b99ec5feec2857"
 dependencies = [
  "futures-core",
  "prost",
@@ -1084,9 +1084,9 @@ dependencies = [
 
 [[package]]
 name = "console-subscriber"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e3a111a37f3333946ebf9da370ba5c5577b18eb342ec683eb488dd21980302"
+checksum = "6539aa9c6a4cd31f4b1c040f860a1eac9aa80e7df6b05d506a6e7179936d6a01"
 dependencies = [
  "console-api",
  "crossbeam-channel",
@@ -1323,7 +1323,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.79",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -1345,7 +1345,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core 0.20.10",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -1410,7 +1410,7 @@ checksum = "d150dea618e920167e5973d70ae6ece4385b7164e0d799fe7c122dd0a5d912ad"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -1463,7 +1463,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -1550,9 +1550,9 @@ dependencies = [
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.34"
+version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
 ]
@@ -1566,7 +1566,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -1756,7 +1756,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -1766,7 +1766,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f2f12607f92c69b12ed746fabf9ca4f5c482cba46679c1a75b874ed7c26adb"
 dependencies = [
  "futures-io",
- "rustls 0.23.14",
+ "rustls 0.23.15",
  "rustls-pki-types",
 ]
 
@@ -1883,7 +1883,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.2.6",
+ "indexmap 2.6.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1902,7 +1902,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.1.0",
- "indexmap 2.2.6",
+ "indexmap 2.6.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1940,6 +1940,12 @@ dependencies = [
  "ahash",
  "allocator-api2",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
 
 [[package]]
 name = "hdrhistogram"
@@ -2167,7 +2173,7 @@ dependencies = [
  "futures",
  "http 1.1.0",
  "http-body-util",
- "hyper 1.4.1",
+ "hyper 1.5.0",
  "hyper-util",
  "log",
  "once_cell",
@@ -2186,9 +2192,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.30"
+version = "0.14.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a152ddd61dfaec7273fe8419ab357f33aee0d914c5f4efbf0d96fa749eea5ec9"
+checksum = "8c08302e8fa335b151b788c775ff56e7a03ae64ff85c548ee820fecb70356e85"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2210,9 +2216,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.4.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50dfd22e0e76d0f662d429a5f80fcaf3855009297eab6a0a9f8543834744ba05"
+checksum = "bbbff0a806a4728c99295b254c8838933b5b082d75e3cb70c8dab21fdfbcfa9a"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2237,7 +2243,7 @@ checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
  "http 0.2.12",
- "hyper 0.14.30",
+ "hyper 0.14.31",
  "rustls 0.21.12",
  "tokio",
  "tokio-rustls 0.24.1",
@@ -2251,10 +2257,10 @@ checksum = "08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333"
 dependencies = [
  "futures-util",
  "http 1.1.0",
- "hyper 1.4.1",
+ "hyper 1.5.0",
  "hyper-util",
  "log",
- "rustls 0.23.14",
+ "rustls 0.23.15",
  "rustls-native-certs 0.8.0",
  "rustls-pki-types",
  "tokio",
@@ -2269,7 +2275,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3203a961e5c83b6f5498933e78b6b263e208c197b63e9c6c53cc82ffd3f63793"
 dependencies = [
- "hyper 1.4.1",
+ "hyper 1.5.0",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -2287,7 +2293,7 @@ dependencies = [
  "futures-util",
  "http 1.1.0",
  "http-body 1.0.1",
- "hyper 1.4.1",
+ "hyper 1.5.0",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -2366,7 +2372,7 @@ dependencies = [
 [[package]]
 name = "ic-bn-lib"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic-bn-lib?rev=550521b9b51cb0b59b18360a3e985f109d9d9664#550521b9b51cb0b59b18360a3e985f109d9d9664"
+source = "git+https://github.com/dfinity/ic-bn-lib?rev=1aa781275cd958f6148f6ea6a5630f73ab7b2d57#1aa781275cd958f6148f6ea6a5630f73ab7b2d57"
 dependencies = [
  "ahash",
  "anyhow",
@@ -2377,6 +2383,8 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "chacha20poly1305",
+ "clap",
+ "clap_derive",
  "cloudflare",
  "derive-new",
  "fqdn",
@@ -2387,7 +2395,8 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.4.1",
+ "humantime",
+ "hyper 1.5.0",
  "hyper-util",
  "instant-acme",
  "mockall",
@@ -2398,7 +2407,7 @@ dependencies = [
  "rand",
  "rcgen",
  "reqwest 0.12.8",
- "rustls 0.23.14",
+ "rustls 0.23.15",
  "rustls-acme",
  "rustls-pemfile 2.2.0",
  "scopeguard",
@@ -2410,6 +2419,7 @@ dependencies = [
  "systemstat",
  "thiserror",
  "tokio",
+ "tokio-io-timeout",
  "tokio-rustls 0.26.0",
  "tokio-util",
  "tower 0.5.1",
@@ -2501,14 +2511,13 @@ dependencies = [
  "http-body-util",
  "httptest",
  "humantime",
- "hyper 1.4.1",
+ "hyper 1.5.0",
  "hyper-util",
  "ic-agent",
  "ic-bn-lib",
  "ic-http-gateway",
  "itertools 0.13.0",
  "lazy_static",
- "little-loadshedder",
  "maxminddb",
  "mockall",
  "moka",
@@ -2519,7 +2528,7 @@ dependencies = [
  "rand",
  "regex",
  "reqwest 0.12.8",
- "rustls 0.23.14",
+ "rustls 0.23.15",
  "rustls-platform-verifier",
  "serde",
  "serde_cbor",
@@ -2733,12 +2742,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.6"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
+checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.0",
 ]
 
 [[package]]
@@ -2761,17 +2770,17 @@ dependencies = [
 
 [[package]]
 name = "instant-acme"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71bc444149bab1b339ba7e92e81d7615227feba7fd635b8551a3a170021598d0"
+checksum = "37221e690dcc5d0ea7c1f70decda6ae3495e72e8af06bca15e982193ffdf4fc4"
 dependencies = [
  "async-trait",
- "base64 0.21.7",
+ "base64 0.22.1",
  "bytes",
  "http 1.1.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.4.1",
+ "hyper 1.5.0",
  "hyper-rustls 0.27.3",
  "hyper-util",
  "ring 0.17.8",
@@ -2992,9 +3001,9 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
-version = "0.2.159"
+version = "0.2.161"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
+checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
 
 [[package]]
 name = "libloading"
@@ -3027,16 +3036,6 @@ name = "linux-raw-sys"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
-
-[[package]]
-name = "little-loadshedder"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edea14a875dba8659cb864480c27e8eb2d099542b657729a7567625a2c1d65a"
-dependencies = [
- "tokio",
- "tower 0.4.13",
-]
 
 [[package]]
 name = "lock_api"
@@ -3186,7 +3185,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -3332,7 +3331,7 @@ dependencies = [
  "rasn-pkix",
  "readme-rustdocifier",
  "reqwest 0.12.8",
- "rustls 0.23.14",
+ "rustls 0.23.15",
  "sha1",
  "tokio",
  "tokio-util",
@@ -3376,9 +3375,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "ordered-float"
-version = "4.3.0"
+version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d501f1a72f71d3c063a6bbc8f7271fa73aa09fe5d6283b6571e2ed176a2537"
+checksum = "83e7ccb95e240b7c9506a3d544f10d935e142cc90b0a1d56954fb44d89ad6b97"
 dependencies = [
  "num-traits",
 ]
@@ -3483,7 +3482,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
- "indexmap 2.2.6",
+ "indexmap 2.6.0",
 ]
 
 [[package]]
@@ -3497,29 +3496,29 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.6"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf123a161dde1e524adf36f90bc5d8d3462824a9c43553ad07a8183161189ec"
+checksum = "be57f64e946e500c8ee36ef6331845d40a93055567ec57e8fae13efd33759b95"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.6"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4502d8515ca9f32f1fb543d987f63d95a14934883db45bdb48060b6b69257f8"
+checksum = "3c0f5fad0874fc7abcd4d750e76917eaebbecaa2c20bde22e1dbeeba8beb758c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.85",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
+checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
 
 [[package]]
 name = "pin-utils"
@@ -3674,12 +3673,12 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.22"
+version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479cf940fbbb3426c32c5d5176f62ad57549a0bb84773423ba8be9d089f5faba"
+checksum = "64d1ec885c64d0457d564db4ec299b2dae3f9c02808b8ad9c3a089c591b18033"
 dependencies = [
  "proc-macro2",
- "syn 2.0.79",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -3693,9 +3692,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.87"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3e4daa0dcf6feba26f985457cdf104d4b4256fc5a09547140f3631bb076b19a"
+checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
 dependencies = [
  "unicode-ident",
 ]
@@ -3735,7 +3734,7 @@ dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -3794,7 +3793,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash 2.0.0",
- "rustls 0.23.14",
+ "rustls 0.23.15",
  "socket2",
  "thiserror",
  "tokio",
@@ -3811,7 +3810,7 @@ dependencies = [
  "rand",
  "ring 0.17.8",
  "rustc-hash 2.0.0",
- "rustls 0.23.14",
+ "rustls 0.23.15",
  "slab",
  "thiserror",
  "tinyvec",
@@ -4009,9 +4008,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38200e5ee88914975b69f657f0801b6f6dccafd44fd9326302a4aaeecfacb1d8"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4071,7 +4070,7 @@ dependencies = [
  "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
- "hyper 0.14.30",
+ "hyper 0.14.31",
  "hyper-rustls 0.24.2",
  "ipnet",
  "js-sys",
@@ -4116,7 +4115,7 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.4.1",
+ "hyper 1.5.0",
  "hyper-rustls 0.27.3",
  "hyper-util",
  "ipnet",
@@ -4127,7 +4126,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.14",
+ "rustls 0.23.15",
  "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "serde",
@@ -4236,9 +4235,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.37"
+version = "0.38.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acb788b847c24f28525660c4d7758620a7210875711f79e7f663cc152726811"
+checksum = "aa260229e6538e52293eeb577aabd09945a09d6d9cc0fc550ed7529056c2e32a"
 dependencies = [
  "bitflags 2.6.0",
  "errno",
@@ -4261,9 +4260,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.14"
+version = "0.23.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "415d9944693cb90382053259f89fbb077ea730ad7273047ec63b19bc9b160ba8"
+checksum = "5fbb44d7acc4e873d613422379f69f237a1b141928c02f6bc6ccfddddc2d7993"
 dependencies = [
  "aws-lc-rs",
  "brotli",
@@ -4349,9 +4348,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e696e35370c65c9c541198af4543ccd580cf17fc25d8e05c5a242b202488c55"
+checksum = "16f1201b3c9a7ee8039bcadc17b7e605e2945b27eee7631788c1bd2b0643674b"
 
 [[package]]
 name = "rustls-platform-verifier"
@@ -4364,7 +4363,7 @@ dependencies = [
  "jni",
  "log",
  "once_cell",
- "rustls 0.23.14",
+ "rustls 0.23.15",
  "rustls-native-certs 0.7.3",
  "rustls-platform-verifier-android",
  "rustls-webpki 0.102.8",
@@ -4404,9 +4403,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
+checksum = "0e819f2bc632f285be6d7cd36e25940d45b2391dd6d9b939e79de557f7014248"
 
 [[package]]
 name = "ryu"
@@ -4457,7 +4456,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -4506,9 +4505,9 @@ checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
-version = "1.0.210"
+version = "1.0.213"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
+checksum = "3ea7893ff5e2466df8d720bb615088341b295f849602c6956047f8f80f0e9bc1"
 dependencies = [
  "serde_derive",
 ]
@@ -4534,13 +4533,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.210"
+version = "1.0.213"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
+checksum = "7e85ad2009c50b58e87caa8cd6dac16bdf511bbfb7af6c33df902396aa480fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -4551,14 +4550,14 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.85",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.128"
+version = "1.0.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ff5456707a1de34e7e37f2a6fd3d3f808c318259cbd01ab6377795054b483d8"
+checksum = "d726bfaff4b320266d395898905d0eba0345aae23b54aee3a737e260fd46db03"
 dependencies = [
  "itoa",
  "memchr",
@@ -4584,7 +4583,7 @@ checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -4624,7 +4623,7 @@ dependencies = [
  "darling 0.20.10",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -4770,7 +4769,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -4877,7 +4876,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.79",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -4905,9 +4904,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.79"
+version = "2.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590"
+checksum = "5023162dfcd14ef8f32034d8bcd4cc5ddc61ef7a247c024a33e24e1f24d21b56"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4937,7 +4936,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -5040,22 +5039,22 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "thiserror"
-version = "1.0.64"
+version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84"
+checksum = "5d11abd9594d9b38965ef50805c5e469ca9cc6f197f883f717e0269a3057b3d5"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.64"
+version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
+checksum = "ae71770322cbd277e69d762a16c444af02aa0575ac0d174f0b9562d3b37f8602"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -5166,9 +5165,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.40.0"
+version = "1.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2b070231665d27ad9ec9b8df639893f46727666c6767db40317fbe920a5d998"
+checksum = "145f3413504347a2be84393cc8a7d2fb4d863b375909ea59f2158261aa258bbb"
 dependencies = [
  "backtrace",
  "bytes",
@@ -5184,6 +5183,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-io-timeout"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf"
+dependencies = [
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-macros"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5191,7 +5200,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -5210,7 +5219,7 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
- "rustls 0.23.14",
+ "rustls 0.23.15",
  "rustls-pki-types",
  "tokio",
 ]
@@ -5258,7 +5267,7 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.4.1",
+ "hyper 1.5.0",
  "hyper-timeout",
  "hyper-util",
  "percent-encoding",
@@ -5343,9 +5352,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tower_governor"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "313fa625fea5790ed56360a30ea980e41229cf482b4835801a67ef1922bf63b9"
+checksum = "aea939ea6cfa7c4880f3e7422616624f97a567c16df67b53b11f0d03917a8e46"
 dependencies = [
  "axum",
  "forwarded-header-value",
@@ -5353,7 +5362,7 @@ dependencies = [
  "http 1.1.0",
  "pin-project",
  "thiserror",
- "tower 0.4.13",
+ "tower 0.5.1",
  "tracing",
 ]
 
@@ -5377,7 +5386,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -5584,9 +5593,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
+checksum = "f8c5f0a0af699448548ad1a2fbf920fb4bee257eae39953ba95cb84891a0446a"
 dependencies = [
  "getrandom",
  "serde",
@@ -5670,7 +5679,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.85",
  "wasm-bindgen-shared",
 ]
 
@@ -5704,7 +5713,7 @@ checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.85",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -5717,9 +5726,9 @@ checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
 
 [[package]]
 name = "wasm-streams"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e072d4e72f700fb3443d8fe94a39315df013eef1104903cdb0a2abd322bbecd"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
 dependencies = [
  "futures-util",
  "js-sys",
@@ -6062,7 +6071,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.85",
 ]
 
 [[package]]
@@ -6082,7 +6091,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.85",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,11 +45,10 @@ http-body-util = "0.1"
 humantime = "2.1"
 hyper-util = "0.1"
 ic-agent = { version = "0.37.1", features = ["reqwest"] }
-ic-bn-lib = { git = "https://github.com/dfinity/ic-bn-lib", rev = "550521b9b51cb0b59b18360a3e985f109d9d9664" }
+ic-bn-lib = { git = "https://github.com/dfinity/ic-bn-lib", rev = "1aa781275cd958f6148f6ea6a5630f73ab7b2d57" }
 ic-http-gateway = { git = "https://github.com/dfinity/http-gateway", tag = "0.1.0-b0" }
 itertools = "0.13"
 lazy_static = "1.5"
-little-loadshedder = "0.2"
 maxminddb = "0.24"
 mockall = "0.12"
 moka = { version = "0.12", features = ["sync", "future"] }
@@ -80,7 +79,7 @@ thiserror = "1.0"
 tikv-jemallocator = "0.6"
 tikv-jemalloc-ctl = { version = "0.6", features = ["stats"] }
 time = { version = "0.3", features = ["macros", "serde"] }
-tokio = { version = "1.40", features = ["full", "tracing"] }
+tokio = { version = "1.41", features = ["full", "tracing"] }
 tokio-util = { version = "0.7.11", features = ["full"] }
 tower = "0.4"
 tower_governor = "0.4"
@@ -102,7 +101,7 @@ zstd = "0.13.2"
 
 [dev-dependencies]
 hex-literal = "0.4"
-hyper = "1.4"
+hyper = "1.5"
 criterion = { version = "0.5", features = ["async_tokio"] }
 httptest = "0.16"
 tempfile = "3.10"

--- a/repro-env.lock
+++ b/repro-env.lock
@@ -1,5 +1,5 @@
 [container]
-image = "docker.io/library/archlinux@sha256:729afdc31856d0faf2c93c2291f3e81bccd5e75082f45e0f3513f65f83b88973"
+image = "docker.io/library/archlinux@sha256:3fb8e79e4037db1536d331dba905e234fa18c8206191458a927013a2d2dafc50"
 
 [[package]]
 name = "abseil-cpp"
@@ -18,12 +18,20 @@ sha256 = "6702f58e662908cbd5a86d554363348c2ab5c2e5e594f9d07d5627d16fda57b7"
 signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCZrE/KV8UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCmU9AQCXKD3fwCpsiulOCWkyRGtDfo6LP7RgB/qUuamWUSrZewD7Bb1wX8sFIlloYrBNBbKjfSyytH4gY7VuJ7fFFTodpwI="
 
 [[package]]
-name = "cmake"
-version = "3.30.3-2"
+name = "ca-certificates-mozilla"
+version = "3.106-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/c/cmake/cmake-3.30.3-2-x86_64.pkg.tar.zst"
-sha256 = "71d6dec3e870d5378efa06fc256ac566237231805cbddf9663e5672af38839b5"
-signature = "iQEzBAABCAAdFiEEFRnVq6Zb9vwrc8dWek52CV2KUuQFAmblaEoACgkQek52CV2KUuSmmAf/YgwSzrVdWMcGrgKCKOVxKa8A7LHNc6oB8uDlv9fYGxE1rk7fS9leBRkheRvVR2kIn1bHdVoc4TeSO+vHUB08Ys+w0oiIOYJj1GSoXB52Iu03dTsnSzIPx52bv8kp3SmkeNIq/lF5SjyUoV/pFUkmz2WNdb+7oztxmANxwRmgbBUtxlgn2qLjb9HP31cB2NfDBMyOxwsTTvZZSHgSnqBpPMg39mcTUNawUQwWXimgTbMWSbOimJ61vxq47xerDZvfuD51C+/fYWA1wO111iiuaSRq9CpODU26UcZ6pDFPFCYTbi4q4qcG7Hdjp7E80LHC5a+Zd8Wrk/VlbXAtNoZ7Yw=="
+url = "https://archive.archlinux.org/packages/c/ca-certificates-mozilla/ca-certificates-mozilla-3.106-1-x86_64.pkg.tar.zst"
+sha256 = "2a34db5480ea46e2cbccf72f0fbb7c887241c3db3a2f545e5ba8bfeec56f0481"
+signature = "iHUEABYKAB0WIQSDvIiJNRtd67toQW64rAhgDxCM3wUCZxu2IQAKCRC4rAhgDxCM3z+oAQDW3U/L7i1xaV4gvBZgJYp/H2EGMp8ceOmkM0HUSDF+twEA8P0EsLZxix+Up5DvLfgGRXeH9+ohD6sxCLQndRXlDQY="
+
+[[package]]
+name = "cmake"
+version = "3.30.5-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/c/cmake/cmake-3.30.5-1-x86_64.pkg.tar.zst"
+sha256 = "6ac95a823c85c37f00a8473349be734746bff73ce76fced6bec9eb11a151f94b"
+signature = "iQEzBAABCAAdFiEEFRnVq6Zb9vwrc8dWek52CV2KUuQFAmcFmjEACgkQek52CV2KUuRPkAf/cWkvVCMxM2Fvm1a4hkraLC7MvR3WPBpfo6bdtHZmO86fsRftUP/Ya1BA7debGkW0zc3G6Q7TgIVXxCOOnTJtSKwm8dKbam+4LTNgmWzlQ4FoRCskyaKBFEBaaQx+IZoDmq2At42a6jHbxisp8Cs+GWKe9e644SbYtZQugRHq0AycZ9HdjB8HaubFV+fWXG4f4QAQFZtc8rzQcedLPiLLShzIzhVP7CajVD8w0BMOO/BcoaHRYvUyBl6iuKXQQkO7+N0j9JlJtt3Sg8hLdffh+iU34YufhO3oiMVTOkggvyOQ6Wu5PpmmLHl9b3NKGnr55VIHurrOP75Hmhw+uvUpDg=="
 
 [[package]]
 name = "cppdap"
@@ -32,6 +40,14 @@ system = "archlinux"
 url = "https://archive.archlinux.org/packages/c/cppdap/cppdap-1.58.0-2-x86_64.pkg.tar.zst"
 sha256 = "29796195345f80920d6e018d53cd0f92eb7b7d379849d262a0dbcd4b1fa573ef"
 signature = "iQEzBAABCAAdFiEEFRnVq6Zb9vwrc8dWek52CV2KUuQFAmaDH8sACgkQek52CV2KUuRK9Qf8CfghNmb2AN0lgBcvxo38BgOIfBUlC/Zyd2yymxInhogQNgj5xKGDF9ZsLzTXNuGx1s5LDrjLsyLHgJgWIg39sfdAepQtZ1kJPm5MmmIqFMwvVmQ1tPUBOgAQSWs8XL4ssYvYuN23npSh+RhkYC62GhCsJm6CXjSCpksV+F4mHnOik/khw6rPb2hj7kzi+k5x5N2G5+qm9cOcKQLgtkX0lefsAkg5ZjH1qZm3Twa0p/2xMc8cigHtdm5TTTqH9nhKk68eOTAFJvr1T9oo/UxKuQm8pOofjTcKpECFpRpGy+nkxADI08pwvFDN44GE4QAnecpchRleWnnzghh87KExIw=="
+
+[[package]]
+name = "curl"
+version = "8.10.1-2"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/c/curl/curl-8.10.1-2-x86_64.pkg.tar.zst"
+sha256 = "f9f420321b55b6c73788a00e890e5f38d6cb769ed5fe0f809a1dd1fb940a936f"
+signature = "iHUEABYKAB0WIQQhkbiUMbrAqLlt6T0kR0DRfH/Q7AUCZxTUnAAKCRAkR0DRfH/Q7DjUAP0fPzb/dSMBpFONe0x/24IdDIVyi8S3cGAcm7zj8z1ZUgD9HFhkTqVhJr9u1HEDwVgsO89+HqUp9Kqy7L/peDv8fwc="
 
 [[package]]
 name = "gc"
@@ -48,6 +64,14 @@ system = "archlinux"
 url = "https://archive.archlinux.org/packages/g/gcc/gcc-14.2.1+r134+gab884fffe3fc-1-x86_64.pkg.tar.zst"
 sha256 = "efcf9a912bb674205fe8cbc2f205ca3d64ec0e8e48700c74bac8952834dc4415"
 signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCZuBXXV8UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaChhNAQC1+ckQFrMS0NCEB/MuyxouCmUQ0COinRuR6OvZ4qoYhQD/X5l3opAxR9lO8dtqfoLbeGUqOwQUqzZHG8gF4Y8z0wQ="
+
+[[package]]
+name = "gnupg"
+version = "2.4.5-6"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/g/gnupg/gnupg-2.4.5-6-x86_64.pkg.tar.zst"
+sha256 = "e7425c89c95f0f86e26d3290564c76c9e3849e1995aed7a6ae26a825b6e5b6d5"
+signature = "iHUEABYKAB0WIQRizHP4hOUpV7L92IObeih9mi7GCAUCZxp8DAAKCRCbeih9mi7GCKfUAP9xcLLspyyJbvO2OWJAFB6PD5ZATKdF/Sq6pQfuJYEMyAD+M/hrtdwobnM27+jMtCx6rF/Ylx5GQKtVC5lysO77Vww="
 
 [[package]]
 name = "gtest"
@@ -74,28 +98,12 @@ sha256 = "22ec69012b9a55e276b5891f916366f692541dce3793bff3e85a28a10b91990a"
 signature = "iHUEABYKAB0WIQSDvIiJNRtd67toQW64rAhgDxCM3wUCZk/ttQAKCRC4rAhgDxCM39FIAP9Zcpg7ei4MUwFlnla8x7YDFRtQFp2WtiPOhyohRoMxhwEA2Fjer9ZWaLxYDvXfG3TbweF7ZzIQ621pJSfzl/HCnw8="
 
 [[package]]
-name = "iproute2"
-version = "6.11.0-1"
-system = "archlinux"
-url = "https://archive.archlinux.org/packages/i/iproute2/iproute2-6.11.0-1-x86_64.pkg.tar.zst"
-sha256 = "3400eb2b0c3dfd93ce22e65c2ea51da21c5ca10d2a52c8646701d586931a9220"
-signature = "iHUEABYKAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCZudA5QAKCRBtQr3RFuAGj5ckAP9LH9TKurjnOMyLgvNci5MYOxtgrwqC1auGWhJ4eA5sRgEA4omZ31LsBBwweBqHbTILsHiqFJAXQzHPDetJajoHfgg="
-
-[[package]]
 name = "jansson"
 version = "2.14-4"
 system = "archlinux"
 url = "https://archive.archlinux.org/packages/j/jansson/jansson-2.14-4-x86_64.pkg.tar.zst"
 sha256 = "a67ab57d4a9b4caa2e718652c392345cdd9c2496d835ab1d0ff1e78ae4429fde"
 signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCZjJful8UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCpfCAP4sFnTjSEIn5wDbLWGZOivsWT2SWPG6AgofrnUjaK/UMAD9E2u6D7WJbVTYrvDhVUz3WN6k8bVB8ZODyoIF66GWEw0="
-
-[[package]]
-name = "json-c"
-version = "0.18-1"
-system = "archlinux"
-url = "https://archive.archlinux.org/packages/j/json-c/json-c-0.18-1-x86_64.pkg.tar.zst"
-sha256 = "0cc442e61fcd36f100ead25dc5d16c401836376363c4035dcdd0588ccbc5f9e4"
-signature = "iHUEABYKAB0WIQSDvIiJNRtd67toQW64rAhgDxCM3wUCZudmzAAKCRC4rAhgDxCM37kcAQCS/n4Gez+/IPHPCBDVl4ODoK0IdoADnu9JONQgwR8aTwEAqvS/ZA8VUNiLbWtBRmodE04fQlEQQyYa9aO9M+fyUwE="
 
 [[package]]
 name = "jsoncpp"
@@ -114,6 +122,14 @@ sha256 = "fa17f759180233be8343ccccb1c3e4ac01cf5367ab141f36ca8830151b7c12be"
 signature = "iQIzBAABCgAdFiEE4kC1fixGMLp2ji8m/BtUfI2BcsgFAmZRDMAACgkQ/BtUfI2BcsjfBg/9GJ/xfxU7NKehazazuulK0VWaeXwc2SydHS4lpnqZggkcNtVlJIXzIrIBAK+A06M99NLqJzdrLsCssa5RjlMSxtB8nZYjZIE7M4fivBHgx4N6xUzzSu7PN8G9A1fvnbRFqtcvywP/FeWnmBIsf404BeKhwHB0PkG9RebYmJAKpg1IHhHNBJ/NkYC04Wov4oskzv/HehibIbnvTu6EZQ2f2NyXJVTqUsEkEw5xSEsyob+fgAtMdfufs6xpFskYV9NWniHKxWN9JKy0HwJ764JrxRW5VrrR2Ua/zWQYBi0r71zfrt/mILjkJwWNe0+LzJWpOqD59sjllW2iBeTeH+0A4lG7beaKdhCAAQQUzAPINuCwhpOGvvFhOn04icVPgqFKVegbNbXN+Wad+60HKgQw4AI0XeHo8uTiJOKolObV27OxaQTK2s5qmsrali4zsLlC+G2lYUvrqvWlrtuIIm+6XGNSMDoYovVd2EoBGRrwFCDlfdah8kFa6PY9J1UWQY7mDPJerpgB0IZ0KycxpXvB5I5XzYLKbSEjWZ331jnCWbR+poQfYwMYI2H9ZFy2YN0R/VohaIU70Ux5F24gjUaLYc1Ld9ZzrV1MSMj+D20vdxLCmNoDLfNwwceBbCyisT5GnxAFVWvaX3WwhI/D/jPnBcuEw11FfsHLUaGNIfM+mQQ="
 
 [[package]]
+name = "libelf"
+version = "0.192-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/l/libelf/libelf-0.192-1-x86_64.pkg.tar.zst"
+sha256 = "bdc392e3a04ae66c253e9cf4ece3727c4625214657ec9d631c5beaef509ee005"
+signature = "iHUEABYKAB0WIQRizHP4hOUpV7L92IObeih9mi7GCAUCZxQYZQAKCRCbeih9mi7GCJgwAQCDfHVmtkOAk+YaiRq82dI+WySEMMl3DPjKIDa21VuPBgEAj6zOvUq7E21vaq/uvaiNeAtN7wrZJerkZyRHArrz9gA="
+
+[[package]]
 name = "libisl"
 version = "0.27-1"
 system = "archlinux"
@@ -130,12 +146,28 @@ sha256 = "10554706eb15ed2186fbd55fd5db8fa5919788ac9a75d26c0b9ef5bdfca9d470"
 signature = "iQEzBAABCAAdFiEEFRnVq6Zb9vwrc8dWek52CV2KUuQFAmaHCZwACgkQek52CV2KUuRjbAf/TmL9cCMXYTGsNmR2om6kT7XjczfZoFR9AM0FSTUNy5AuNZNUUCfm6ie6F4rFwHc3nETOSojScOZauZlcNiLrVriHYYFSZ8EhKiCJCo68a7KTbceBNoBuT6AEIpGMpIMti/cvWhu8VXl5JIRo8LNPBzDih05aCDUJ2nayKPYNHalDayu87sDXzJYXuzC8KD7XmUa7Kirn0ZpA4VZXc8CUjYYvn0wvRwLKQP4WMpszxmblQWjMVbQxh7dwC+gPtqIANVjoGKMRfr6QpT03XXIEaTBKbMsxeYFvwn+y2JN30t6oFI6LJADZ22VwimEzu06u+x9c+3+pr4k7Py43OCOGmg=="
 
 [[package]]
-name = "libuv"
-version = "1.48.0-2"
+name = "libnghttp2"
+version = "1.64.0-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/l/libuv/libuv-1.48.0-2-x86_64.pkg.tar.zst"
-sha256 = "056230841b7996548c51c7c78537ad083f60bdc8566dbfc28954d7216dfee848"
-signature = "iHUEABYKAB0WIQRUwf0nM2HqUUojd5Pylr3lA2jGzgUCZgxhiAAKCRDylr3lA2jGztcEAQChHQFGtNeygBgcfqP3tL5CkN+S312f3Pywo9mX2q7d6wEAr2jsF9qe4+dRQDgz2nPZkzL5Lon9TKzpeQ4/loJsvgU="
+url = "https://archive.archlinux.org/packages/l/libnghttp2/libnghttp2-1.64.0-1-x86_64.pkg.tar.zst"
+sha256 = "cbf36ec454555c49d3ee0205ab8293778dcf5b3a59de6242bd042741cd7f8fb7"
+signature = "iHUEABYKAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCZxfh+wAKCRBtQr3RFuAGj2bwAQDDXVfGbTyjNlS/j75jpq3qYoyPpXmujysVEsY47vYnmQEAuFk2S2V/5IdosdX76ks40FU4gaC1VV59N5Q9ppPx2gc="
+
+[[package]]
+name = "libtirpc"
+version = "1.3.6-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/l/libtirpc/libtirpc-1.3.6-1-x86_64.pkg.tar.zst"
+sha256 = "36a431c8d414748846ae5e7d4e6e625342121a15aff5ec0054387692eaad78b0"
+signature = "iQEzBAABCgAdFiEErcih/MFeAdRTEEGelGV6sg8qCSsFAmcRXMsACgkQlGV6sg8qCSuANQf+NqV7mXLbBLLbdU/wFUj966Pm8FHpEGA3fomBIci0c74IjVB4iY62Zi3HS7rFjmpGreuip7KhAvvKYYaEtwnS9fa2zY58ffg3hZKNQkdiiX1MdNlJ81atAwRlfgkdWfEANWheXigAzFzHtSUxE7rNQsL1v8DtPi1e/gZExQZHk6D+jzZTbPXxMOl0OgoLFbmxk6wprYLM+/GL7u9S66sNJ/mAQ+U8QJ5YH1Z8x4VP/9xUPzknot7JtiIwq2RujPqvGBDvW7GVAjIwt+xFp50wkXlQN7TNnCceo049vPD8JS46ontex7rzoBlqKqHf5mgbc7rIPeiPegcnMcMkYx5LQA=="
+
+[[package]]
+name = "libuv"
+version = "1.49.2-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/l/libuv/libuv-1.49.2-1-x86_64.pkg.tar.zst"
+sha256 = "42a62df50626ec1033faca8c4271bc0f827ece480b9fccb2fba8ad39344a78da"
+signature = "iHUEABYKAB0WIQRUwf0nM2HqUUojd5Pylr3lA2jGzgUCZxK0HAAKCRDylr3lA2jGzriOAP0YjsWj3E5A3eCw6qer7NrTCx+HbHSX3neuIKy4ZuINzQD+OZHvsOMuQxQQEZQNi9uQMwgOFXzbAjhMvSXOEB3Qyws="
 
 [[package]]
 name = "llvm-libs"
@@ -170,12 +202,20 @@ sha256 = "146b60543069d4eb92fd9086ffd6f442ee0a1f41f724445adc29af80693ce2da"
 signature = "iQJLBAABCAA1FiEEiee5MxxK59f699MFwTIpOVS75K0FAmaUdzsXHHNwdXB5a2luQGFyY2hsaW51eC5vcmcACgkQwTIpOVS75K2C+g//ddIjb7CKai01nuuzLd9hZQBP51iBe+lYdhv5lxlKaSzQZXHVUGXDAZdb7TaV9pbzdGPE+l5V2ZngivXdR5twUDWOQzvorXdxLgX7trBTghLDTBIKu6jPtrH2bNWrL8A908RumQVeWsOxUcompgAsRpQ4DhZkzk8325k9et0Nv1oQic96B5G1WefE85IYc2PDJeRhfyfnZmQ15aoVhohyhF0XSudlJSc/hqMZePW8tmyYz4ltvgOs4EF3smNwOaZVOew+w/5vOCYaSre5MFwHiilvYJaWhCji10m0MrBzLhRx0ZfRlBwTGbsToRbmczuwMXoYIiJsI2OiXsZD5/X9T5yPjl7pWP7uLaNTXCcbfrCZIWMVBXYQFxnWhUbKFZu8E7eXU2z75GukkC7GjR+VKw+SFH06Xdq73JltIXURRKe03uigC8ciME1xHOMv5kc1pQukQC/hTaR4GPF32pOX27CPQkNQ0dhRi1Cgyt47V+3GncI+mhlY3gJsCv31+Z0kM+WornVJYFSQnO0/frFPJaZUt0ONO7lHU2UMTe2tHm+zFHuHh6xOGaMjdRslrzq0Pby0xMb6nT0HsT1VXfSW30rywN1UPLd3TxAXGkG3SS8szftrLrmK6NAsK5tWfd5H2tiwSibYNnYYYVB720LKBl7bgpGFicdROohXJKqXsvA="
 
 [[package]]
-name = "protobuf"
-version = "28.1-1"
+name = "openssl"
+version = "3.4.0-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/p/protobuf/protobuf-28.1-1-x86_64.pkg.tar.zst"
-sha256 = "81cff070479e2ec3a2c59d9327915456e2654124e86df74f1caa0b83c0181789"
-signature = "iQIzBAABCAAdFiEE8AuW0VIoAT/8nJ0Dk7EdqkwZfj0FAmbjJKsACgkQk7EdqkwZfj3V7Q//fWb/eW2jeq/DzGNXbYgZuwbWBZKdg5baQiRJI8hpBhcX9nXZGrHZ8pM3OwMJgJN3E6XXV4QPtAY5FfF0kgtHZnzq2piaHHVuSH13OI8t4qEX7Uyp8eXxrAnApGjObV8sp8liQwULoB2fS/ZR1iGNC9lof2OaczZlQ9qHD9gk8dpIsBzeOpfgrvKX2dOsNIcLAEqAdrUCQZKDyrgY9oVEzv8v4H9F3eQfT3h/wej0FdGn/T9BCynHs+gD/fUq+fPPLBvuRZXB2PVG3G9eIMpqHvR1mrgIM8NCeU6PROk3otfBpuDYp3zcL4TvVJwupi1ss8KkIaSPuxZgC0pq8nSrzMtD1poncwlBHrodqyeUMxrgrmgBo23JJFrqjz+dI3+h1CdCD47t5/+BGKM13wlcXHZa/aSAQRxeN4nEj3keJIZnK8QopLdFuYikA+S20b19mEDEvTss/QQHGFPEjdbXFNUv4xfkNwuVdKLJ2lG2iK9yAYxRml9gPnKueQ3tYaPM0FSTxoeIgULI4dR3TYHe99f+t6XSxbL7NdcOnBGgevaLIkipiaLAycZEVWGQ0PeN5fxa0LuXCAl3iJHMruSrD8bsMshpLW8Z1fcZV2wcafVJuSWV50vswNbN14ktlb55DSI7xUXLJD8Nb2TstojnGlaWLj7iQuoEnrR/6YDqLQI="
+url = "https://archive.archlinux.org/packages/o/openssl/openssl-3.4.0-1-x86_64.pkg.tar.zst"
+sha256 = "a7c364b6e0969d13b773ad2a4e6266d7bee0a4de0824a246b4ad6bf11f723034"
+signature = "iHUEABYKAB0WIQQ+gMoai4n2nLpX2Yp2pe+QVESaXAUCZxilVgAKCRB2pe+QVESaXN/FAP4lFSH0UclXcrCSZR+K2OwAxeYC76Utav2TnLxIzYHvmwD9EDJYrcTp59lYSH2yBBXHsR7L0SuwQH9UPN9YidYNwgc="
+
+[[package]]
+name = "protobuf"
+version = "28.2-3"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/p/protobuf/protobuf-28.2-3-x86_64.pkg.tar.zst"
+sha256 = "cfc875aea0e98f066ce6a77ddd2c2731254189fb6456933a2c71a2a73edd5d3a"
+signature = "iQIzBAABCAAdFiEElnTU7T37atzE+fHqHHNq75ZALnwFAmb+sTkACgkQHHNq75ZALny3lQ/9F7zScUzVh4KjLKHdSd57/p6K9sY2r2XGRb40ABB49Gq/J/PMVe2EKDsxRje8dB3P4iBHZq4+QrpLA+sWDIbaFMng11UVMRvSkLeneTqvo3wRBWHH4ItNc2b+A3Sdqq3BZSvYWrnetp+c0/i+mMo1Tjl3NeOb3F0Xt1q8Xsn7ILf6KaoZm7yn5nmI289rSAkkUJhQiCNtkjbS4VImciXKOiHuv1ohJrtrakXqLHDel4g4DN2n0oBjXJTy2Si3EgyA13GvDvqnVvXZQqFpxhAQOb8r+ieRYZWLypY1NyCebixFxi5PwaaVkReZB+8Xi4umOl/45gZHv/3OaL+viXjUKRRWYtPE/ITMle3l/lTfPuttN82AUe5LR2z/XLFVRnOvDzeNpTtgZohWdi6Dghiq7MGQbAccoZo1wnMT1gq9Wa7Syr7bG8k/B61UTj+gmuGH0XYgLA7g9WaRowDXTfkNwRWdVeFxRcRLdjNcMbtRGfFn9IiCrq6Ar/LN1HdgBfTlk2penN9S5juT9LRbXMP1NtFt+bPfsdSDzs4H2vzEI5FiivJa2lYPfQpkSGsiBHExpNYzBFE4j/2p2iOID/TEMnQ/poKHL6/dA1ElwPlr7pIqoCvhuVT7qTYqzi+zcCqB9VFKG45Akumgl7gpaF2AItmMWu9MKB046aTXSIC9Xs8="
 
 [[package]]
 name = "rhash"
@@ -187,16 +227,24 @@ signature = "iQTHBAABCgCxFiEE5VD//9SF4mShcX4wkBwcMg6w1F0FAmUt0ElfFIAAAAAALgAoaXN
 
 [[package]]
 name = "rust"
-version = "1:1.81.0-1"
+version = "1:1.82.0-2"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/r/rust/rust-1:1.81.0-1-x86_64.pkg.tar.zst"
-sha256 = "da6889ab6dd5776f218f6cad14e2c59b0a888d4eaac8ab7740800ec24546bc38"
-signature = "iHUEABYKAB0WIQSDvIiJNRtd67toQW64rAhgDxCM3wUCZtoTmwAKCRC4rAhgDxCM38CQAQCDBhr9e7FIryxuFMw69MK+0UCR2oOxc8JshgVs9mZ6vgD+NBSqW/RgPwErLyWWLs1TqSIQ5Dvf42SyzTtJQDUQyg8="
+url = "https://archive.archlinux.org/packages/r/rust/rust-1:1.82.0-2-x86_64.pkg.tar.zst"
+sha256 = "9737ce575d92aa777db79d5586eb93836a140ae793f78d093f59cb8e66df6e63"
+signature = "iHUEABYKAB0WIQSDvIiJNRtd67toQW64rAhgDxCM3wUCZxVKVgAKCRC4rAhgDxCM3xjTAP9nD4ATeTlb/472+fc+zRkGPg5hGOUGua8WLm7Mp1lMlgEA1ts6H7YIsRshlC+H0FFVuOMHH/HsncoXgDiMkCLuXQI="
 
 [[package]]
 name = "rust-musl"
-version = "1:1.81.0-1"
+version = "1:1.82.0-2"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/r/rust-musl/rust-musl-1:1.81.0-1-x86_64.pkg.tar.zst"
-sha256 = "34c2af8f2601f1c16c68bf3a7b2086bb13797044af038591595f3f311ca0e969"
-signature = "iHUEABYKAB0WIQSDvIiJNRtd67toQW64rAhgDxCM3wUCZtoTnQAKCRC4rAhgDxCM36+2AP4pkXZIrVXZNIwA/We46u2h0dIJBMIp4L9JF5wp/jwNfQD+Osc9IPqO6IP7mWUGh0+BrLncAbkw8anIecTb/+d2HgQ="
+url = "https://archive.archlinux.org/packages/r/rust-musl/rust-musl-1:1.82.0-2-x86_64.pkg.tar.zst"
+sha256 = "a5f4499771881581885544a31f674dfb89e0af2b0386ac96db95d9f0d7c9e206"
+signature = "iHUEABYKAB0WIQSDvIiJNRtd67toQW64rAhgDxCM3wUCZxVKWQAKCRC4rAhgDxCM36MHAQCw7HHttt9lnOkCvVtRJa/Q2fenUbB4kA91AqmWYz4GwwEAjagxoHfsA/adRRZMX4wl95ZQ/29eicqCvhboktAEGwk="
+
+[[package]]
+name = "tpm2-tss"
+version = "4.1.3-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/t/tpm2-tss/tpm2-tss-4.1.3-1-x86_64.pkg.tar.zst"
+sha256 = "b1098a8ecc8886023c466827ea057861ea53ef4dc36a2142afee8b85fdf27c3c"
+signature = "iQJLBAABCgA1FiEEwQA0ZnZjToDJQPuenAL/QZ/svhYFAmbkrxIXHGZveGJvcm9uQGFyY2hsaW51eC5vcmcACgkQnAL/QZ/svhbYtg/9E8A0shPraoJw3XJ9bX2yZGjlAuw+iSDdah/WgxONtbj1ur31QfnQ+6LNftUZl50AVnN778NMD3bZyLqbCc6NVwjThB4vWTIeWWJXSokccvH3p+DigoSE6K4xeY86jlMTnFJSC32BaJpzx84s3Umx2iKcKka4BAG22FVZUHuuqTjg3h7pmP4gXoZRhOOM6o1sWldGQaqbv8RV22iilTSEM9cl+zg/brU5EoTQuZJ1ofV3WzlOOGZKDqJwX/3xAFiEcKidq8oYTACAy1iXfPFY2tviVPoi35K7qeEIswj70qi68ZlhLyOGoJyZ4ZuL1Wubim+cpfVjUYylAlCBMFC5Qa2JO+N2ZWSMYX1uKRXgf314MEmlP0VXavnA3e5/WZ0dzK3RPfJWBtPWOrPkGMUxqXgy/5gG9KGXHro0XIqXFDKfQKBEaRGx/e7SnMU0hjtN2F7qZpFPwj0cH9Gy5HLNFBDvVFFRDYjbIne+FwKeD5zsUaiKtMpmKDfqJiI0S9RnF2gJ2FUmLPr4J1odleDHy72gKC20WhGY/T8KSMLy75FBG68i2NrDCxgGZ4j6QagCVQE0jxSYXiHrD3cic8cdBGuPswKnesXnwcdtrafRhwFWuZ+l7tmppCNJfPrcW+LQkbwcBgVr8pVNuRoW852FLz4dZfVHaTWc064IYSuUebg="

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.81.0"
+channel = "1.82.0"
 targets = ["x86_64-unknown-linux-musl"]
-profile = "minimal"
+profile = "default"

--- a/src/routing/mod.rs
+++ b/src/routing/mod.rs
@@ -249,7 +249,7 @@ pub async fn setup_router(
     );
 
     // Load shedders
-    
+
     // We need to map the generic response of a shedder to an Axum's Response
     let shed_map_response = MapResponseLayer::new(|resp| match resp {
         ShedResponse::Inner(inner) => inner,
@@ -284,16 +284,14 @@ pub async fn setup_router(
         option_layer(if !cli.shed_latency.shed_sharded_latency.is_empty() {
             warn!("Latency load shedder enabled ({:?})", cli.shed_latency);
 
-            Some(
-                ServiceBuilder::new()
-                    .layer(shed_map_response)
-                    .layer(ShardedLittleLoadShedderLayer::new(ShardedOptions {
-                        extractor: RequestTypeExtractor,
-                        ewma_alpha: cli.shed_latency.shed_sharded_ewma,
-                        passthrough_count: cli.shed_latency.shed_sharded_passthrough,
-                        latencies: cli.shed_latency.shed_sharded_latency.clone(),
-                    })),
-            )
+            Some(ServiceBuilder::new().layer(shed_map_response).layer(
+                ShardedLittleLoadShedderLayer::new(ShardedOptions {
+                    extractor: RequestTypeExtractor,
+                    ewma_alpha: cli.shed_latency.shed_sharded_ewma,
+                    passthrough_count: cli.shed_latency.shed_sharded_passthrough,
+                    latencies: cli.shed_latency.shed_sharded_latency.clone(),
+                }),
+            ))
         } else {
             None
         });

--- a/src/routing/mod.rs
+++ b/src/routing/mod.rs
@@ -256,14 +256,16 @@ pub async fn setup_router(
         ShedResponse::Overload(_) => ErrorCause::LoadShed.into_response(),
     });
 
-    let load_shedder_system_mw = option_layer(
-        // TODO make nicer?
-        if cli.shed_system.shed_system_cpu.is_some()
-            || cli.shed_system.shed_system_memory.is_some()
-            || cli.shed_system.shed_system_load_avg_1.is_some()
-            || cli.shed_system.shed_system_load_avg_5.is_some()
-            || cli.shed_system.shed_system_load_avg_15.is_some()
-        {
+    let load_shedder_system_mw = option_layer({
+        let opts = &[
+            cli.shed_system.shed_system_cpu,
+            cli.shed_system.shed_system_memory,
+            cli.shed_system.shed_system_load_avg_1,
+            cli.shed_system.shed_system_load_avg_5,
+            cli.shed_system.shed_system_load_avg_15,
+        ];
+
+        if opts.iter().any(|x| x.is_some()) {
             warn!("System load shedder enabled ({:?})", cli.shed_system);
 
             Some(
@@ -277,8 +279,8 @@ pub async fn setup_router(
             )
         } else {
             None
-        },
-    );
+        }
+    });
 
     let load_shedder_latency_mw =
         option_layer(if !cli.shed_latency.shed_sharded_latency.is_empty() {

--- a/src/routing/mod.rs
+++ b/src/routing/mod.rs
@@ -4,11 +4,11 @@ pub mod ic;
 pub mod middleware;
 pub mod proxy;
 
-use std::sync::Arc;
+use std::{str::FromStr, sync::Arc};
 
-use anyhow::Error;
+use anyhow::{Context, Error};
 use axum::{
-    extract::{Host, OriginalUri, Request},
+    extract::{Host, MatchedPath, OriginalUri, Request},
     middleware::{from_fn, from_fn_with_state, FromFnLayer},
     response::{IntoResponse, Redirect},
     routing::{get, post},
@@ -19,15 +19,19 @@ use candid::Principal;
 use domain::{CustomDomainStorage, DomainResolver, ProvidesCustomDomains};
 use fqdn::FQDN;
 use http::{method::Method, uri::PathAndQuery, StatusCode, Uri};
-use ic::route_provider::setup_route_provider;
 use ic_bn_lib::{
     http::{
         cache::{Cache, KeyExtractorUriRange, Opts},
+        shed::{
+            sharded::{ShardedLittleLoadShedderLayer, ShardedOptions, TypeExtractor},
+            system::{SystemInfo, SystemLoadShedderLayer},
+            ShedResponse,
+        },
         Client,
     },
     tasks::TaskManager,
+    types::RequestType as RequestTypeApi,
 };
-use little_loadshedder::{LoadShedLayer, LoadShedResponse};
 use middleware::cache;
 use prometheus::Registry;
 use strum::{Display, IntoStaticStr};
@@ -47,7 +51,7 @@ use self::middleware::denylist;
 use {
     domain::{Domain, ResolvesDomain},
     error_cause::ErrorCause,
-    ic::handler,
+    ic::{handler, route_provider::setup_route_provider},
 };
 
 #[derive(Clone, Copy, Eq, PartialEq, PartialOrd, Ord)]
@@ -59,19 +63,7 @@ impl From<CanisterId> for Principal {
     }
 }
 
-// Type of IC API request
-#[derive(Debug, Clone, Copy, Display, PartialEq, Eq, Hash, IntoStaticStr)]
-#[strum(serialize_all = "snake_case")]
-pub enum RequestTypeApi {
-    Status,
-    Query,
-    Call,
-    SyncCall,
-    ReadState,
-    ReadStateSubnet,
-}
-
-#[derive(Debug, Clone, Copy, Display, PartialEq, Eq, Hash, IntoStaticStr)]
+#[derive(Debug, Clone, Copy, Display, PartialEq, Eq, PartialOrd, Ord, Hash, IntoStaticStr)]
 #[strum(serialize_all = "snake_case")]
 pub enum RequestType {
     Http,
@@ -82,17 +74,67 @@ pub enum RequestType {
     Unknown,
 }
 
-#[derive(Clone)]
+// Strum can't handle FromStr for nested types (Api) the way we want
+impl FromStr for RequestType {
+    type Err = ic_bn_lib::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(match s {
+            "http" => Self::Http,
+            "health" => Self::Health,
+            "registrations" => Self::Registrations,
+            "unknown" => Self::Unknown,
+            _ => Self::Api(RequestTypeApi::from_str(s).context("unable to parse API type")?),
+        })
+    }
+}
+
+// Derive request type from the matched path if there's one
+impl From<Option<&MatchedPath>> for RequestType {
+    fn from(path: Option<&MatchedPath>) -> Self {
+        let Some(path) = path else {
+            return Self::Http;
+        };
+
+        match path.as_str() {
+            "/api/v2/canister/:principal/query" => Self::Api(RequestTypeApi::Query),
+            "/api/v2/canister/:principal/call" => Self::Api(RequestTypeApi::Call),
+            "/api/v3/canister/:principal/call" => Self::Api(RequestTypeApi::SyncCall),
+            "/api/v2/canister/:principal/read_state" => Self::Api(RequestTypeApi::ReadState),
+            "/api/v2/subnet/:principal/read_state" => Self::Api(RequestTypeApi::ReadStateSubnet),
+            "/api/v2/status" => Self::Api(RequestTypeApi::Status),
+            "/health" => Self::Health,
+            "/registrations" | "/registrations/:id" => Self::Registrations,
+            _ => Self::Unknown,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
 pub struct RequestCtx {
     // HTTP2 authority or HTTP1 Host header
     pub authority: FQDN,
     pub domain: Domain,
     pub verify: bool,
+    pub request_type: RequestType,
 }
 
 impl RequestCtx {
     fn is_base_domain(&self) -> bool {
         !self.domain.custom && self.authority == self.domain.name
+    }
+}
+
+#[derive(Clone, Debug)]
+struct RequestTypeExtractor;
+impl TypeExtractor for RequestTypeExtractor {
+    type Request = Request;
+    type Type = RequestType;
+
+    fn extract(&self, req: &Self::Request) -> Option<Self::Type> {
+        req.extensions()
+            .get::<Arc<RequestCtx>>()
+            .map(|x| x.request_type)
     }
 }
 
@@ -206,15 +248,54 @@ pub async fn setup_router(
             .map(ConcurrencyLimitLayer::new),
     );
 
-    // Load shedder
-    let load_shedder_mw = option_layer(cli.load.load_shed_ewma_param.map(|x| {
-        ServiceBuilder::new()
-            .layer(MapResponseLayer::new(|resp| match resp {
-                LoadShedResponse::Inner(inner) => inner,
-                LoadShedResponse::Overload => ErrorCause::LoadShed.into_response(),
-            }))
-            .layer(LoadShedLayer::new(x, cli.load.load_shed_target_latency))
-    }));
+    // Load shedders
+    let load_shedder_system_mw = option_layer(
+        // TODO make nicer?
+        if cli.shed_system.shed_system_cpu.is_some()
+            || cli.shed_system.shed_system_memory.is_some()
+            || cli.shed_system.shed_system_load_avg_1.is_some()
+            || cli.shed_system.shed_system_load_avg_5.is_some()
+            || cli.shed_system.shed_system_load_avg_15.is_some()
+        {
+            warn!("System load shedder enabled ({:?})", cli.shed_system);
+
+            Some(
+                ServiceBuilder::new()
+                    .layer(MapResponseLayer::new(|resp| match resp {
+                        ShedResponse::Inner(inner) => inner,
+                        ShedResponse::Overload(_) => ErrorCause::LoadShed.into_response(),
+                    }))
+                    .layer(SystemLoadShedderLayer::new(
+                        cli.shed_system.shed_system_ewma,
+                        cli.shed_system.clone().into(),
+                        SystemInfo::new(),
+                    )),
+            )
+        } else {
+            None
+        },
+    );
+
+    let load_shedder_latency_mw =
+        option_layer(if !cli.shed_latency.shed_sharded_latency.is_empty() {
+            warn!("Latency load shedder enabled ({:?})", cli.shed_latency);
+
+            Some(
+                ServiceBuilder::new()
+                    .layer(MapResponseLayer::new(|resp| match resp {
+                        ShedResponse::Inner(inner) => inner,
+                        ShedResponse::Overload(_) => ErrorCause::LoadShed.into_response(),
+                    }))
+                    .layer(ShardedLittleLoadShedderLayer::new(ShardedOptions {
+                        extractor: RequestTypeExtractor,
+                        ewma_alpha: cli.shed_latency.shed_sharded_ewma,
+                        passthrough_count: cli.shed_latency.shed_sharded_passthrough,
+                        latencies: cli.shed_latency.shed_sharded_latency.clone(),
+                    })),
+            )
+        } else {
+            None
+        });
 
     // Prepare the HTTP->IC library
     let route_provider =
@@ -351,10 +432,11 @@ pub async fn setup_router(
         .layer(from_fn(request_id::middleware))
         .layer(from_fn(headers::middleware))
         .layer(metrics_mw)
+        .layer(load_shedder_system_mw)
+        .layer(from_fn_with_state(domain_resolver, validate::middleware))
         .layer(concurrency_limit_mw)
         .layer(geoip_mw)
-        .layer(load_shedder_mw)
-        .layer(from_fn_with_state(domain_resolver, validate::middleware));
+        .layer(load_shedder_latency_mw);
 
     // Top-level router
     let router = Router::new()
@@ -395,4 +477,52 @@ pub async fn setup_router(
 
     // The layer that's added last is executed first
     Ok(router)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use std::str::FromStr;
+
+    #[test]
+    fn test_request_type() {
+        assert_eq!(RequestType::Http, RequestType::from_str("http").unwrap());
+        assert_eq!(
+            RequestType::Health,
+            RequestType::from_str("health").unwrap()
+        );
+        assert_eq!(
+            RequestType::Registrations,
+            RequestType::from_str("registrations").unwrap()
+        );
+        assert_eq!(
+            RequestType::Unknown,
+            RequestType::from_str("unknown").unwrap()
+        );
+
+        assert_eq!(
+            RequestType::Api(RequestTypeApi::Query),
+            RequestType::from_str("query").unwrap()
+        );
+        assert_eq!(
+            RequestType::Api(RequestTypeApi::Call),
+            RequestType::from_str("call").unwrap()
+        );
+        assert_eq!(
+            RequestType::Api(RequestTypeApi::SyncCall),
+            RequestType::from_str("sync_call").unwrap()
+        );
+        assert_eq!(
+            RequestType::Api(RequestTypeApi::Status),
+            RequestType::from_str("status").unwrap()
+        );
+        assert_eq!(
+            RequestType::Api(RequestTypeApi::ReadState),
+            RequestType::from_str("read_state").unwrap()
+        );
+        assert_eq!(
+            RequestType::Api(RequestTypeApi::ReadStateSubnet),
+            RequestType::from_str("read_state_subnet").unwrap()
+        );
+    }
 }


### PR DESCRIPTION
* Switch from the direct usage of `little-loadshedder` to a sharded version from `ic-bn-lib`. `little-loadshedder` itself was also forked there to support using a single state across all of its clones (layer instances)
* System shedder is added that sheds based on system load
* Added CLI args to support various new idle timers in the HTTP server of `ic-bn-lib`
* Update deps
* Update Rust to 1.82
* Update repro environment
