### PR TITLE
feat(BOUN-1358): overridable CORS, update deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -829,9 +829,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.16"
+version = "1.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c"
+checksum = "1fcb57c740ae1daf453ae85f16e37396f672b039e00d9d866e07ddb24e328e3a"
 dependencies = [
  "jobserver",
  "libc",
@@ -1309,9 +1309,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
+checksum = "28cfac68e08048ae1883171632c2aef3ebc555621ae56fbccce1cbf22dd7f058"
 dependencies = [
  "powerfmt",
  "serde",
@@ -2137,14 +2137,15 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.61"
+version = "0.1.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
+checksum = "b2fd658b06e56721792c5df4475705b6cda790e9298d19d2f8af083457bcd127"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
  "iana-time-zone-haiku",
  "js-sys",
+ "log",
  "wasm-bindgen",
  "windows-core 0.52.0",
 ]
@@ -2975,9 +2976,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.26"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "loom"
@@ -3520,7 +3521,7 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -3755,7 +3756,7 @@ checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
- "zerocopy 0.8.23",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -4677,9 +4678,9 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "stacker"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9156ebd5870ef293bfb43f91c7a74528d363ec0d424afe24160ed5a4343d08a"
+checksum = "601f9201feb9b09c00266478bf459952b9ef9a6b94edb2f21eba14ab681a60a9"
 dependencies = [
  "cc",
  "cfg-if",
@@ -4868,9 +4869,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.19.0"
+version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488960f40a3fd53d72c2a29a58722561dee8afdd175bd88e3db4677d7b2ba600"
+checksum = "7437ac7763b9b123ccf33c338a5cc1bac6f69b45a136c19bdd8a65e3916435bf"
 dependencies = [
  "fastrand",
  "getrandom 0.3.2",
@@ -4978,9 +4979,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.40"
+version = "0.3.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d9c75b47bdff86fa3334a3db91356b8d7d86a9b839dab7d0bdc5c3d3a077618"
+checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
 dependencies = [
  "deranged",
  "itoa",
@@ -4999,9 +5000,9 @@ checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
 
 [[package]]
 name = "time-macros"
-version = "0.2.21"
+version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29aa485584182073ed57fd5004aa09c371f021325014694e432313345865fd04"
+checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
 dependencies = [
  "num-conv",
  "time-core",
@@ -6172,11 +6173,11 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.23"
+version = "0.8.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd97444d05a4328b90e75e503a34bad781f14e28a823ad3557f0750df1ebcbc6"
+checksum = "2586fea28e186957ef732a5f8b3be2da217d65c5969d4b1e17f973ebbe876879"
 dependencies = [
- "zerocopy-derive 0.8.23",
+ "zerocopy-derive 0.8.24",
 ]
 
 [[package]]
@@ -6192,9 +6193,9 @@ dependencies = [
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.23"
+version = "0.8.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6352c01d0edd5db859a63e2605f4ea3183ddbd15e2c4a9e7d32184df75e4f154"
+checksum = "a996a8f63c5c4448cd959ac1bab0aaa3306ccfd060472f85943ee0750f0169be"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6275,18 +6276,18 @@ dependencies = [
 
 [[package]]
 name = "zstd-safe"
-version = "7.2.3"
+version = "7.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3051792fbdc2e1e143244dc28c60f73d8470e93f3f9cbd0ead44da5ed802722"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
 dependencies = [
  "zstd-sys",
 ]
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.14+zstd.1.5.7"
+version = "2.0.15+zstd.1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fb060d4926e4ac3a3ad15d864e99ceb5f343c6b34f5bd6d81ae6ed417311be5"
+checksum = "eb81183ddd97d0c74cedf1d50d85c8d08c1b8b68ee863bdee9e706eedba1a237"
 dependencies = [
  "cc",
  "pkg-config",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2352,6 +2352,7 @@ dependencies = [
  "lazy_static",
  "maxminddb",
  "mockall",
+ "moka",
  "ocsp-stapler",
  "prometheus",
  "rand 0.8.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ ic-transport-types = "0.40.0"
 itertools = "0.14.0"
 lazy_static = "1.5.0"
 maxminddb = "0.25.0"
+moka = { version = "0.12.8", features = ["sync", "future"] }
 ocsp-stapler = "0.4.1"
 prometheus = "0.13.4"
 rand = "0.8.5"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -4,6 +4,7 @@ use std::{
     time::Duration,
 };
 
+use ::http::HeaderValue;
 use clap::{Args, Parser};
 use fqdn::FQDN;
 use hickory_resolver::config::CLOUDFLARE_IPS;
@@ -521,7 +522,16 @@ pub struct CacheConfig {
 
 #[derive(Args)]
 pub struct Cors {
-    /// Whether to forward CORS requests to the canisters
+    /// Default value for Access-Control-Allow-Origin header
+    #[clap(env, long, default_value = "*")]
+    pub cors_allow_origin: Vec<HeaderValue>,
+
+    /// Default value for Access-Control-Max-Age header. Usually capped to 2h by the browser.
+    #[clap(env, long, default_value = "2h", value_parser = parse_duration)]
+    pub cors_max_age: Duration,
+
+    /// Whether to forward CORS requests to the canisters.
+    /// If the CORS reply from the canister is incorrect then it will be replaced with a default one.
     #[clap(env, long)]
     pub cors_canister_passthrough: bool,
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -20,7 +20,7 @@ use reqwest::Url;
 
 use crate::{
     core::{AUTHOR_NAME, SERVICE_NAME},
-    routing::{domain::CanisterAlias, RequestType},
+    routing::{RequestType, domain::CanisterAlias},
 };
 
 /// Clap does not support prefixes due to macro limitations.
@@ -69,6 +69,9 @@ pub struct Cli {
 
     #[command(flatten, next_help_heading = "Misc")]
     pub misc: Misc,
+
+    #[command(flatten, next_help_heading = "CORS")]
+    pub cors: Cors,
 
     #[command(flatten, next_help_heading = "Cache")]
     pub cache: CacheConfig,
@@ -514,6 +517,21 @@ pub struct CacheConfig {
     /// Value of 0.0 would effectively disable the x-fetch algorithm.
     #[clap(env, long, default_value = "3.0")]
     pub cache_xfetch_beta: f64,
+}
+
+#[derive(Args)]
+pub struct Cors {
+    /// Whether to forward CORS requests to the canisters
+    #[clap(env, long)]
+    pub cors_canister_passthrough: bool,
+
+    /// Maximum number of canisters to cache that replied incorrectly to the OPTIONS request
+    #[clap(env, long, default_value = "1000000")]
+    pub cors_invalid_canisters_max: u64,
+
+    /// Timeout for expiring invalid canisters from the cache
+    #[clap(env, long, default_value = "1d", value_parser = parse_duration)]
+    pub cors_invalid_canisters_ttl: Duration,
 }
 
 // Some conversions

--- a/src/routing/middleware/cors.rs
+++ b/src/routing/middleware/cors.rs
@@ -520,17 +520,17 @@ mod test {
             ACCESS_CONTROL_ALLOW_HEADERS,
             HeaderValue::from_static("foo"),
         );
-    assert!(
-        is_valid_preflight_response(&r),
-        "Expected valid preflight response, but it was invalid"
-    );
+        assert!(
+            is_valid_preflight_response(&r),
+            "Expected valid preflight response, but it was invalid"
+        );
 
         // Check no headers
         let r = Response::new(Body::empty());
-    assert!(
-        !is_valid_preflight_response(&r),
-        "Expected invalid preflight response due to missing headers, but it was valid"
-    );
+        assert!(
+            !is_valid_preflight_response(&r),
+            "Expected invalid preflight response due to missing headers, but it was valid"
+        );
 
         // Check non-empty body
         let mut r = Response::new(Body::new(http_body_util::Full::new(Bytes::from_static(
@@ -540,17 +540,17 @@ mod test {
             ACCESS_CONTROL_ALLOW_HEADERS,
             HeaderValue::from_static("foo"),
         );
-    assert!(
-        !is_valid_preflight_response(&r),
-        "Expected invalid preflight response due to non-empty body, but it was valid"
-    );
+        assert!(
+            !is_valid_preflight_response(&r),
+            "Expected invalid preflight response due to non-empty body, but it was valid"
+        );
 
         // Check bad status
         let mut r = Response::new(Body::empty());
         *r.status_mut() = StatusCode::METHOD_NOT_ALLOWED;
-    assert!(
-        !is_valid_preflight_response(&r),
-        "Expected invalid preflight response due to "non-success" status code, but it was valid"
-    );
+        assert!(
+            !is_valid_preflight_response(&r),
+            "Expected invalid preflight response due to non-success status code, but it was valid"
+        );
     }
 }

--- a/src/routing/middleware/cors.rs
+++ b/src/routing/middleware/cors.rs
@@ -20,8 +20,6 @@ use ic_bn_lib::http::headers::{X_IC_CANISTER_ID, X_REQUEST_ID, X_REQUESTED_WITH}
 use itertools::Itertools;
 use tower_http::cors::{Any, CorsLayer};
 
-const MINUTE: Duration = Duration::from_secs(60);
-
 const X_OC_JWT: HeaderName = HeaderName::from_static("x-oc-jwt");
 const X_OC_API_KEY: HeaderName = HeaderName::from_static("x-oc-api-key");
 
@@ -132,7 +130,7 @@ pub fn layer(methods: &[Method]) -> CorsLayer {
         .allow_methods(methods.to_vec())
         .expose_headers(EXPOSE_HEADERS)
         .allow_headers(ALLOW_HEADERS)
-        .max_age(10 * MINUTE)
+        .max_age(Duration::from_secs(7200))
 }
 
 #[cfg(test)]

--- a/src/routing/middleware/cors.rs
+++ b/src/routing/middleware/cors.rs
@@ -524,7 +524,10 @@ mod test {
 
         // Check no headers
         let r = Response::new(Body::empty());
-        assert!(!is_valid_preflight_response(&r));
+    assert!(
+        !is_valid_preflight_response(&r),
+        "Expected invalid preflight response due to missing headers, but it was valid"
+    );
 
         // Check non-empty body
         let mut r = Response::new(Body::new(http_body_util::Full::new(Bytes::from_static(

--- a/src/routing/middleware/cors.rs
+++ b/src/routing/middleware/cors.rs
@@ -542,6 +542,9 @@ mod test {
         // Check bad status
         let mut r = Response::new(Body::empty());
         *r.status_mut() = StatusCode::METHOD_NOT_ALLOWED;
-        assert!(!is_valid_preflight_response(&r));
+    assert!(
+        !is_valid_preflight_response(&r),
+        "Expected invalid preflight response due to "non-success" status code, but it was valid"
+    );
     }
 }

--- a/src/routing/middleware/cors.rs
+++ b/src/routing/middleware/cors.rs
@@ -291,7 +291,7 @@ mod test {
 
         let canister_id = CanisterId(principal!("aaaaa-aa"));
 
-        // Check that the existing response headers are not overriden
+        // Check that the existing response headers are not overridden
         let router = Router::new()
             .fallback(|req: Request| async move {
                 let mut resp = Response::new(Body::empty());

--- a/src/routing/middleware/cors.rs
+++ b/src/routing/middleware/cors.rs
@@ -537,7 +537,10 @@ mod test {
             ACCESS_CONTROL_ALLOW_HEADERS,
             HeaderValue::from_static("foo"),
         );
-        assert!(!is_valid_preflight_response(&r));
+    assert!(
+        !is_valid_preflight_response(&r),
+        "Expected invalid preflight response due to non-empty body, but it was valid"
+    );
 
         // Check bad status
         let mut r = Response::new(Body::empty());

--- a/src/routing/middleware/cors.rs
+++ b/src/routing/middleware/cors.rs
@@ -1,15 +1,23 @@
 #![allow(clippy::declare_interior_mutable_const)]
 
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
 
-use http::{
-    header::{
-        HeaderName, ACCEPT_RANGES, CACHE_CONTROL, CONTENT_LENGTH, CONTENT_RANGE, CONTENT_TYPE,
-        COOKIE, DNT, IF_MODIFIED_SINCE, IF_NONE_MATCH, RANGE, USER_AGENT,
-    },
-    Method,
+use axum::{
+    extract::{Request, State},
+    middleware::Next,
+    response::{IntoResponse, Response},
 };
-use ic_bn_lib::http::headers::{X_IC_CANISTER_ID, X_REQUESTED_WITH, X_REQUEST_ID};
+use http::{
+    Method,
+    header::{
+        ACCEPT_RANGES, ACCESS_CONTROL_ALLOW_HEADERS, ACCESS_CONTROL_ALLOW_METHODS,
+        ACCESS_CONTROL_ALLOW_ORIGIN, ACCESS_CONTROL_EXPOSE_HEADERS, ACCESS_CONTROL_MAX_AGE,
+        CACHE_CONTROL, CONTENT_LENGTH, CONTENT_RANGE, CONTENT_TYPE, COOKIE, DNT, HeaderName,
+        HeaderValue, IF_MODIFIED_SINCE, IF_NONE_MATCH, RANGE, USER_AGENT,
+    },
+};
+use ic_bn_lib::http::headers::{X_IC_CANISTER_ID, X_REQUEST_ID, X_REQUESTED_WITH};
+use itertools::Itertools;
 use tower_http::cors::{Any, CorsLayer};
 
 const MINUTE: Duration = Duration::from_secs(60);
@@ -17,64 +25,241 @@ const MINUTE: Duration = Duration::from_secs(60);
 const X_OC_JWT: HeaderName = HeaderName::from_static("x-oc-jwt");
 const X_OC_API_KEY: HeaderName = HeaderName::from_static("x-oc-api-key");
 
-/*
-add_header "Access-Control-Allow-Origin" "*" always;
-add_header "Access-Control-Allow-Methods" "$cors_allow_methods" always;
-add_header "Access-Control-Allow-Headers" "DNT,User-Agent,X-Requested-With,If-None-Match,If-Modified-Since,Cache-Control,Content-Type,Range,Cookie,X-Ic-Canister-Id" always;
-add_header "Access-Control-Expose-Headers" "Accept-Ranges,Content-Length,Content-Range,X-Request-Id,X-Ic-Canister-Id" always;
-add_header "Access-Control-Max-Age" "600" always;
-*/
+// Methods allowed for HTTP calls
+const ALLOW_METHODS_HTTP: [Method; 6] = [
+    Method::HEAD,
+    Method::GET,
+    Method::POST,
+    Method::PUT,
+    Method::DELETE,
+    Method::PATCH,
+];
+
+// Base headers
+const EXPOSE_HEADERS: [HeaderName; 5] = [
+    ACCEPT_RANGES,
+    CONTENT_LENGTH,
+    CONTENT_RANGE,
+    X_REQUEST_ID,
+    X_IC_CANISTER_ID,
+];
+
+const ALLOW_HEADERS: [HeaderName; 10] = [
+    USER_AGENT,
+    DNT,
+    IF_NONE_MATCH,
+    IF_MODIFIED_SINCE,
+    CACHE_CONTROL,
+    CONTENT_TYPE,
+    RANGE,
+    COOKIE,
+    X_REQUESTED_WITH,
+    X_IC_CANISTER_ID,
+];
+
+// Additional headers to allow for HTTP calls
+const ALLOW_HEADERS_HTTP: [HeaderName; 2] = [X_OC_JWT, X_OC_API_KEY];
+
+const HEADER_WILDCARD: HeaderValue = HeaderValue::from_static("*");
+const HEADER_MAX_AGE: HeaderValue = HeaderValue::from_static("7200");
+
+pub struct CorsStateHttp {
+    allow_methods: HeaderValue,
+    allow_headers: HeaderValue,
+    expose_headers: HeaderValue,
+}
+
+impl CorsStateHttp {
+    pub fn new() -> Self {
+        let allow_methods = HeaderValue::from_str(&ALLOW_METHODS_HTTP.iter().join(", ")).unwrap();
+
+        let allow_headers = HeaderValue::from_str(
+            &ALLOW_HEADERS
+                .into_iter()
+                .chain(ALLOW_HEADERS_HTTP)
+                .join(", "),
+        )
+        .unwrap();
+
+        let expose_headers = HeaderValue::from_str(&EXPOSE_HEADERS.into_iter().join(", ")).unwrap();
+
+        Self {
+            allow_headers,
+            allow_methods,
+            expose_headers,
+        }
+    }
+
+    pub fn apply_cors(&self, response: &mut Response) {
+        let hdr = response.headers_mut();
+
+        // Insert our CORS headers if they're missing in the response
+        if !hdr.contains_key(ACCESS_CONTROL_ALLOW_METHODS) {
+            hdr.insert(ACCESS_CONTROL_ALLOW_METHODS, self.allow_methods.clone());
+        }
+
+        if !hdr.contains_key(ACCESS_CONTROL_ALLOW_HEADERS) {
+            hdr.insert(ACCESS_CONTROL_ALLOW_HEADERS, self.allow_headers.clone());
+        }
+
+        if !hdr.contains_key(ACCESS_CONTROL_EXPOSE_HEADERS) {
+            hdr.insert(ACCESS_CONTROL_EXPOSE_HEADERS, self.expose_headers.clone());
+        }
+
+        if !hdr.contains_key(ACCESS_CONTROL_ALLOW_ORIGIN) {
+            hdr.insert(ACCESS_CONTROL_ALLOW_ORIGIN, HEADER_WILDCARD);
+        }
+
+        if !hdr.contains_key(ACCESS_CONTROL_MAX_AGE) {
+            hdr.insert(ACCESS_CONTROL_MAX_AGE, HEADER_MAX_AGE);
+        }
+    }
+}
+
+pub async fn middleware(
+    State(state): State<Arc<CorsStateHttp>>,
+    request: Request,
+    next: Next,
+) -> impl IntoResponse {
+    let mut response = next.run(request).await;
+    state.apply_cors(&mut response);
+    response
+}
 
 pub fn layer(methods: &[Method]) -> CorsLayer {
     CorsLayer::new()
         .allow_origin(Any)
         .allow_methods(methods.to_vec())
-        .expose_headers([
-            ACCEPT_RANGES,
-            CONTENT_LENGTH,
-            CONTENT_RANGE,
-            X_REQUEST_ID,
-            X_IC_CANISTER_ID,
-        ])
-        .allow_headers([
-            USER_AGENT,
-            DNT,
-            IF_NONE_MATCH,
-            IF_MODIFIED_SINCE,
-            CACHE_CONTROL,
-            CONTENT_TYPE,
-            RANGE,
-            COOKIE,
-            X_REQUESTED_WITH,
-            X_IC_CANISTER_ID,
-        ])
+        .expose_headers(EXPOSE_HEADERS)
+        .allow_headers(ALLOW_HEADERS)
         .max_age(10 * MINUTE)
 }
 
-pub fn http_gw_layer(methods: &[Method]) -> CorsLayer {
-    CorsLayer::new()
-        .allow_origin(Any)
-        .allow_methods(methods.to_vec())
-        .expose_headers([
-            ACCEPT_RANGES,
-            CONTENT_LENGTH,
-            CONTENT_RANGE,
-            X_REQUEST_ID,
-            X_IC_CANISTER_ID,
-        ])
-        .allow_headers([
-            USER_AGENT,
-            DNT,
-            IF_NONE_MATCH,
-            IF_MODIFIED_SINCE,
-            CACHE_CONTROL,
-            CONTENT_TYPE,
-            RANGE,
-            COOKIE,
-            X_REQUESTED_WITH,
-            X_IC_CANISTER_ID,
-            X_OC_JWT,
-            X_OC_API_KEY,
-        ])
-        .max_age(10 * MINUTE)
+#[cfg(test)]
+mod test {
+    use super::*;
+    use axum::body::Body;
+
+    #[test]
+    fn test_cors_http() {
+        let s = CorsStateHttp::new();
+        assert_eq!(s.allow_methods, "HEAD, GET, POST, PUT, DELETE, PATCH");
+        assert_eq!(
+            s.allow_headers,
+            "user-agent, dnt, if-none-match, if-modified-since, cache-control, content-type, range, cookie, x-requested-with, x-ic-canister-id, x-oc-jwt, x-oc-api-key"
+        );
+        assert_eq!(
+            s.expose_headers,
+            "accept-ranges, content-length, content-range, x-request-id, x-ic-canister-id"
+        );
+
+        // Check that the existing response headers are not overriden
+        let mut resp = Response::new(Body::empty());
+        resp.headers_mut().insert(
+            ACCESS_CONTROL_ALLOW_HEADERS,
+            HeaderValue::from_static("foo"),
+        );
+        resp.headers_mut().insert(
+            ACCESS_CONTROL_EXPOSE_HEADERS,
+            HeaderValue::from_static("bar"),
+        );
+        resp.headers_mut().insert(
+            ACCESS_CONTROL_ALLOW_METHODS,
+            HeaderValue::from_static("baz"),
+        );
+        resp.headers_mut()
+            .insert(ACCESS_CONTROL_MAX_AGE, HeaderValue::from_static("1234"));
+        resp.headers_mut().insert(
+            ACCESS_CONTROL_ALLOW_ORIGIN,
+            HeaderValue::from_static("foobar.com"),
+        );
+
+        s.apply_cors(&mut resp);
+
+        assert_eq!(
+            resp.headers()
+                .get(ACCESS_CONTROL_ALLOW_HEADERS)
+                .unwrap()
+                .to_str()
+                .unwrap(),
+            "foo"
+        );
+        assert_eq!(
+            resp.headers()
+                .get(ACCESS_CONTROL_EXPOSE_HEADERS)
+                .unwrap()
+                .to_str()
+                .unwrap(),
+            "bar"
+        );
+        assert_eq!(
+            resp.headers()
+                .get(ACCESS_CONTROL_ALLOW_METHODS)
+                .unwrap()
+                .to_str()
+                .unwrap(),
+            "baz"
+        );
+        assert_eq!(
+            resp.headers()
+                .get(ACCESS_CONTROL_MAX_AGE)
+                .unwrap()
+                .to_str()
+                .unwrap(),
+            "1234"
+        );
+        assert_eq!(
+            resp.headers()
+                .get(ACCESS_CONTROL_ALLOW_ORIGIN)
+                .unwrap()
+                .to_str()
+                .unwrap(),
+            "foobar.com"
+        );
+
+        // Check that default headers are added
+        let mut resp = Response::new(Body::empty());
+        s.apply_cors(&mut resp);
+
+        assert_eq!(
+            resp.headers()
+                .get(ACCESS_CONTROL_ALLOW_HEADERS)
+                .unwrap()
+                .to_str()
+                .unwrap(),
+            s.allow_headers.to_str().unwrap()
+        );
+        assert_eq!(
+            resp.headers()
+                .get(ACCESS_CONTROL_EXPOSE_HEADERS)
+                .unwrap()
+                .to_str()
+                .unwrap(),
+            s.expose_headers.to_str().unwrap()
+        );
+        assert_eq!(
+            resp.headers()
+                .get(ACCESS_CONTROL_ALLOW_METHODS)
+                .unwrap()
+                .to_str()
+                .unwrap(),
+            s.allow_methods.to_str().unwrap(),
+        );
+        assert_eq!(
+            resp.headers()
+                .get(ACCESS_CONTROL_MAX_AGE)
+                .unwrap()
+                .to_str()
+                .unwrap(),
+            HEADER_MAX_AGE.to_str().unwrap()
+        );
+        assert_eq!(
+            resp.headers()
+                .get(ACCESS_CONTROL_ALLOW_ORIGIN)
+                .unwrap()
+                .to_str()
+                .unwrap(),
+            HEADER_WILDCARD.to_str().unwrap(),
+        );
+    }
 }

--- a/src/routing/middleware/cors.rs
+++ b/src/routing/middleware/cors.rs
@@ -520,7 +520,10 @@ mod test {
             ACCESS_CONTROL_ALLOW_HEADERS,
             HeaderValue::from_static("foo"),
         );
-        assert!(is_valid_preflight_response(&r));
+    assert!(
+        is_valid_preflight_response(&r),
+        "Expected valid preflight response, but it was invalid"
+    );
 
         // Check no headers
         let r = Response::new(Body::empty());

--- a/src/routing/middleware/cors.rs
+++ b/src/routing/middleware/cors.rs
@@ -3,22 +3,23 @@
 use std::{sync::Arc, time::Duration};
 
 use axum::{
+    body::Body,
     extract::{Request, State},
     middleware::Next,
     response::{IntoResponse, Response},
 };
 use http::{
-    Method,
+    Method, StatusCode,
     header::{
         ACCEPT_RANGES, ACCESS_CONTROL_ALLOW_HEADERS, ACCESS_CONTROL_ALLOW_METHODS,
         ACCESS_CONTROL_ALLOW_ORIGIN, ACCESS_CONTROL_EXPOSE_HEADERS, ACCESS_CONTROL_MAX_AGE,
         CACHE_CONTROL, CONTENT_LENGTH, CONTENT_RANGE, CONTENT_TYPE, COOKIE, DNT, HeaderName,
-        HeaderValue, IF_MODIFIED_SINCE, IF_NONE_MATCH, RANGE, USER_AGENT,
+        HeaderValue, IF_MODIFIED_SINCE, IF_NONE_MATCH, RANGE, USER_AGENT, VARY,
     },
 };
 use ic_bn_lib::http::headers::{X_IC_CANISTER_ID, X_REQUEST_ID, X_REQUESTED_WITH};
 use itertools::Itertools;
-use tower_http::cors::{Any, CorsLayer};
+use tower_http::cors::{Any, CorsLayer, preflight_request_headers};
 
 const X_OC_JWT: HeaderName = HeaderName::from_static("x-oc-jwt");
 const X_OC_API_KEY: HeaderName = HeaderName::from_static("x-oc-api-key");
@@ -65,12 +66,12 @@ pub struct CorsStateHttp {
     allow_methods: HeaderValue,
     allow_headers: HeaderValue,
     expose_headers: HeaderValue,
+    vary: HeaderValue,
 }
 
 impl CorsStateHttp {
     pub fn new() -> Self {
         let allow_methods = HeaderValue::from_str(&ALLOW_METHODS_HTTP.iter().join(", ")).unwrap();
-
         let allow_headers = HeaderValue::from_str(
             &ALLOW_HEADERS
                 .into_iter()
@@ -78,39 +79,60 @@ impl CorsStateHttp {
                 .join(", "),
         )
         .unwrap();
-
         let expose_headers = HeaderValue::from_str(&EXPOSE_HEADERS.into_iter().join(", ")).unwrap();
+        let vary = HeaderValue::from_str(&preflight_request_headers().join(", ")).unwrap();
 
         Self {
             allow_headers,
             allow_methods,
             expose_headers,
+            vary,
         }
     }
 
-    pub fn apply_cors(&self, response: &mut Response) {
+    fn apply_cors(&self, method: Method, response: &mut Response) {
         let hdr = response.headers_mut();
 
-        // Insert our CORS headers if they're missing in the response
-        if !hdr.contains_key(ACCESS_CONTROL_ALLOW_METHODS) {
-            hdr.insert(ACCESS_CONTROL_ALLOW_METHODS, self.allow_methods.clone());
+        // These go only to preflight response
+        if method == Method::OPTIONS {
+            if !hdr.contains_key(ACCESS_CONTROL_ALLOW_METHODS) {
+                hdr.insert(ACCESS_CONTROL_ALLOW_METHODS, self.allow_methods.clone());
+            }
+
+            if !hdr.contains_key(ACCESS_CONTROL_ALLOW_HEADERS) {
+                hdr.insert(ACCESS_CONTROL_ALLOW_HEADERS, self.allow_headers.clone());
+            }
+
+            if !hdr.contains_key(ACCESS_CONTROL_MAX_AGE) {
+                hdr.insert(ACCESS_CONTROL_MAX_AGE, HEADER_MAX_AGE);
+            }
+        } else {
+            // This only to the actual response
+            if !hdr.contains_key(ACCESS_CONTROL_EXPOSE_HEADERS) {
+                hdr.insert(ACCESS_CONTROL_EXPOSE_HEADERS, self.expose_headers.clone());
+            }
         }
 
-        if !hdr.contains_key(ACCESS_CONTROL_ALLOW_HEADERS) {
-            hdr.insert(ACCESS_CONTROL_ALLOW_HEADERS, self.allow_headers.clone());
-        }
-
-        if !hdr.contains_key(ACCESS_CONTROL_EXPOSE_HEADERS) {
-            hdr.insert(ACCESS_CONTROL_EXPOSE_HEADERS, self.expose_headers.clone());
-        }
-
+        // These are sent out always
         if !hdr.contains_key(ACCESS_CONTROL_ALLOW_ORIGIN) {
             hdr.insert(ACCESS_CONTROL_ALLOW_ORIGIN, HEADER_WILDCARD);
         }
 
-        if !hdr.contains_key(ACCESS_CONTROL_MAX_AGE) {
-            hdr.insert(ACCESS_CONTROL_MAX_AGE, HEADER_MAX_AGE);
+        if !hdr.contains_key(VARY) {
+            hdr.insert(VARY, self.vary.clone());
         }
+    }
+
+    // Default response for OPTIONS request
+    fn default_preflight_response(&self) -> Response {
+        let mut response = Response::new(Body::empty());
+        let hdr = response.headers_mut();
+        hdr.insert(ACCESS_CONTROL_ALLOW_METHODS, self.allow_methods.clone());
+        hdr.insert(ACCESS_CONTROL_ALLOW_HEADERS, self.allow_headers.clone());
+        hdr.insert(ACCESS_CONTROL_ALLOW_ORIGIN, HEADER_WILDCARD);
+        hdr.insert(ACCESS_CONTROL_MAX_AGE, HEADER_MAX_AGE);
+        hdr.insert(VARY, self.vary.clone());
+        response
     }
 }
 
@@ -119,8 +141,18 @@ pub async fn middleware(
     request: Request,
     next: Next,
 ) -> impl IntoResponse {
+    let method = request.method().clone();
+
+    // Pass the request further
     let mut response = next.run(request).await;
-    state.apply_cors(&mut response);
+
+    // If the request was OPTIONS but we didn't get a successful response - return our own response
+    // with default headers set.
+    if method == Method::OPTIONS && response.status() != StatusCode::OK {
+        return state.default_preflight_response();
+    }
+
+    state.apply_cors(method, &mut response);
     response
 }
 
@@ -136,11 +168,12 @@ pub fn layer(methods: &[Method]) -> CorsLayer {
 #[cfg(test)]
 mod test {
     use super::*;
-    use axum::body::Body;
+    use axum::{Router, body::Body, middleware::from_fn_with_state};
+    use tower::ServiceExt;
 
-    #[test]
-    fn test_cors_http() {
-        let s = CorsStateHttp::new();
+    #[tokio::test]
+    async fn test_cors_http() {
+        let s = Arc::new(CorsStateHttp::new());
         assert_eq!(s.allow_methods, "HEAD, GET, POST, PUT, DELETE, PATCH");
         assert_eq!(
             s.allow_headers,
@@ -150,29 +183,49 @@ mod test {
             s.expose_headers,
             "accept-ranges, content-length, content-range, x-request-id, x-ic-canister-id"
         );
+        assert_eq!(
+            s.vary,
+            "origin, access-control-request-method, access-control-request-headers"
+        );
 
         // Check that the existing response headers are not overriden
-        let mut resp = Response::new(Body::empty());
-        resp.headers_mut().insert(
-            ACCESS_CONTROL_ALLOW_HEADERS,
-            HeaderValue::from_static("foo"),
-        );
-        resp.headers_mut().insert(
-            ACCESS_CONTROL_EXPOSE_HEADERS,
-            HeaderValue::from_static("bar"),
-        );
-        resp.headers_mut().insert(
-            ACCESS_CONTROL_ALLOW_METHODS,
-            HeaderValue::from_static("baz"),
-        );
-        resp.headers_mut()
-            .insert(ACCESS_CONTROL_MAX_AGE, HeaderValue::from_static("1234"));
-        resp.headers_mut().insert(
-            ACCESS_CONTROL_ALLOW_ORIGIN,
-            HeaderValue::from_static("foobar.com"),
-        );
+        let router = Router::new()
+            .fallback(|req: Request| async move {
+                let mut resp = Response::new(Body::empty());
 
-        s.apply_cors(&mut resp);
+                if req.method() == Method::OPTIONS {
+                    resp.headers_mut().insert(
+                        ACCESS_CONTROL_ALLOW_HEADERS,
+                        HeaderValue::from_static("foo"),
+                    );
+                    resp.headers_mut().insert(
+                        ACCESS_CONTROL_ALLOW_METHODS,
+                        HeaderValue::from_static("baz"),
+                    );
+                    resp.headers_mut()
+                        .insert(ACCESS_CONTROL_MAX_AGE, HeaderValue::from_static("1234"));
+                } else {
+                    resp.headers_mut().insert(
+                        ACCESS_CONTROL_EXPOSE_HEADERS,
+                        HeaderValue::from_static("bar"),
+                    );
+                }
+
+                resp.headers_mut().insert(
+                    ACCESS_CONTROL_ALLOW_ORIGIN,
+                    HeaderValue::from_static("foobar.com"),
+                );
+                resp.headers_mut()
+                    .insert(VARY, HeaderValue::from_static("vary"));
+
+                resp
+            })
+            .layer(from_fn_with_state(s.clone(), middleware));
+
+        // For preflight
+        let mut req = Request::new(Body::empty());
+        *req.method_mut() = Method::OPTIONS;
+        let resp = router.clone().oneshot(req).await.unwrap();
 
         assert_eq!(
             resp.headers()
@@ -181,14 +234,6 @@ mod test {
                 .to_str()
                 .unwrap(),
             "foo"
-        );
-        assert_eq!(
-            resp.headers()
-                .get(ACCESS_CONTROL_EXPOSE_HEADERS)
-                .unwrap()
-                .to_str()
-                .unwrap(),
-            "bar"
         );
         assert_eq!(
             resp.headers()
@@ -214,10 +259,39 @@ mod test {
                 .unwrap(),
             "foobar.com"
         );
+        assert_eq!(resp.headers().get(VARY).unwrap().to_str().unwrap(), "vary");
+
+        // For normal request
+        let req = Request::new(Body::empty());
+        let resp = router.oneshot(req).await.unwrap();
+
+        assert_eq!(
+            resp.headers()
+                .get(ACCESS_CONTROL_EXPOSE_HEADERS)
+                .unwrap()
+                .to_str()
+                .unwrap(),
+            "bar"
+        );
+        assert_eq!(
+            resp.headers()
+                .get(ACCESS_CONTROL_ALLOW_ORIGIN)
+                .unwrap()
+                .to_str()
+                .unwrap(),
+            "foobar.com"
+        );
+        assert_eq!(resp.headers().get(VARY).unwrap().to_str().unwrap(), "vary");
 
         // Check that default headers are added
-        let mut resp = Response::new(Body::empty());
-        s.apply_cors(&mut resp);
+        let router = Router::new()
+            .fallback(|| async { "foo" })
+            .layer(from_fn_with_state(s.clone(), middleware));
+
+        // For preflight
+        let mut req = Request::new(Body::empty());
+        *req.method_mut() = Method::OPTIONS;
+        let resp = router.oneshot(req).await.unwrap();
 
         assert_eq!(
             resp.headers()
@@ -226,14 +300,6 @@ mod test {
                 .to_str()
                 .unwrap(),
             s.allow_headers.to_str().unwrap()
-        );
-        assert_eq!(
-            resp.headers()
-                .get(ACCESS_CONTROL_EXPOSE_HEADERS)
-                .unwrap()
-                .to_str()
-                .unwrap(),
-            s.expose_headers.to_str().unwrap()
         );
         assert_eq!(
             resp.headers()
@@ -259,5 +325,81 @@ mod test {
                 .unwrap(),
             HEADER_WILDCARD.to_str().unwrap(),
         );
+        assert_eq!(resp.headers().get(VARY).unwrap().to_str().unwrap(), s.vary);
+        assert!(resp.headers().get(ACCESS_CONTROL_EXPOSE_HEADERS).is_none());
+
+        // For normal request
+        let router = Router::new()
+            .fallback(|| async { "foo" })
+            .layer(from_fn_with_state(s.clone(), middleware));
+
+        let req = Request::new(Body::empty());
+        let resp = router.oneshot(req).await.unwrap();
+
+        assert_eq!(
+            resp.headers()
+                .get(ACCESS_CONTROL_EXPOSE_HEADERS)
+                .unwrap()
+                .to_str()
+                .unwrap(),
+            s.expose_headers.to_str().unwrap()
+        );
+        assert_eq!(
+            resp.headers()
+                .get(ACCESS_CONTROL_ALLOW_ORIGIN)
+                .unwrap()
+                .to_str()
+                .unwrap(),
+            HEADER_WILDCARD.to_str().unwrap(),
+        );
+        assert_eq!(resp.headers().get(VARY).unwrap().to_str().unwrap(), s.vary);
+        assert!(resp.headers().get(ACCESS_CONTROL_ALLOW_METHODS).is_none());
+        assert!(resp.headers().get(ACCESS_CONTROL_ALLOW_HEADERS).is_none());
+        assert!(resp.headers().get(ACCESS_CONTROL_MAX_AGE).is_none());
+
+        // Check that default response is sent for OPTIONS request if the backend returns non-200
+        let router = Router::new()
+            .fallback(|| async { StatusCode::METHOD_NOT_ALLOWED })
+            .layer(from_fn_with_state(s.clone(), middleware));
+
+        let mut req = Request::new(Body::empty());
+        *req.method_mut() = Method::OPTIONS;
+        let resp = router.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        assert_eq!(
+            resp.headers()
+                .get(ACCESS_CONTROL_ALLOW_HEADERS)
+                .unwrap()
+                .to_str()
+                .unwrap(),
+            s.allow_headers.to_str().unwrap()
+        );
+        assert_eq!(
+            resp.headers()
+                .get(ACCESS_CONTROL_ALLOW_METHODS)
+                .unwrap()
+                .to_str()
+                .unwrap(),
+            s.allow_methods.to_str().unwrap(),
+        );
+        assert_eq!(
+            resp.headers()
+                .get(ACCESS_CONTROL_MAX_AGE)
+                .unwrap()
+                .to_str()
+                .unwrap(),
+            HEADER_MAX_AGE.to_str().unwrap()
+        );
+        assert_eq!(
+            resp.headers()
+                .get(ACCESS_CONTROL_ALLOW_ORIGIN)
+                .unwrap()
+                .to_str()
+                .unwrap(),
+            HEADER_WILDCARD.to_str().unwrap(),
+        );
+        assert_eq!(resp.headers().get(VARY).unwrap().to_str().unwrap(), s.vary);
+        assert!(resp.headers().get(ACCESS_CONTROL_EXPOSE_HEADERS).is_none());
     }
 }

--- a/src/routing/mod.rs
+++ b/src/routing/mod.rs
@@ -38,7 +38,7 @@ use middleware::{cache, validate::ValidateState};
 use prometheus::Registry;
 use strum::{Display, IntoStaticStr};
 use tower::{ServiceBuilder, ServiceExt, limit::ConcurrencyLimitLayer, util::MapResponseLayer};
-use tracing::{debug, warn};
+use tracing::warn;
 
 use crate::{
     cli::Cli,
@@ -208,46 +208,50 @@ pub fn setup_router(
                 let geoip_db = geoip::GeoIp::new(x)?;
                 Ok(from_fn_with_state(Arc::new(geoip_db), geoip::middleware))
             })
-            .transpose()?,
+            .transpose()
+            .context("unable to init GeoIP")?,
     );
 
     // Denylist
-    let denylist_mw =
-        if cli.policy.policy_denylist_seed.is_some() || cli.policy.policy_denylist_url.is_some() {
-            let state = denylist::DenylistState::new(
-                cli.policy.policy_denylist_url.clone(),
-                cli.policy.policy_denylist_seed.clone(),
-                cli.policy.policy_denylist_allowlist.clone(),
-                http_client.clone(),
-                registry,
-            )?;
+    let denylist_mw = option_layer(
+        (cli.policy.policy_denylist_seed.is_some() || cli.policy.policy_denylist_url.is_some())
+            .then(|| -> Result<_, Error> {
+                let state = denylist::DenylistState::new(
+                    cli.policy.policy_denylist_url.clone(),
+                    cli.policy.policy_denylist_seed.clone(),
+                    cli.policy.policy_denylist_allowlist.clone(),
+                    http_client.clone(),
+                    registry,
+                )?;
 
-            // Only run periodic job if an URL was given
-            if cli.policy.policy_denylist_url.is_some() {
-                tasks.add_interval(
-                    "denylist_updater",
-                    Arc::new(state.clone()),
-                    cli.policy.policy_denylist_poll_interval,
-                );
-            }
+                // Only run periodic job if an URL was given
+                if cli.policy.policy_denylist_url.is_some() {
+                    tasks.add_interval(
+                        "denylist_updater",
+                        Arc::new(state.clone()),
+                        cli.policy.policy_denylist_poll_interval,
+                    );
+                }
 
-            Some(from_fn_with_state(state, denylist::middleware))
-        } else {
-            debug!("Running without denylist: neither a seed nor a URL has been specified.");
-            None
-        };
+                Ok(from_fn_with_state(state, denylist::middleware))
+            })
+            .transpose()
+            .context("unable to init Denylisting")?,
+    );
 
     // Domain-Canister Matching
     // CLI makes sure that domains_system is also set
-    let canister_match_mw = if !cli.domain.domain_app.is_empty() {
-        Some(from_fn_with_state(
-            canister_match::CanisterMatcherState::new(cli)?,
-            canister_match::middleware,
-        ))
-    } else {
-        debug!("Running without domain-canister matching.");
-        None
-    };
+    let canister_match_mw = option_layer(
+        (!cli.domain.domain_app.is_empty())
+            .then(|| -> Result<_, Error> {
+                Ok(from_fn_with_state(
+                    canister_match::CanisterMatcherState::new(cli)?,
+                    canister_match::middleware,
+                ))
+            })
+            .transpose()
+            .context("unable to init Domain-Canister matcher")?,
+    );
 
     // Metrics
     let metrics_state = Arc::new(metrics::HttpMetrics::new(
@@ -282,45 +286,41 @@ pub fn setup_router(
             cli.shed_system.shed_system_load_avg_15,
         ];
 
-        if opts.iter().any(|x| x.is_some()) {
+        opts.iter().any(|x| x.is_some()).then(|| {
             warn!("System load shedder enabled ({:?})", cli.shed_system);
 
-            Some(
-                ServiceBuilder::new()
-                    .layer(shed_map_response.clone())
-                    .layer(SystemLoadShedderLayer::new(
-                        cli.shed_system.shed_system_ewma,
-                        cli.shed_system.clone().into(),
-                        SystemInfo::new(),
-                    )),
-            )
-        } else {
-            None
-        }
+            ServiceBuilder::new()
+                .layer(shed_map_response.clone())
+                .layer(SystemLoadShedderLayer::new(
+                    cli.shed_system.shed_system_ewma,
+                    cli.shed_system.clone().into(),
+                    SystemInfo::new(),
+                ))
+        })
     });
 
-    let load_shedder_latency_mw =
-        option_layer(if !cli.shed_latency.shed_sharded_latency.is_empty() {
+    let load_shedder_latency_mw = option_layer(
+        (!cli.shed_latency.shed_sharded_latency.is_empty()).then(|| {
             warn!("Latency load shedder enabled ({:?})", cli.shed_latency);
 
-            Some(ServiceBuilder::new().layer(shed_map_response).layer(
+            ServiceBuilder::new().layer(shed_map_response).layer(
                 ShardedLittleLoadShedderLayer::new(ShardedOptions {
                     extractor: RequestTypeExtractor,
                     ewma_alpha: cli.shed_latency.shed_sharded_ewma,
                     passthrough_count: cli.shed_latency.shed_sharded_passthrough,
                     latencies: cli.shed_latency.shed_sharded_latency.clone(),
                 }),
-            ))
-        } else {
-            None
-        });
+            )
+        }),
+    );
 
     // Prepare the HTTP->IC library
-    let client = ic::setup(cli, http_client.clone(), route_provider.clone())?;
+    let ic_client = ic::setup(cli, http_client.clone(), route_provider.clone())
+        .context("unable to init IC client")?;
 
     // Prepare the states
     let state_handler = Arc::new(handler::HandlerState::new(
-        client,
+        ic_client,
         !cli.ic.ic_unsafe_disable_response_verification,
         cli.http_server.http_server_body_read_timeout,
         cli.ic.ic_request_max_size,
@@ -334,9 +334,11 @@ pub fn setup_router(
         cli.ic.ic_request_body_timeout,
     ));
 
+    let cors_base = cors::layer(cli.cors.cors_max_age, cli.cors.cors_allow_origin.clone());
+
     // Common CORS layers
-    let cors_post = cors::layer(&[Method::POST]);
-    let cors_get = cors::layer(&[Method::HEAD, Method::GET]);
+    let cors_post = cors_base.clone().allow_methods([Method::POST]);
+    let cors_get = cors_base.clone().allow_methods([Method::HEAD, Method::GET]);
 
     // IC API proxy routers
     let router_api_v2 = Router::new()
@@ -374,43 +376,51 @@ pub fn setup_router(
     );
 
     // Caching middleware
-    let cache_middleware = option_layer(if let Some(v) = cli.cache.cache_size {
-        let opts = Opts {
-            cache_size: v,
-            max_item_size: cli.cache.cache_max_item_size,
-            ttl: cli.cache.cache_ttl,
-            lock_timeout: cli.cache.cache_lock_timeout,
-            body_timeout: cli.cache.cache_body_timeout,
-            xfetch_beta: cli.cache.cache_xfetch_beta,
-            methods: vec![Method::GET],
-        };
+    let cache_middleware = option_layer(
+        cli.cache
+            .cache_size
+            .map(|v| -> Result<_, Error> {
+                let opts = Opts {
+                    cache_size: v,
+                    max_item_size: cli.cache.cache_max_item_size,
+                    ttl: cli.cache.cache_ttl,
+                    lock_timeout: cli.cache.cache_lock_timeout,
+                    body_timeout: cli.cache.cache_body_timeout,
+                    xfetch_beta: cli.cache.cache_xfetch_beta,
+                    methods: vec![Method::GET],
+                };
 
-        let cache = Arc::new(Cache::new(opts, KeyExtractorUriRange, registry)?);
-        tasks.add_interval("cache", cache.clone(), Duration::from_secs(5));
-        Some(from_fn_with_state(cache, cache::middleware))
-    } else {
-        warn!("Running without HTTP cache");
-        None
-    });
+                let cache = Arc::new(Cache::new(opts, KeyExtractorUriRange, registry)?);
+                tasks.add_interval("cache", cache.clone(), Duration::from_secs(5));
+                Ok(from_fn_with_state(cache, cache::middleware))
+            })
+            .transpose()
+            .context("unable to init cache")?,
+    );
 
     // Use either static CORS layer or a dynamic one
-    let cors_layer = if cli.cors.cors_canister_passthrough {
+    let cors_http = if cli.cors.cors_canister_passthrough {
         Either::E1(from_fn_with_state(
-            Arc::new(cors::CorsStateHttp::new(
-                cli.cors.cors_invalid_canisters_max,
-                cli.cors.cors_invalid_canisters_ttl,
-            )),
+            Arc::new(
+                cors::CorsStateHttp::new(
+                    cli.cors.cors_invalid_canisters_max,
+                    cli.cors.cors_invalid_canisters_ttl,
+                    cli.cors.cors_allow_origin.clone(),
+                    cli.cors.cors_max_age,
+                )
+                .context("unable to init CORS")?,
+            ),
             cors::middleware,
         ))
     } else {
-        Either::E2(cors::layer(&cors::ALLOW_METHODS_HTTP))
+        Either::E2(cors_base.clone().allow_methods(cors::ALLOW_METHODS_HTTP))
     };
 
     // Layers for the main HTTP->IC route
     let http_layers = ServiceBuilder::new()
-        .layer(cors_layer)
-        .layer(option_layer(denylist_mw))
-        .layer(option_layer(canister_match_mw))
+        .layer(cors_http)
+        .layer(denylist_mw)
+        .layer(canister_match_mw)
         .layer(cache_middleware);
 
     let router_http = Router::new().fallback(
@@ -440,7 +450,7 @@ pub fn setup_router(
                 get(proxy::issuer_proxy)
                     .put(proxy::issuer_proxy)
                     .delete(proxy::issuer_proxy)
-                    .layer(cors::layer(&[
+                    .layer(cors_base.allow_methods([
                         Method::HEAD,
                         Method::GET,
                         Method::PUT,


### PR DESCRIPTION
* Add CORS cli options
* Add a custom CORS middleware that inserts various CORS headers only if they're not already present in the response. This middleware is only used with HTTP endpoint, not API & others. Its usage is controlled by CLI flags
* When CORS middleware is enabled it caches the canister ids with incorrect responses to avoid querying them again for some time
* Rework some router init (chore)
* Update the deps.