### PR TITLE
chore: add arg `k_top_api_nodes` for dynamic routing to best `k` nodes

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -125,6 +125,11 @@ pub struct Ic {
     #[clap(env, long)]
     pub ic_use_discovery: bool,
 
+    /// In dynamic routing mode, limits routing to the top K API nodes with best score (ranked by latency and availability).
+    /// If not set, routing uses all healthy API nodes.
+    #[clap(env, long)]
+    pub ic_use_k_top_api_nodes: Option<usize>,
+
     /// Path to an IC root key. Must be DER-encoded. If not specified - hardcoded or fetched (see ic_root_key_fetch_unsafe) will be used.
     #[clap(env, long)]
     pub ic_root_key: Option<PathBuf>,

--- a/src/core.rs
+++ b/src/core.rs
@@ -126,7 +126,7 @@ pub async fn main(cli: &Cli) -> Result<(), Error> {
     }));
 
     let route_provider =
-        setup_route_provider(&cli.ic.ic_url, cli.ic.ic_use_discovery, reqwest_client).await?;
+        setup_route_provider(&cli.ic.ic_url, cli.ic.ic_use_discovery, cli.ic.ic_use_k_top_api_nodes,  reqwest_client).await?;
 
     // Create gateway router to serve all endpoints
     let gateway_router = routing::setup_router(

--- a/src/core.rs
+++ b/src/core.rs
@@ -125,8 +125,7 @@ pub async fn main(cli: &Cli) -> Result<(), Error> {
         )) as Arc<dyn ProvidesCustomDomains>
     }));
 
-    let route_provider =
-        setup_route_provider(&cli.ic.ic_url, cli.ic.ic_use_discovery, cli.ic.ic_use_k_top_api_nodes,  reqwest_client).await?;
+    let route_provider = setup_route_provider(cli, reqwest_client).await?;
 
     // Create gateway router to serve all endpoints
     let gateway_router = routing::setup_router(

--- a/src/routing/ic/route_provider.rs
+++ b/src/routing/ic/route_provider.rs
@@ -17,17 +17,16 @@ use crate::routing::ic::{
     health_check::{HealthChecker, CHECK_TIMEOUT},
     nodes_fetcher::{NodesFetcher, MAINNET_ROOT_SUBNET_ID},
 };
+use crate::Cli;
 
 pub async fn setup_route_provider(
-    urls: &[Url],
-    ic_use_discovery: bool,
-    ic_use_k_top_api_nodes: Option<usize>,
+    cli: &Cli,
     reqwest_client: reqwest::Client,
 ) -> anyhow::Result<Arc<dyn RouteProvider>> {
-    let urls_str = urls.iter().map(Url::as_str).collect::<Vec<_>>();
+    let urls_str = cli.ic.ic_url.iter().map(Url::as_str).collect::<Vec<_>>();
 
-    let route_provider = if ic_use_discovery {
-        let api_seed_nodes = urls
+    let route_provider = if cli.ic.ic_use_discovery {
+        let api_seed_nodes = cli.ic.ic_url
             .iter()
             .filter_map(|url| url.domain())
             .map(|url| Node::new(url).unwrap())
@@ -40,7 +39,7 @@ pub async fn setup_route_provider(
         }
 
         let route_provider = {
-            let snapshot = ic_use_k_top_api_nodes.map_or_else(LatencyRoutingSnapshot::new, |k| {
+            let snapshot = cli.ic.ic_use_k_top_api_nodes.map_or_else(LatencyRoutingSnapshot::new, |k| {
                 info!("Using up to k_top={k} API Nodes with best score for dynamic routing");
                 LatencyRoutingSnapshot::new().set_k_top_nodes(k)
             });


### PR DESCRIPTION
For example setting  `ic_use_k_top_api_nodes=4` would cause routing to only 4 API nodes using weighted random sampling. NOTE: this is different from the [n_ordered_routes()](https://github.com/dfinity/agent-rs/blob/96910e70c44946d4ba8a78f050fc33610e1dda60/ic-agent/src/agent/route_provider.rs#L72).

In `/metrics` this would manifest in:
```
# HELP ic_gateway_api_boundary_nodes Number of API boundary nodes with status.
# TYPE ic_gateway_api_boundary_nodes gauge
ic_gateway_api_boundary_nodes{status="healthy"} 4
ic_gateway_api_boundary_nodes{status="total"} 20
```
We might need another status `in_routing` as healthy is a bit misleading here.