### PR TITLE
feat(BOUN-1320): add generic custom domain provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1696,6 +1696,9 @@ name = "fqdn"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7722a38bde19627699ee91aca8b0fca068945ee28ea8489c7cb29ec25172d055"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "fragile"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -437,7 +437,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper 1.0.2",
  "tokio",
- "tower 0.5.1",
+ "tower 0.5.2",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -482,7 +482,7 @@ dependencies = [
  "multer",
  "pin-project-lite",
  "serde",
- "tower 0.5.1",
+ "tower 0.5.2",
  "tower-layer",
  "tower-service",
 ]
@@ -695,9 +695,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a68f1f47cdf0ec8ee4b941b2eee2a80cb796db73118c0dd09ac63fbe405be22"
+checksum = "786a307d683a5bf92e6fd5fd69a7eb613751668d1d8d67d802846dfe367c62c8"
 dependencies = [
  "memchr",
  "regex-automata 0.4.9",
@@ -817,9 +817,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.3"
+version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27f657647bcff5394bf56c7317665bbf790a137a50eaaa5c6bfbb9e27a518f2d"
+checksum = "9157bbaa6b165880c27a4293a474c91cdcf265cc68cc829bf10be0964a391caf"
 dependencies = [
  "jobserver",
  "libc",
@@ -1006,7 +1006,7 @@ dependencies = [
  "lz4_flex",
  "quanta",
  "replace_with",
- "rustls 0.23.19",
+ "rustls 0.23.20",
  "sealed",
  "serde",
  "static_assertions",
@@ -1216,18 +1216,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.13"
+version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
+checksum = "06ba6d68e24814cb8de6bb986db8222d3a027d15872cabc0d18817bc3c0e4471"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -1244,9 +1244,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.20"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crunchy"
@@ -1797,7 +1797,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f2f12607f92c69b12ed746fabf9ca4f5c482cba46679c1a75b874ed7c26adb"
 dependencies = [
  "futures-io",
- "rustls 0.23.19",
+ "rustls 0.23.20",
  "rustls-pki-types",
 ]
 
@@ -2286,7 +2286,7 @@ dependencies = [
  "http 1.2.0",
  "hyper 1.5.1",
  "hyper-util",
- "rustls 0.23.19",
+ "rustls 0.23.20",
  "rustls-native-certs 0.8.1",
  "rustls-pki-types",
  "tokio",
@@ -2438,7 +2438,7 @@ dependencies = [
  "rand",
  "rcgen",
  "reqwest 0.12.9",
- "rustls 0.23.19",
+ "rustls 0.23.20",
  "rustls-acme",
  "rustls-pemfile 2.2.0",
  "rustls-platform-verifier",
@@ -2450,12 +2450,12 @@ dependencies = [
  "strum_macros",
  "sync_wrapper 1.0.2",
  "systemstat",
- "thiserror 2.0.6",
+ "thiserror 2.0.7",
  "tokio",
  "tokio-io-timeout",
  "tokio-rustls 0.26.1",
  "tokio-util",
- "tower 0.5.1",
+ "tower 0.5.2",
  "tower-service",
  "tracing",
  "url",
@@ -2569,7 +2569,7 @@ dependencies = [
  "rand",
  "regex",
  "reqwest 0.12.9",
- "rustls 0.23.19",
+ "rustls 0.23.20",
  "rustls-platform-verifier",
  "serde",
  "serde_cbor",
@@ -2577,13 +2577,13 @@ dependencies = [
  "strum",
  "strum_macros",
  "tempfile",
- "thiserror 2.0.6",
+ "thiserror 2.0.7",
  "tikv-jemalloc-ctl",
  "tikv-jemallocator",
  "time",
  "tokio",
  "tokio-util",
- "tower 0.5.1",
+ "tower 0.5.2",
  "tower-http",
  "tower-service",
  "tower_governor",
@@ -3499,7 +3499,7 @@ dependencies = [
  "rasn-pkix",
  "readme-rustdocifier",
  "reqwest 0.12.9",
- "rustls 0.23.19",
+ "rustls 0.23.20",
  "sha1",
  "tokio",
  "tokio-util",
@@ -3931,9 +3931,9 @@ dependencies = [
 
 [[package]]
 name = "quanta"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5167a477619228a0b284fac2674e3c388cba90631d7b7de620e6f1fcd08da5"
+checksum = "773ce68d0bb9bc7ef20be3536ffe94e223e1f365bd374108b2659fac0c65cfe6"
 dependencies = [
  "crossbeam-utils",
  "libc",
@@ -3961,9 +3961,9 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash 2.1.0",
- "rustls 0.23.19",
+ "rustls 0.23.20",
  "socket2",
- "thiserror 2.0.6",
+ "thiserror 2.0.7",
  "tokio",
  "tracing",
 ]
@@ -3979,10 +3979,10 @@ dependencies = [
  "rand",
  "ring 0.17.8",
  "rustc-hash 2.1.0",
- "rustls 0.23.19",
+ "rustls 0.23.20",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.6",
+ "thiserror 2.0.7",
  "tinyvec",
  "tracing",
  "web-time",
@@ -4160,9 +4160,9 @@ checksum = "08ad765b21a08b1a8e5cdce052719188a23772bcbefb3c439f0baaf62c56ceac"
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
+checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
 dependencies = [
  "bitflags 2.6.0",
 ]
@@ -4298,7 +4298,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.19",
+ "rustls 0.23.20",
  "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "serde",
@@ -4432,9 +4432,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.19"
+version = "0.23.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "934b404430bb06b3fae2cba809eb45a1ab1aecd64491213d7c3301b88393f8d1"
+checksum = "5065c3f250cbd332cd894be57c40fa52387247659b14a2d6041d121547903b1b"
 dependencies = [
  "aws-lc-rs",
  "brotli",
@@ -4469,7 +4469,7 @@ dependencies = [
  "ring 0.17.8",
  "serde",
  "serde_json",
- "thiserror 2.0.6",
+ "thiserror 2.0.7",
  "webpki-roots 0.26.7",
  "x509-parser",
 ]
@@ -4519,9 +4519,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16f1201b3c9a7ee8039bcadc17b7e605e2945b27eee7631788c1bd2b0643674b"
+checksum = "d2bf47e6ff922db3825eb750c4e2ff784c6ff8fb9e13046ef6a1d1c5401b0b37"
 dependencies = [
  "web-time",
 ]
@@ -4537,7 +4537,7 @@ dependencies = [
  "jni",
  "log",
  "once_cell",
- "rustls 0.23.19",
+ "rustls 0.23.20",
  "rustls-native-certs 0.7.3",
  "rustls-platform-verifier-android",
  "rustls-webpki 0.102.8",
@@ -4685,9 +4685,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
+checksum = "3cb6eb87a131f756572d7fb904f6e7b68633f09cca868c5df1c4b8d1a694bbba"
 
 [[package]]
 name = "serde"
@@ -5187,9 +5187,9 @@ dependencies = [
 
 [[package]]
 name = "systemstat"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a24aec24a9312c83999a28e3ef9db7e2afd5c64bf47725b758cdc1cafd5b0bd2"
+checksum = "668a4db78b439df482c238f559e4ea869017f9e62ef0a059c8bfcd841a4df544"
 dependencies = [
  "bytesize",
  "lazy_static",
@@ -5252,11 +5252,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.6"
+version = "2.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec2a1820ebd077e2b90c4df007bebf344cd394098a13c563957d0afc83ea47"
+checksum = "93605438cbd668185516ab499d589afb7ee1859ea3d5fc8f6b0755e1c7443767"
 dependencies = [
- "thiserror-impl 2.0.6",
+ "thiserror-impl 2.0.7",
 ]
 
 [[package]]
@@ -5272,9 +5272,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.6"
+version = "2.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d65750cab40f4ff1929fb1ba509e9914eb756131cef4210da8d5d700d26f6312"
+checksum = "e1d8749b4531af2117677a5fcd12b1348a3fe2b81e36e61ffeac5c4aa3273e36"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5453,7 +5453,7 @@ version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f6d0975eaace0cf0fcadee4e4aaa5da15b5c079146f2cffb67c113be122bf37"
 dependencies = [
- "rustls 0.23.19",
+ "rustls 0.23.20",
  "tokio",
 ]
 
@@ -5537,14 +5537,14 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2873938d487c3cfb9aed7546dc9f2711d867c9f90c46b889989a2cb84eba6b4f"
+checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
 dependencies = [
  "futures-core",
  "futures-util",
  "pin-project-lite",
- "sync_wrapper 0.1.2",
+ "sync_wrapper 1.0.2",
  "tokio",
  "tokio-util",
  "tower-layer",
@@ -5595,7 +5595,7 @@ dependencies = [
  "http 1.2.0",
  "pin-project",
  "thiserror 1.0.69",
- "tower 0.5.1",
+ "tower 0.5.2",
  "tracing",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ clickhouse = { version = "0.13.1", features = [
 console-subscriber = { version = "0.4.1", optional = true }
 ctrlc = { version = "3.4.5", features = ["termination"] }
 derive-new = "0.7.0"
-fqdn = "0.4.1"
+fqdn = { version = "0.4.1", features = ["serde"] }
 futures = "0.3.31"
 futures-util = "0.3.31"
 governor = "0.6.0" # must match tower-governor deps

--- a/repro-env.lock
+++ b/repro-env.lock
@@ -1,5 +1,5 @@
 [container]
-image = "docker.io/library/archlinux@sha256:3fb8e79e4037db1536d331dba905e234fa18c8206191458a927013a2d2dafc50"
+image = "docker.io/library/archlinux@sha256:5906892165fc79b4e282e36f24802528bcee2bd2896982ad771045341e15db5c"
 
 [[package]]
 name = "abseil-cpp"
@@ -18,20 +18,12 @@ sha256 = "6702f58e662908cbd5a86d554363348c2ab5c2e5e594f9d07d5627d16fda57b7"
 signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCZrE/KV8UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCmU9AQCXKD3fwCpsiulOCWkyRGtDfo6LP7RgB/qUuamWUSrZewD7Bb1wX8sFIlloYrBNBbKjfSyytH4gY7VuJ7fFFTodpwI="
 
 [[package]]
-name = "ca-certificates-mozilla"
-version = "3.106-1"
-system = "archlinux"
-url = "https://archive.archlinux.org/packages/c/ca-certificates-mozilla/ca-certificates-mozilla-3.106-1-x86_64.pkg.tar.zst"
-sha256 = "2a34db5480ea46e2cbccf72f0fbb7c887241c3db3a2f545e5ba8bfeec56f0481"
-signature = "iHUEABYKAB0WIQSDvIiJNRtd67toQW64rAhgDxCM3wUCZxu2IQAKCRC4rAhgDxCM3z+oAQDW3U/L7i1xaV4gvBZgJYp/H2EGMp8ceOmkM0HUSDF+twEA8P0EsLZxix+Up5DvLfgGRXeH9+ohD6sxCLQndRXlDQY="
-
-[[package]]
 name = "cmake"
-version = "3.30.5-1"
+version = "3.31.2-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/c/cmake/cmake-3.30.5-1-x86_64.pkg.tar.zst"
-sha256 = "6ac95a823c85c37f00a8473349be734746bff73ce76fced6bec9eb11a151f94b"
-signature = "iQEzBAABCAAdFiEEFRnVq6Zb9vwrc8dWek52CV2KUuQFAmcFmjEACgkQek52CV2KUuRPkAf/cWkvVCMxM2Fvm1a4hkraLC7MvR3WPBpfo6bdtHZmO86fsRftUP/Ya1BA7debGkW0zc3G6Q7TgIVXxCOOnTJtSKwm8dKbam+4LTNgmWzlQ4FoRCskyaKBFEBaaQx+IZoDmq2At42a6jHbxisp8Cs+GWKe9e644SbYtZQugRHq0AycZ9HdjB8HaubFV+fWXG4f4QAQFZtc8rzQcedLPiLLShzIzhVP7CajVD8w0BMOO/BcoaHRYvUyBl6iuKXQQkO7+N0j9JlJtt3Sg8hLdffh+iU34YufhO3oiMVTOkggvyOQ6Wu5PpmmLHl9b3NKGnr55VIHurrOP75Hmhw+uvUpDg=="
+url = "https://archive.archlinux.org/packages/c/cmake/cmake-3.31.2-1-x86_64.pkg.tar.zst"
+sha256 = "ee7e6a65641ffdd13835bddadc65476c809bfdf0aa0ff10473f601ff6d6d79b7"
+signature = "iQEzBAABCAAdFiEEFRnVq6Zb9vwrc8dWek52CV2KUuQFAmdR1W8ACgkQek52CV2KUuQOqwf+LGmHHXWSM222B/Cxe7QAuezYS738+d9+f7hOS1NAUq7JsaKrrflqqSziOee5Y+UttVXPgtQOhiOM6ruqXjSWAcHJskCUoDDzCe2AZajdxrxSEAUId39mlROrOxGyxe0W1D3fGGezoEHTIbKSqJN3tD3tXnKpWbF8WDQs83NQ5/wznxhqDgyYA1PSA2ERGghe2hdnj1YglFtcslw+c5P8ML+q4oiqT06ZIMOfOj03B2KM4HRmPYZUMHV0O+CgwUKbMgc4S8OM2iaq+zsA6yfYJgCLOEiiLsPyWXBoFWXDHvZEbydg9MwTXZbhSenVtzIMwrM2lfBtjiZtQyrpV1IwDA=="
 
 [[package]]
 name = "cppdap"
@@ -43,11 +35,19 @@ signature = "iQEzBAABCAAdFiEEFRnVq6Zb9vwrc8dWek52CV2KUuQFAmaDH8sACgkQek52CV2KUuR
 
 [[package]]
 name = "curl"
-version = "8.10.1-2"
+version = "8.11.1-3"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/c/curl/curl-8.10.1-2-x86_64.pkg.tar.zst"
-sha256 = "f9f420321b55b6c73788a00e890e5f38d6cb769ed5fe0f809a1dd1fb940a936f"
-signature = "iHUEABYKAB0WIQQhkbiUMbrAqLlt6T0kR0DRfH/Q7AUCZxTUnAAKCRAkR0DRfH/Q7DjUAP0fPzb/dSMBpFONe0x/24IdDIVyi8S3cGAcm7zj8z1ZUgD9HFhkTqVhJr9u1HEDwVgsO89+HqUp9Kqy7L/peDv8fwc="
+url = "https://archive.archlinux.org/packages/c/curl/curl-8.11.1-3-x86_64.pkg.tar.zst"
+sha256 = "3cb1d2a639a3fec0388df077a9ddf0ffb2d097b9b85f085ca5321b7aad996777"
+signature = "iHUEABYKAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCZ1r7pAAKCRBtQr3RFuAGjy/IAP45N0Y5Xbg74aaMmdKNzu5V+WpJLeiyqtlY9TUkA4L3yAD/Rq5hfHAE+gtpQo/2xVlMVoLbD/obRilQjoQw5fjnlwE="
+
+[[package]]
+name = "device-mapper"
+version = "2.03.29-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/d/device-mapper/device-mapper-2.03.29-1-x86_64.pkg.tar.zst"
+sha256 = "e9c01f8ea5db7f3b9efb6f1a83a9dc5d961eae3199af516265ea747b547aab23"
+signature = "iHUEABYKAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCZ1cFowAKCRBtQr3RFuAGj3O2AQDt9d84iD3UWAboOvzWd0SSXREi+HHrUsR23lq30/XC3wD5Ad0TGODreMtb9DO85GHIY76+UVWydM1KFB87hJavRAs="
 
 [[package]]
 name = "gc"
@@ -66,12 +66,12 @@ sha256 = "efcf9a912bb674205fe8cbc2f205ca3d64ec0e8e48700c74bac8952834dc4415"
 signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCZuBXXV8UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaChhNAQC1+ckQFrMS0NCEB/MuyxouCmUQ0COinRuR6OvZ4qoYhQD/X5l3opAxR9lO8dtqfoLbeGUqOwQUqzZHG8gF4Y8z0wQ="
 
 [[package]]
-name = "gnupg"
-version = "2.4.5-6"
+name = "glib2"
+version = "2.82.4-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/g/gnupg/gnupg-2.4.5-6-x86_64.pkg.tar.zst"
-sha256 = "e7425c89c95f0f86e26d3290564c76c9e3849e1995aed7a6ae26a825b6e5b6d5"
-signature = "iHUEABYKAB0WIQRizHP4hOUpV7L92IObeih9mi7GCAUCZxp8DAAKCRCbeih9mi7GCKfUAP9xcLLspyyJbvO2OWJAFB6PD5ZATKdF/Sq6pQfuJYEMyAD+M/hrtdwobnM27+jMtCx6rF/Ylx5GQKtVC5lysO77Vww="
+url = "https://archive.archlinux.org/packages/g/glib2/glib2-2.82.4-1-x86_64.pkg.tar.zst"
+sha256 = "bea3af65df9d5446bae37d3c8761b566d9433214953582ccd85c036173ec1e5b"
+signature = "iHUEABYKAB0WIQSDvIiJNRtd67toQW64rAhgDxCM3wUCZ1pLtwAKCRC4rAhgDxCM31FyAQCD13zAb38Fv7c7SLHed6WkPr4RPd+keZ4NdAfdkfwnMAD+NGYvK/DUFRvPMdywYiqUFMXFKl771eYNSm0OiSDsTw0="
 
 [[package]]
 name = "gtest"
@@ -98,6 +98,14 @@ sha256 = "22ec69012b9a55e276b5891f916366f692541dce3793bff3e85a28a10b91990a"
 signature = "iHUEABYKAB0WIQSDvIiJNRtd67toQW64rAhgDxCM3wUCZk/ttQAKCRC4rAhgDxCM39FIAP9Zcpg7ei4MUwFlnla8x7YDFRtQFp2WtiPOhyohRoMxhwEA2Fjer9ZWaLxYDvXfG3TbweF7ZzIQ621pJSfzl/HCnw8="
 
 [[package]]
+name = "iana-etc"
+version = "20241206-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/i/iana-etc/iana-etc-20241206-1-any.pkg.tar.zst"
+sha256 = "4da97deaa9574efa50e43bd3d1a8d76ae0404409f384b516859263cfe6e4be15"
+signature = "iQEzBAABCgAdFiEE5JnHn1PJalTlcv7hwGCGM3xQdz4FAmdUBJsACgkQwGCGM3xQdz4cYQf/ThGUaNJGfmd+aECHqlSMHoWIQucyJ1+Zedws1LKM4EJlk7WJELHmWzVTY3/lN0jXLmBKeMRsibrK+wGxc/k2aplLdqhFG3bi+w3LkpMOOzL15Mdo7PbHoquRWU+AtDBfKB75D0geKruWFq4ovjpKjmfUu/JTaBCgKY6FYRqeSM13gDB0N4i4/167N/Vpyyq3XANBhVp6y1iU6EH/5UXarJj1SvjVZ8DXKiKyTGFRoM+AIoJ/dnUV4tsqb3cLmWyTl3eUguN0FzNcrqTA+gUPTWaMouuQ8BbSKGd97UXyA6LLX9jWHtcbNGKyHTzCfJJQacHTw8D+l+v6SHau1mqYqA=="
+
+[[package]]
 name = "jansson"
 version = "2.14-4"
 system = "archlinux"
@@ -114,20 +122,20 @@ sha256 = "2aa066e1840850aad3b901dec9e8aaa047afcd1835576378f6ba16285c268fcb"
 signature = "iQEzBAABCAAdFiEEFRnVq6Zb9vwrc8dWek52CV2KUuQFAmblvasACgkQek52CV2KUuSEOwf/fm7VzJjRdFKN6DVeDqFkQjkfaOenZtUCQc3GuSvt9xOZ9ghv6F1Myt3Z5aDnApntNsn+zqjV+OpAPjeiJcrnS8vN+PZ8QLx2udJgO9uZ2e/SG5gkowJvjJFqB2eTL1XeUOhyFzjo2b4dC4VRMxId5oZ/o2jsa1HfRVipSYz3ulfngiJTaUlGHGqSvQc7ykmrs2cnWuCuhY9xIhhLQSo0xvYGaBuCOwCTfGmG+G/IcL+JKQh8kBkTydu92Odpig+dyyhhAZXWHXNuUN/WMxRJZUrsHWLV4eCVV8G1pZknF0o8bu77uS5rTC7hPXSLElvK3eZ+UE2A0EVoha8jn3HVFQ=="
 
 [[package]]
+name = "kbd"
+version = "2.7-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/k/kbd/kbd-2.7-1-x86_64.pkg.tar.zst"
+sha256 = "8365c41f7de9c086f886824b63e1dff711e08d0d2bb05e1bb29b5eb86f21b5ee"
+signature = "iQEzBAABCAAdFiEEW34/txt/EDKaHAOrdx32Yn7faB8FAmdYmNEACgkQdx32Yn7faB9CoAf/VjKQhKFS0hejDclB24RHkzvKVrTRdYHXyZFuXnGTzAU/fhmN5jbRCf3AM8xAcD1zTVRWkQVkQnLFT7MwZGnKv5s20g2G/m8z8rJRtpywAWVGglKFxk9/d3+4XOAX/jWoQxSDAT/u0d27umsgAl5DBnRsHUawmRgxnrdVi3McLzEPUjoY8MC0O0/dzR4Q/rgoK9BUs/a7PkfKZ94EBTNSVBlPMS05fq+LvT/C/uR3I6edvgZy3YkEBAebPSXWIYFZPnlozrFVWRZFgyS+0qCXg/ymObl4sMLVkfHzrfSol42eGxjfTJx8on9J7u0cCa31zuS6MCN21G+kX2F9p66anA=="
+
+[[package]]
 name = "libedit"
 version = "20240517_3.1-1"
 system = "archlinux"
 url = "https://archive.archlinux.org/packages/l/libedit/libedit-20240517_3.1-1-x86_64.pkg.tar.zst"
 sha256 = "fa17f759180233be8343ccccb1c3e4ac01cf5367ab141f36ca8830151b7c12be"
 signature = "iQIzBAABCgAdFiEE4kC1fixGMLp2ji8m/BtUfI2BcsgFAmZRDMAACgkQ/BtUfI2BcsjfBg/9GJ/xfxU7NKehazazuulK0VWaeXwc2SydHS4lpnqZggkcNtVlJIXzIrIBAK+A06M99NLqJzdrLsCssa5RjlMSxtB8nZYjZIE7M4fivBHgx4N6xUzzSu7PN8G9A1fvnbRFqtcvywP/FeWnmBIsf404BeKhwHB0PkG9RebYmJAKpg1IHhHNBJ/NkYC04Wov4oskzv/HehibIbnvTu6EZQ2f2NyXJVTqUsEkEw5xSEsyob+fgAtMdfufs6xpFskYV9NWniHKxWN9JKy0HwJ764JrxRW5VrrR2Ua/zWQYBi0r71zfrt/mILjkJwWNe0+LzJWpOqD59sjllW2iBeTeH+0A4lG7beaKdhCAAQQUzAPINuCwhpOGvvFhOn04icVPgqFKVegbNbXN+Wad+60HKgQw4AI0XeHo8uTiJOKolObV27OxaQTK2s5qmsrali4zsLlC+G2lYUvrqvWlrtuIIm+6XGNSMDoYovVd2EoBGRrwFCDlfdah8kFa6PY9J1UWQY7mDPJerpgB0IZ0KycxpXvB5I5XzYLKbSEjWZ331jnCWbR+poQfYwMYI2H9ZFy2YN0R/VohaIU70Ux5F24gjUaLYc1Ld9ZzrV1MSMj+D20vdxLCmNoDLfNwwceBbCyisT5GnxAFVWvaX3WwhI/D/jPnBcuEw11FfsHLUaGNIfM+mQQ="
-
-[[package]]
-name = "libelf"
-version = "0.192-1"
-system = "archlinux"
-url = "https://archive.archlinux.org/packages/l/libelf/libelf-0.192-1-x86_64.pkg.tar.zst"
-sha256 = "bdc392e3a04ae66c253e9cf4ece3727c4625214657ec9d631c5beaef509ee005"
-signature = "iHUEABYKAB0WIQRizHP4hOUpV7L92IObeih9mi7GCAUCZxQYZQAKCRCbeih9mi7GCJgwAQCDfHVmtkOAk+YaiRq82dI+WySEMMl3DPjKIDa21VuPBgEAj6zOvUq7E21vaq/uvaiNeAtN7wrZJerkZyRHArrz9gA="
 
 [[package]]
 name = "libisl"
@@ -144,22 +152,6 @@ system = "archlinux"
 url = "https://archive.archlinux.org/packages/l/libmpc/libmpc-1.3.1-2-x86_64.pkg.tar.zst"
 sha256 = "10554706eb15ed2186fbd55fd5db8fa5919788ac9a75d26c0b9ef5bdfca9d470"
 signature = "iQEzBAABCAAdFiEEFRnVq6Zb9vwrc8dWek52CV2KUuQFAmaHCZwACgkQek52CV2KUuRjbAf/TmL9cCMXYTGsNmR2om6kT7XjczfZoFR9AM0FSTUNy5AuNZNUUCfm6ie6F4rFwHc3nETOSojScOZauZlcNiLrVriHYYFSZ8EhKiCJCo68a7KTbceBNoBuT6AEIpGMpIMti/cvWhu8VXl5JIRo8LNPBzDih05aCDUJ2nayKPYNHalDayu87sDXzJYXuzC8KD7XmUa7Kirn0ZpA4VZXc8CUjYYvn0wvRwLKQP4WMpszxmblQWjMVbQxh7dwC+gPtqIANVjoGKMRfr6QpT03XXIEaTBKbMsxeYFvwn+y2JN30t6oFI6LJADZ22VwimEzu06u+x9c+3+pr4k7Py43OCOGmg=="
-
-[[package]]
-name = "libnghttp2"
-version = "1.64.0-1"
-system = "archlinux"
-url = "https://archive.archlinux.org/packages/l/libnghttp2/libnghttp2-1.64.0-1-x86_64.pkg.tar.zst"
-sha256 = "cbf36ec454555c49d3ee0205ab8293778dcf5b3a59de6242bd042741cd7f8fb7"
-signature = "iHUEABYKAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCZxfh+wAKCRBtQr3RFuAGj2bwAQDDXVfGbTyjNlS/j75jpq3qYoyPpXmujysVEsY47vYnmQEAuFk2S2V/5IdosdX76ks40FU4gaC1VV59N5Q9ppPx2gc="
-
-[[package]]
-name = "libtirpc"
-version = "1.3.6-1"
-system = "archlinux"
-url = "https://archive.archlinux.org/packages/l/libtirpc/libtirpc-1.3.6-1-x86_64.pkg.tar.zst"
-sha256 = "36a431c8d414748846ae5e7d4e6e625342121a15aff5ec0054387692eaad78b0"
-signature = "iQEzBAABCgAdFiEErcih/MFeAdRTEEGelGV6sg8qCSsFAmcRXMsACgkQlGV6sg8qCSuANQf+NqV7mXLbBLLbdU/wFUj966Pm8FHpEGA3fomBIci0c74IjVB4iY62Zi3HS7rFjmpGreuip7KhAvvKYYaEtwnS9fa2zY58ffg3hZKNQkdiiX1MdNlJ81atAwRlfgkdWfEANWheXigAzFzHtSUxE7rNQsL1v8DtPi1e/gZExQZHk6D+jzZTbPXxMOl0OgoLFbmxk6wprYLM+/GL7u9S66sNJ/mAQ+U8QJ5YH1Z8x4VP/9xUPzknot7JtiIwq2RujPqvGBDvW7GVAjIwt+xFp50wkXlQN7TNnCceo049vPD8JS46ontex7rzoBlqKqHf5mgbc7rIPeiPegcnMcMkYx5LQA=="
 
 [[package]]
 name = "libuv"
@@ -202,20 +194,12 @@ sha256 = "146b60543069d4eb92fd9086ffd6f442ee0a1f41f724445adc29af80693ce2da"
 signature = "iQJLBAABCAA1FiEEiee5MxxK59f699MFwTIpOVS75K0FAmaUdzsXHHNwdXB5a2luQGFyY2hsaW51eC5vcmcACgkQwTIpOVS75K2C+g//ddIjb7CKai01nuuzLd9hZQBP51iBe+lYdhv5lxlKaSzQZXHVUGXDAZdb7TaV9pbzdGPE+l5V2ZngivXdR5twUDWOQzvorXdxLgX7trBTghLDTBIKu6jPtrH2bNWrL8A908RumQVeWsOxUcompgAsRpQ4DhZkzk8325k9et0Nv1oQic96B5G1WefE85IYc2PDJeRhfyfnZmQ15aoVhohyhF0XSudlJSc/hqMZePW8tmyYz4ltvgOs4EF3smNwOaZVOew+w/5vOCYaSre5MFwHiilvYJaWhCji10m0MrBzLhRx0ZfRlBwTGbsToRbmczuwMXoYIiJsI2OiXsZD5/X9T5yPjl7pWP7uLaNTXCcbfrCZIWMVBXYQFxnWhUbKFZu8E7eXU2z75GukkC7GjR+VKw+SFH06Xdq73JltIXURRKe03uigC8ciME1xHOMv5kc1pQukQC/hTaR4GPF32pOX27CPQkNQ0dhRi1Cgyt47V+3GncI+mhlY3gJsCv31+Z0kM+WornVJYFSQnO0/frFPJaZUt0ONO7lHU2UMTe2tHm+zFHuHh6xOGaMjdRslrzq0Pby0xMb6nT0HsT1VXfSW30rywN1UPLd3TxAXGkG3SS8szftrLrmK6NAsK5tWfd5H2tiwSibYNnYYYVB720LKBl7bgpGFicdROohXJKqXsvA="
 
 [[package]]
-name = "openssl"
-version = "3.4.0-1"
-system = "archlinux"
-url = "https://archive.archlinux.org/packages/o/openssl/openssl-3.4.0-1-x86_64.pkg.tar.zst"
-sha256 = "a7c364b6e0969d13b773ad2a4e6266d7bee0a4de0824a246b4ad6bf11f723034"
-signature = "iHUEABYKAB0WIQQ+gMoai4n2nLpX2Yp2pe+QVESaXAUCZxilVgAKCRB2pe+QVESaXN/FAP4lFSH0UclXcrCSZR+K2OwAxeYC76Utav2TnLxIzYHvmwD9EDJYrcTp59lYSH2yBBXHsR7L0SuwQH9UPN9YidYNwgc="
-
-[[package]]
 name = "protobuf"
-version = "28.2-3"
+version = "28.3-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/p/protobuf/protobuf-28.2-3-x86_64.pkg.tar.zst"
-sha256 = "cfc875aea0e98f066ce6a77ddd2c2731254189fb6456933a2c71a2a73edd5d3a"
-signature = "iQIzBAABCAAdFiEElnTU7T37atzE+fHqHHNq75ZALnwFAmb+sTkACgkQHHNq75ZALny3lQ/9F7zScUzVh4KjLKHdSd57/p6K9sY2r2XGRb40ABB49Gq/J/PMVe2EKDsxRje8dB3P4iBHZq4+QrpLA+sWDIbaFMng11UVMRvSkLeneTqvo3wRBWHH4ItNc2b+A3Sdqq3BZSvYWrnetp+c0/i+mMo1Tjl3NeOb3F0Xt1q8Xsn7ILf6KaoZm7yn5nmI289rSAkkUJhQiCNtkjbS4VImciXKOiHuv1ohJrtrakXqLHDel4g4DN2n0oBjXJTy2Si3EgyA13GvDvqnVvXZQqFpxhAQOb8r+ieRYZWLypY1NyCebixFxi5PwaaVkReZB+8Xi4umOl/45gZHv/3OaL+viXjUKRRWYtPE/ITMle3l/lTfPuttN82AUe5LR2z/XLFVRnOvDzeNpTtgZohWdi6Dghiq7MGQbAccoZo1wnMT1gq9Wa7Syr7bG8k/B61UTj+gmuGH0XYgLA7g9WaRowDXTfkNwRWdVeFxRcRLdjNcMbtRGfFn9IiCrq6Ar/LN1HdgBfTlk2penN9S5juT9LRbXMP1NtFt+bPfsdSDzs4H2vzEI5FiivJa2lYPfQpkSGsiBHExpNYzBFE4j/2p2iOID/TEMnQ/poKHL6/dA1ElwPlr7pIqoCvhuVT7qTYqzi+zcCqB9VFKG45Akumgl7gpaF2AItmMWu9MKB046aTXSIC9Xs8="
+url = "https://archive.archlinux.org/packages/p/protobuf/protobuf-28.3-1-x86_64.pkg.tar.zst"
+sha256 = "d5cf53cf4ddcf3ba152424a9804381d3173f9919477c08a92cf16251bc0a602d"
+signature = "iQIzBAABCAAdFiEE8AuW0VIoAT/8nJ0Dk7EdqkwZfj0FAmcs0g8ACgkQk7EdqkwZfj3TaQ//UU7Vin4VJxnk93MXjtcMWdUAytLfSjxbsENNXD0dzrtF8qC/AhFYl0x+y3xjFX9mQAF/oZHVSGEcf3X8rjx/u9DwO4E21WpHQSM2E+JvUVIONYMtjCPf5IHzlaXfXbT06cQTCgJ1zaMYATpggFXqnbQE0oK+b46j8IMBWHuiUQxzbH0Cxz2NQHV/3ioMX4pqQE9srC2Tp9wyrxYZtW/+o7bH5+DuzkID37fxPNVKUlBKVc9S1sa3kfQSIICYibQX0X00tSMyHntD3YfJbmewgNmPQ9UxmN+ILQy/o9CnPsxLkAJfVpN6ggQ+8YM5ekhv6xenKdeB+xqgnVUaP3Eqvo1PXbhZa2E5i/FV5A2O/MhY22UjIx4O4Y3N6OdjilwBhHX5Khw+UDtHGQQz4U3WbMoODe0ysMhFkS3xm0Lq25tvSqdsBp9WDBWy6J1gw9nWyVERTr4A6mw4WYBz8a7MC2uyTAMmqq76zg1e7NFHzCf2BP4FQFtRopBAdfVyrDIGO1Gjuy6PGALmlbf7pEv6YjETM4huQJflkoh6fyQXq6JZ2sGa8Nc/55jP3KVGF45HHgQd+fIPawECYfUiuGoG+LZw1ygBQ/YLe/enrOmoHRw3/EQPP1ScR3lEl5R7DGeR2BKBDna6Kjd64GuJDl/mqG4h8vaz2to7XJ927R16Hxw="
 
 [[package]]
 name = "rhash"
@@ -227,24 +211,48 @@ signature = "iQTHBAABCgCxFiEE5VD//9SF4mShcX4wkBwcMg6w1F0FAmUt0ElfFIAAAAAALgAoaXN
 
 [[package]]
 name = "rust"
-version = "1:1.82.0-2"
+version = "1:1.83.0-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/r/rust/rust-1:1.82.0-2-x86_64.pkg.tar.zst"
-sha256 = "9737ce575d92aa777db79d5586eb93836a140ae793f78d093f59cb8e66df6e63"
-signature = "iHUEABYKAB0WIQSDvIiJNRtd67toQW64rAhgDxCM3wUCZxVKVgAKCRC4rAhgDxCM3xjTAP9nD4ATeTlb/472+fc+zRkGPg5hGOUGua8WLm7Mp1lMlgEA1ts6H7YIsRshlC+H0FFVuOMHH/HsncoXgDiMkCLuXQI="
+url = "https://archive.archlinux.org/packages/r/rust/rust-1:1.83.0-1-x86_64.pkg.tar.zst"
+sha256 = "124da2216ea4535a80cdc8f5d94a6d8742c17ee8a0360a2db225c49f31e33a4b"
+signature = "iHUEABYKAB0WIQSDvIiJNRtd67toQW64rAhgDxCM3wUCZ0iXvgAKCRC4rAhgDxCM3xYkAQDu48VQVpRO/EqLMKgIlZHHVo9XPKqrl6z+ZaSiHdWS6wD+Iou2voo7B7JBHmByfXlCnUDVRfK0qhDsKgMju5FBjg8="
 
 [[package]]
 name = "rust-musl"
-version = "1:1.82.0-2"
+version = "1:1.83.0-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/r/rust-musl/rust-musl-1:1.82.0-2-x86_64.pkg.tar.zst"
-sha256 = "a5f4499771881581885544a31f674dfb89e0af2b0386ac96db95d9f0d7c9e206"
-signature = "iHUEABYKAB0WIQSDvIiJNRtd67toQW64rAhgDxCM3wUCZxVKWQAKCRC4rAhgDxCM36MHAQCw7HHttt9lnOkCvVtRJa/Q2fenUbB4kA91AqmWYz4GwwEAjagxoHfsA/adRRZMX4wl95ZQ/29eicqCvhboktAEGwk="
+url = "https://archive.archlinux.org/packages/r/rust-musl/rust-musl-1:1.83.0-1-x86_64.pkg.tar.zst"
+sha256 = "51eceefd41c25912feff5ae16c3460a99d263b2a8a7be68a2a2bbcc73e629c4c"
+signature = "iHUEABYKAB0WIQSDvIiJNRtd67toQW64rAhgDxCM3wUCZ0iXwAAKCRC4rAhgDxCM36wRAQC8jFZaDhROX3uMAz3uB5C1w491SBANWlL4udDibvgNSwD/aQEHTueCG4DLQcEskmtKTevQtCEF7DORwDl3p5lw5Qs="
 
 [[package]]
-name = "tpm2-tss"
-version = "4.1.3-1"
+name = "sqlite"
+version = "3.47.2-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/t/tpm2-tss/tpm2-tss-4.1.3-1-x86_64.pkg.tar.zst"
-sha256 = "b1098a8ecc8886023c466827ea057861ea53ef4dc36a2142afee8b85fdf27c3c"
-signature = "iQJLBAABCgA1FiEEwQA0ZnZjToDJQPuenAL/QZ/svhYFAmbkrxIXHGZveGJvcm9uQGFyY2hsaW51eC5vcmcACgkQnAL/QZ/svhbYtg/9E8A0shPraoJw3XJ9bX2yZGjlAuw+iSDdah/WgxONtbj1ur31QfnQ+6LNftUZl50AVnN778NMD3bZyLqbCc6NVwjThB4vWTIeWWJXSokccvH3p+DigoSE6K4xeY86jlMTnFJSC32BaJpzx84s3Umx2iKcKka4BAG22FVZUHuuqTjg3h7pmP4gXoZRhOOM6o1sWldGQaqbv8RV22iilTSEM9cl+zg/brU5EoTQuZJ1ofV3WzlOOGZKDqJwX/3xAFiEcKidq8oYTACAy1iXfPFY2tviVPoi35K7qeEIswj70qi68ZlhLyOGoJyZ4ZuL1Wubim+cpfVjUYylAlCBMFC5Qa2JO+N2ZWSMYX1uKRXgf314MEmlP0VXavnA3e5/WZ0dzK3RPfJWBtPWOrPkGMUxqXgy/5gG9KGXHro0XIqXFDKfQKBEaRGx/e7SnMU0hjtN2F7qZpFPwj0cH9Gy5HLNFBDvVFFRDYjbIne+FwKeD5zsUaiKtMpmKDfqJiI0S9RnF2gJ2FUmLPr4J1odleDHy72gKC20WhGY/T8KSMLy75FBG68i2NrDCxgGZ4j6QagCVQE0jxSYXiHrD3cic8cdBGuPswKnesXnwcdtrafRhwFWuZ+l7tmppCNJfPrcW+LQkbwcBgVr8pVNuRoW852FLz4dZfVHaTWc064IYSuUebg="
+url = "https://archive.archlinux.org/packages/s/sqlite/sqlite-3.47.2-1-x86_64.pkg.tar.zst"
+sha256 = "3a68140a02506d0bfcf7de082dcd5d0d514f86a5d0272f047be4d80279621aa4"
+signature = "iQEzBAABCgAdFiEErcih/MFeAdRTEEGelGV6sg8qCSsFAmdV0ugACgkQlGV6sg8qCSsR6Qf/XrefEVBW9UaF1tGN0/e5Kotx+nfcdg4Yuz7G8E1ZE8co4b4hX2/2QVI4KPKG7AlbjAg2Kcs8ahgwrZNo8gDUnDT1jpBHXR+wEZguoEhjHD9GTY3k8XQzIZ0qHs1mINViUWAsxZJVS7ltKioPstsvkJRTr/AE3SO30luDFJtiLy2/vfTzDgC2ReA15d0cqJjhzulCBRTxFstMjTgpi9GjbalxizetVICaTsWrcMVacv2BAKRxen/y7NN3gaUqWdFM/1hnywQ4y4YrAXSeJq9Vvdx4OKk16FqtxJqhDcF6ey7DHxyFsq6CaWS4/EHcbCYlI8Txzt5DukzhzTkWcqNO8g=="
+
+[[package]]
+name = "systemd"
+version = "257-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/s/systemd/systemd-257-1-x86_64.pkg.tar.zst"
+sha256 = "c66a852360db7e49fca265b888c2d39a1310875ebfd97ce568fbe14b2b7a71b6"
+signature = "iHUEABYKAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCZ1iZqAAKCRBtQr3RFuAGj23pAQDsp5K+4TXRaTfVytu4ba4tW2f4H77UmJ8pb2yaDYgjPAEAz3TnokB2G3JO5zJIUbTL8km2M20pDx1PRisu9s/K6gE="
+
+[[package]]
+name = "systemd-libs"
+version = "257-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/s/systemd-libs/systemd-libs-257-1-x86_64.pkg.tar.zst"
+sha256 = "fca941af65ba6c79bcd8d9d718061156ca17afb7ea6df6dd117e0ef6acb68ecd"
+signature = "iHUEABYKAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCZ1iZqAAKCRBtQr3RFuAGj7lmAP9heelPlHRR7fmLHLpwG8gR0NuFQDVv9N0kBSGXr0OkBgEAspscdoR3gE5gJeAy/E8AgiYltD78V02chfTjGSjsbgA="
+
+[[package]]
+name = "systemd-sysvcompat"
+version = "257-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/s/systemd-sysvcompat/systemd-sysvcompat-257-1-x86_64.pkg.tar.zst"
+sha256 = "e623b3c20b95dd9c6983437666b272f6228a0c4c854d3ca323056d8f2ad75516"
+signature = "iHUEABYKAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCZ1iZqAAKCRBtQr3RFuAGj/4UAP9DpXPiB6nFg32Kr6qaVdZwj70hyyXWgbU0wZWafDlXoAD/X8wbeaBmoekMXb+eCSREUhx4XnAIWpxI1QGxf3LjjgE="

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.82.0"
+channel = "1.83.0"
 targets = ["x86_64-unknown-linux-musl"]
 profile = "default"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -198,7 +198,9 @@ pub struct Domain {
     #[clap(env, long, value_delimiter = ',')]
     pub domain_api: Vec<FQDN>,
 
-    /// List of domains that we serve system subnets from. This enables domain-canister matching for these domains & adds them to the list of served domains above, do not list them there separately.
+    /// List of domains that we serve system subnets from.
+    /// This enables domain-canister matching for these domains & adds them to the
+    /// list of served domains above, do not list them there separately.
     /// Requires --domain-app.
     #[clap(env, long, requires = "domain_app", value_delimiter = ',')]
     pub domain_system: Vec<FQDN>,
@@ -211,6 +213,15 @@ pub struct Domain {
     /// List of canister aliases in format '<alias>:<canister_id>'
     #[clap(env, long, value_delimiter = ',')]
     pub domain_canister_alias: Vec<CanisterAlias>,
+
+    /// List of generic custom domain provider URLs.
+    /// Expects a JSON object in form '{"domain.bar": "aaaaa-aa"}'
+    #[clap(env, long, value_delimiter = ',')]
+    pub domain_custom_provider: Vec<Url>,
+
+    /// How frequently to poll custom domain providers for updates
+    #[clap(env, long, default_value = "30s", value_parser = parse_duration)]
+    pub domain_custom_provider_poll_interval: Duration,
 }
 
 #[derive(Args)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -222,6 +222,10 @@ pub struct Domain {
     /// How frequently to poll custom domain providers for updates
     #[clap(env, long, default_value = "30s", value_parser = parse_duration)]
     pub domain_custom_provider_poll_interval: Duration,
+
+    /// Timeout for the outgoing HTTP calls made to fetch custom domains
+    #[clap(env, long, default_value = "30s", value_parser = parse_duration)]
+    pub domain_custom_provider_timeout: Duration,
 }
 
 #[derive(Args)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -215,7 +215,7 @@ pub struct Domain {
     pub domain_canister_alias: Vec<CanisterAlias>,
 
     /// List of generic custom domain provider URLs.
-    /// Expects a JSON object in form '{"domain.bar": "aaaaa-aa"}'
+    /// Expects a JSON object in form '{"domain.bar": "aaaaa-aa"}' in response to a GET request.
     #[clap(env, long, value_delimiter = ',')]
     pub domain_custom_provider: Vec<Url>,
 

--- a/src/core.rs
+++ b/src/core.rs
@@ -121,6 +121,7 @@ pub async fn main(cli: &Cli) -> Result<(), Error> {
         Arc::new(routing::custom_domains::GenericProvider::new(
             http_client.clone(),
             x.clone(),
+            cli.domain.domain_custom_provider_timeout,
         )) as Arc<dyn ProvidesCustomDomains>
     }));
 

--- a/src/routing/custom_domains.rs
+++ b/src/routing/custom_domains.rs
@@ -1,0 +1,126 @@
+use std::str::FromStr as _;
+use std::{sync::Arc, time::Duration};
+
+use ahash::HashMap;
+use anyhow::Error;
+use anyhow::{anyhow, Context as AnyhowContext};
+use async_trait::async_trait;
+use candid::Principal;
+use derive_new::new;
+use fqdn::FQDN;
+use ic_bn_lib::http;
+use reqwest::{Method, Request, StatusCode, Url};
+
+use crate::routing::domain::{CustomDomain, ProvidesCustomDomains};
+
+#[derive(new)]
+pub struct GenericProvider {
+    http_client: Arc<dyn http::Client>,
+    url: Url,
+}
+
+#[async_trait]
+impl ProvidesCustomDomains for GenericProvider {
+    async fn get_custom_domains(&self) -> Result<Vec<CustomDomain>, Error> {
+        let mut req = Request::new(Method::GET, self.url.clone());
+        *req.timeout_mut() = Some(Duration::from_secs(30));
+
+        let response = self
+            .http_client
+            .execute(req)
+            .await
+            .context("failed to make http request")?;
+
+        if response.status() != StatusCode::OK {
+            return Err(anyhow!("incorrect response code: {}", response.status()));
+        }
+
+        let bs = response
+            .bytes()
+            .await
+            .context("failed to fetch response body")?
+            .to_vec();
+
+        // TODO use fqdn's crate serde when it's fixed
+        let domains: HashMap<String, Principal> =
+            serde_json::from_slice(&bs).context("failed to parse json body")?;
+
+        Ok(domains
+            .into_iter()
+            .map(|(k, v)| -> Result<CustomDomain, Error> {
+                Ok(CustomDomain {
+                    name: FQDN::from_str(&k)?,
+                    canister_id: v,
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()?)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use ::http::Response as HttpResponse;
+    use async_trait::async_trait;
+    use fqdn::fqdn;
+    use itertools::Itertools;
+    use serde_json::json;
+
+    use super::*;
+    use crate::principal;
+
+    #[derive(Debug)]
+    struct MockClient;
+
+    #[async_trait]
+    impl http::Client for MockClient {
+        async fn execute(&self, _: reqwest::Request) -> Result<reqwest::Response, reqwest::Error> {
+            Ok(HttpResponse::new(
+                json!({"foo.bar": "aaaaa-aa", "bar.foo": "qoctq-giaaa-aaaaa-aaaea-cai"})
+                    .to_string(),
+            )
+            .into())
+        }
+    }
+
+    #[derive(Debug)]
+    struct MockClientBad;
+
+    #[async_trait]
+    impl http::Client for MockClientBad {
+        async fn execute(&self, _: reqwest::Request) -> Result<reqwest::Response, reqwest::Error> {
+            Ok(HttpResponse::new(json!({"foo.bar!!!!": "aaaaa-aa"}).to_string()).into())
+        }
+    }
+
+    #[tokio::test]
+    async fn test_provider() {
+        let cli = Arc::new(MockClient);
+        let prov = GenericProvider::new(cli, "http://foo".try_into().unwrap());
+
+        let domains: Vec<CustomDomain> = prov
+            .get_custom_domains()
+            .await
+            .unwrap()
+            .into_iter()
+            .sorted_by_key(|x| x.name.clone())
+            .collect();
+
+        assert_eq!(
+            domains,
+            vec![
+                CustomDomain {
+                    name: fqdn!("bar.foo"),
+                    canister_id: principal!("qoctq-giaaa-aaaaa-aaaea-cai")
+                },
+                CustomDomain {
+                    name: fqdn!("foo.bar"),
+                    canister_id: principal!("aaaaa-aa")
+                },
+            ]
+        );
+
+        let cli = Arc::new(MockClientBad);
+        let prov = GenericProvider::new(cli, "http://foo".try_into().unwrap());
+        assert!(prov.get_custom_domains().await.is_err());
+    }
+}

--- a/src/routing/mod.rs
+++ b/src/routing/mod.rs
@@ -1,3 +1,4 @@
+pub mod custom_domains;
 pub mod domain;
 pub mod error_cause;
 pub mod ic;
@@ -172,7 +173,7 @@ pub async fn setup_router(
     tasks.add_interval(
         "custom_domain_storage",
         custom_domain_storage.clone(),
-        cli.cert.cert_provider_poll_interval,
+        cli.domain.domain_custom_provider_poll_interval,
     );
 
     // Prepare domain resolver to resolve domains & infer canister_id from requests


### PR DESCRIPTION
Currently it supports a simple map-like schema e.g.
```
{"foo.bar": "aaaaa-aa"}
```

Later we can add and/or change that.