### PR TITLE
Make custom domain providers independent

### DIFF
--- a/src/routing/custom_domains.rs
+++ b/src/routing/custom_domains.rs
@@ -3,7 +3,7 @@ use std::{sync::Arc, time::Duration};
 
 use ahash::HashMap;
 use anyhow::Error;
-use anyhow::{anyhow, Context as AnyhowContext};
+use anyhow::{Context as AnyhowContext, anyhow};
 use async_trait::async_trait;
 use candid::Principal;
 use derive_new::new;
@@ -13,7 +13,7 @@ use reqwest::{Method, Request, StatusCode, Url};
 
 use crate::routing::domain::{CustomDomain, ProvidesCustomDomains};
 
-#[derive(new)]
+#[derive(new, Debug)]
 pub struct GenericProvider {
     http_client: Arc<dyn http::Client>,
     url: Url,

--- a/src/routing/domain.rs
+++ b/src/routing/domain.rs
@@ -11,7 +11,7 @@ use candid::Principal;
 use fqdn::{FQDN, Fqdn, fqdn};
 use ic_bn_lib::tasks::Run;
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, warn};
+use tracing::{debug, info, warn};
 
 #[macro_export]
 macro_rules! principal {
@@ -130,7 +130,7 @@ impl CustomDomainStorage {
 
         // Check if the new set is different
         if snapshot == snapshot_old {
-            debug!("CustomDomainStorage: certs haven't changed, not updating");
+            debug!("CustomDomainStorage: domains haven't changed, not updating");
             return;
         }
 

--- a/src/routing/domain.rs
+++ b/src/routing/domain.rs
@@ -11,7 +11,7 @@ use candid::Principal;
 use fqdn::{FQDN, Fqdn, fqdn};
 use ic_bn_lib::tasks::Run;
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, info, warn};
+use tracing::{debug, warn};
 
 #[macro_export]
 macro_rules! principal {

--- a/src/routing/domain.rs
+++ b/src/routing/domain.rs
@@ -1,19 +1,21 @@
-use std::{collections::BTreeMap, str::FromStr, sync::Arc};
+use std::{
+    collections::BTreeMap,
+    str::FromStr,
+    sync::{Arc, Mutex},
+};
 
-use anyhow::{anyhow, Context, Error};
+use anyhow::{Context, Error, anyhow};
 use arc_swap::ArcSwapOption;
 use async_trait::async_trait;
 use candid::Principal;
-use derive_new::new;
-use fqdn::{fqdn, Fqdn, FQDN};
+use fqdn::{FQDN, Fqdn, fqdn};
 use ic_bn_lib::tasks::Run;
 use tokio_util::sync::CancellationToken;
+use tracing::{debug, warn};
 
 #[macro_export]
 macro_rules! principal {
-    ($id:expr) => {{
-        Principal::from_text($id).unwrap()
-    }};
+    ($id:expr) => {{ Principal::from_text($id).unwrap() }};
 }
 
 /// Domain entity with certain metadata
@@ -49,7 +51,7 @@ pub struct CustomDomain {
 
 // Provides a list of custom domains
 #[async_trait]
-pub trait ProvidesCustomDomains: Sync + Send {
+pub trait ProvidesCustomDomains: Sync + Send + std::fmt::Debug {
     async fn get_custom_domains(&self) -> Result<Vec<CustomDomain>, Error>;
 }
 
@@ -85,50 +87,89 @@ impl FromStr for CanisterAlias {
 struct CustomDomainStorageInner(BTreeMap<FQDN, DomainLookup>);
 
 /// Custom domain storage.
-/// Fetches custom domains from several providers and stores them as `DomainLookups`
-#[derive(new)]
+/// Fetches custom domains from several providers and stores them as `DomainLookup`
 pub struct CustomDomainStorage {
     providers: Vec<Arc<dyn ProvidesCustomDomains>>,
-    #[new(default)]
     inner: ArcSwapOption<CustomDomainStorageInner>,
+    snapshot: Mutex<Vec<Option<Vec<CustomDomain>>>>,
 }
 
 impl CustomDomainStorage {
-    async fn refresh(&self) -> Result<(), Error> {
-        let mut buf = vec![];
-        for p in &self.providers {
-            buf.push(p.get_custom_domains().await?);
+    pub fn new(providers: Vec<Arc<dyn ProvidesCustomDomains>>) -> Self {
+        Self {
+            inner: ArcSwapOption::empty(),
+            snapshot: Mutex::new(vec![None; providers.len()]),
+            providers,
+        }
+    }
+
+    // Fetches the new set of domains from each provider on top of the provided snapshot
+    async fn fetch(
+        &self,
+        mut snapshot: Vec<Option<Vec<CustomDomain>>>,
+    ) -> Vec<Option<Vec<CustomDomain>>> {
+        for (i, p) in self.providers.iter().enumerate() {
+            match p.get_custom_domains().await {
+                Ok(mut v) => {
+                    v.sort_by(|a, b| a.name.cmp(&b.name));
+                    snapshot[i] = Some(v);
+                }
+
+                Err(e) => {
+                    warn!("CustomDomainStorage: unable to fetch domains from provider '{p:?}': {e}")
+                }
+            }
         }
 
-        let domains = buf.into_iter().flatten().map(|x| {
-            (
-                x.name.clone(),
-                DomainLookup {
-                    domain: Domain {
-                        name: x.name,
-                        custom: true,
-                        http: true,
-                        api: true,
+        snapshot
+    }
+
+    async fn refresh(&self) {
+        let snapshot_old = self.snapshot.lock().unwrap().clone();
+        let snapshot = self.fetch(snapshot_old.clone()).await;
+
+        // Check if the new set is different
+        if snapshot == snapshot_old {
+            debug!("CustomDomainStorage: certs haven't changed, not updating");
+            return;
+        }
+
+        // Store the new snapshot
+        *self.snapshot.lock().unwrap() = snapshot.clone();
+
+        // Convert the snapshot into new lookup structure
+        let domains = snapshot
+            .into_iter()
+            .flatten()
+            .flatten()
+            .map(|x| {
+                (
+                    x.name.clone(),
+                    DomainLookup {
+                        domain: Domain {
+                            name: x.name,
+                            custom: true,
+                            http: true,
+                            api: true,
+                        },
+                        canister_id: Some(x.canister_id),
+                        verify: true,
                     },
-                    canister_id: Some(x.canister_id),
-                    verify: true,
-                },
-            )
-        });
+                )
+            })
+            .collect::<BTreeMap<_, _>>();
 
-        let inner = CustomDomainStorageInner(domains.collect::<BTreeMap<_, _>>());
+        // Store it
+        let inner = CustomDomainStorageInner(domains);
         self.inner.store(Some(Arc::new(inner)));
-
-        Ok(())
     }
 }
 
 #[async_trait]
 impl Run for CustomDomainStorage {
     async fn run(&self, _: CancellationToken) -> Result<(), Error> {
-        self.refresh()
-            .await
-            .context("unable to refresh custom domains")
+        self.refresh().await;
+        Ok(())
     }
 }
 
@@ -307,12 +348,23 @@ mod test {
         Ok(())
     }
 
+    #[derive(Debug)]
     struct TestCustomDomainProvider(CustomDomain);
 
     #[async_trait]
     impl ProvidesCustomDomains for TestCustomDomainProvider {
         async fn get_custom_domains(&self) -> Result<Vec<CustomDomain>, Error> {
             Ok(vec![self.0.clone()])
+        }
+    }
+
+    #[derive(Debug)]
+    struct TestCustomDomainProviderBroken;
+
+    #[async_trait]
+    impl ProvidesCustomDomains for TestCustomDomainProviderBroken {
+        async fn get_custom_domains(&self) -> Result<Vec<CustomDomain>, Error> {
+            Err(anyhow!("I'm dead"))
         }
     }
 
@@ -334,9 +386,12 @@ mod test {
             canister_id: principal!(TEST_CANISTER_ID),
         });
 
-        let custom_domain_storage =
-            CustomDomainStorage::new(vec![Arc::new(custom_domain_provider)]);
-        custom_domain_storage.refresh().await?;
+        // Add one working and one broken provider to make sure that broken one doesn't affect the outcome
+        let custom_domain_storage = CustomDomainStorage::new(vec![
+            Arc::new(custom_domain_provider),
+            Arc::new(TestCustomDomainProviderBroken),
+        ]);
+        custom_domain_storage.refresh().await;
 
         let resolver = DomainResolver::new(
             domains_base.clone(),

--- a/src/tls/cert/mod.rs
+++ b/src/tls/cert/mod.rs
@@ -9,11 +9,12 @@ use ic_bn_lib::{
     tasks::Run,
     tls::{extract_sans_der, pem_convert_to_rustls},
 };
-use providers::{Pem, ProvidesCertificates};
 use rustls::sign::CertifiedKey;
-use storage::StoresCertificates;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, warn};
+
+use providers::{Pem, ProvidesCertificates};
+use storage::StoresCertificates;
 
 // Generic certificate and a list of its SANs
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/src/tls/cert/mod.rs
+++ b/src/tls/cert/mod.rs
@@ -1,21 +1,19 @@
 pub mod providers;
 pub mod storage;
 
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
-use anyhow::{anyhow, Error};
+use anyhow::{Error, anyhow};
 use async_trait::async_trait;
 use ic_bn_lib::{
     tasks::Run,
     tls::{extract_sans_der, pem_convert_to_rustls},
 };
+use providers::{Pem, ProvidesCertificates};
 use rustls::sign::CertifiedKey;
-use tokio::sync::Mutex;
+use storage::StoresCertificates;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, warn};
-
-use providers::{Pem, ProvidesCertificates};
-use storage::StoresCertificates;
 
 // Generic certificate and a list of its SANs
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -77,7 +75,6 @@ impl Eq for AggregatorSnapshot {}
 pub struct Aggregator {
     providers: Vec<Arc<dyn ProvidesCertificates>>,
     storage: Arc<dyn StoresCertificates<Arc<CertifiedKey>>>,
-    // Mutex here only to make it Sync
     snapshot: Mutex<AggregatorSnapshot>,
 }
 
@@ -110,13 +107,17 @@ impl Aggregator {
                 Ok(pem) => {
                     // Try to parse them first to make sure they're valid
                     match parse_pem(&pem) {
-                        Ok(parsed) => {
+                        Ok(mut parsed) => {
+                            parsed.sort_by(|a, b| a.san.cmp(&b.san));
+
                             // Update the entries in the snapshot
                             snapshot.pem[i] = Some(pem);
                             snapshot.parsed[i] = Some(parsed);
-                        },
+                        }
 
-                        Err(e) => warn!("CertAggregator: failed to parse certificates from provider {p:?}: {e:#}"),
+                        Err(e) => warn!(
+                            "CertAggregator: failed to parse certificates from provider {p:?}: {e:#}"
+                        ),
                     }
                 }
 
@@ -130,8 +131,7 @@ impl Aggregator {
     #[allow(clippy::significant_drop_tightening)]
     async fn refresh(&self) {
         // Get a snapshot of current data to update
-        let mut snapshot_lock = self.snapshot.lock().await;
-        let snapshot_old = snapshot_lock.clone();
+        let snapshot_old = self.snapshot.lock().unwrap().clone();
 
         // Fetch new certificates on top of the old snapshot
         let snapshot = self.fetch(snapshot_old.clone()).await;
@@ -154,7 +154,7 @@ impl Aggregator {
         }
 
         // Store the new snapshot
-        *snapshot_lock = snapshot;
+        *self.snapshot.lock().unwrap() = snapshot;
 
         // Publish to storage
         if let Err(e) = self.storage.store(certs) {
@@ -330,7 +330,7 @@ pub mod test {
         let aggregator = Aggregator::new(vec![Arc::new(prov1), Arc::new(prov2)], storage);
         aggregator.refresh().await;
 
-        let certs = aggregator.snapshot.lock().await.clone().flatten();
+        let certs = aggregator.snapshot.lock().unwrap().clone().flatten();
         assert_eq!(certs.len(), 2);
         assert_eq!(certs[0].san, vec!["novg"]);
         assert_eq!(certs[1].san, vec!["3658153f27e0"]);
@@ -338,7 +338,7 @@ pub mod test {
         // The providers will fail on the 2nd request, make sure the snapshot stays the same
         aggregator.refresh().await;
 
-        let certs = aggregator.snapshot.lock().await.clone().flatten();
+        let certs = aggregator.snapshot.lock().unwrap().clone().flatten();
         assert_eq!(certs.len(), 2);
         assert_eq!(certs[0].san, vec!["novg"]);
         assert_eq!(certs[1].san, vec!["3658153f27e0"]);


### PR DESCRIPTION
* Failure in one custom domain provider now won't affect the other ones. If the provider is failing - we'll use the latest valid data from it.
* Don't use tokio Mutex and sort the certificates by SAN to make sure the result is consistent in CertProvider