### PR TITLE
Add benchmark & other stuff

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,9 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-24.04
+    runs-on: dind-small
+    container:
+      image: ghcr.io/catthehacker/ubuntu:rust-22.04@sha256:e451382a9fe2bb34d253dfdaea49886be285526be9027e819ddbbdff5fcca799
 
     permissions:
       contents: write

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
   test:
     runs-on: dind-small
     container:
-      image: ghcr.io/catthehacker/ubuntu:rust-22.04@sha256:baeacfa8e05a4402c2e17d8a495dadbb7a6062a8ae44eef7c22424d617c53373
+      image: ghcr.io/catthehacker/ubuntu:rust-22.04@sha256:e451382a9fe2bb34d253dfdaea49886be285526be9027e819ddbbdff5fcca799
 
     steps:
       - uses: actions/checkout@v4

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ target/
 /target
 
 /cert
+
+profile.json*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1016,9 +1016,9 @@ checksum = "93a719913643003b84bd13022b4b7e703c09342cd03b679c4641c7d2e50dc34d"
 
 [[package]]
 name = "clap"
-version = "4.5.37"
+version = "4.5.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eccb054f56cbd38340b380d4a8e69ef1f02f1af43db2f0cc817a4774d80ae071"
+checksum = "ed93b9805f8ba930df42c2590f05453d5ec36cbb85d018868a5b24d31f6ac000"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1026,9 +1026,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.37"
+version = "4.5.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efd9466fac8543255d3b1fcad4762c5e116ffe808c8a3043d4263cd4fd4862a2"
+checksum = "379026ff283facf611b0ea629334361c4211d1b12ee01024eec1591133b04120"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1350,11 +1350,11 @@ dependencies = [
 
 [[package]]
 name = "ctrlc"
-version = "3.4.6"
+version = "3.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "697b5419f348fd5ae2478e8018cb016c00a5881c7f46c717de98ffd135a5651c"
+checksum = "46f93780a459b7d656ef7f071fe699c4d3d2cb201c4b24d085b6ddc505276e73"
 dependencies = [
- "nix",
+ "nix 0.30.1",
  "windows-sys 0.59.0",
 ]
 
@@ -2488,7 +2488,7 @@ dependencies = [
 [[package]]
 name = "ic-bn-lib"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic-bn-lib?rev=5d2046fb74f9c981ab7afa1c9e95d8dd96dac2e1#5d2046fb74f9c981ab7afa1c9e95d8dd96dac2e1"
+source = "git+https://github.com/dfinity/ic-bn-lib?rev=d973c98ba30882592b4e0798e6dab7b3c651c10b#d973c98ba30882592b4e0798e6dab7b3c651c10b"
 dependencies = [
  "ahash",
  "anyhow",
@@ -2721,13 +2721,12 @@ dependencies = [
  "ic-http-certification 3.0.3",
  "ic-http-gateway",
  "ic-transport-types 0.40.0",
- "instant-acme",
  "itertools 0.14.0",
  "lazy_static",
  "maxminddb",
  "mockall",
  "moka",
- "nix",
+ "nix 0.29.0",
  "ocsp-stapler",
  "pocket-ic",
  "prometheus",
@@ -3621,6 +3620,18 @@ name = "nix"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -4706,7 +4717,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4825,9 +4836,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.2"
+version = "0.103.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7149975849f1abb3832b246010ef62ccc80d3a76169517ada7188252b9cfb437"
+checksum = "e4a72fe2bcf7a6ac6fd7d0b9e5cb68aeb7d4c0a0271730218b3e92d43b4eb435"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -5544,9 +5555,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.19.1"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7437ac7763b9b123ccf33c338a5cc1bac6f69b45a136c19bdd8a65e3916435bf"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
 dependencies = [
  "fastrand",
  "getrandom 0.3.3",
@@ -5877,9 +5888,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.2"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "403fa3b783d4b626a8ad51d766ab03cb6d2dbfc46b1c5d4448395e6628dc9697"
+checksum = "0fdb0c213ca27a9f57ab69ddb290fd80d970922355b83ae380b395d3986b8a2e"
 dependencies = [
  "async-compression",
  "bitflags",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1354,7 +1354,7 @@ version = "3.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46f93780a459b7d656ef7f071fe699c4d3d2cb201c4b24d085b6ddc505276e73"
 dependencies = [
- "nix 0.30.1",
+ "nix",
  "windows-sys 0.59.0",
 ]
 
@@ -2726,7 +2726,7 @@ dependencies = [
  "maxminddb",
  "mockall",
  "moka",
- "nix 0.29.0",
+ "nix",
  "ocsp-stapler",
  "pocket-ic",
  "prometheus",
@@ -3614,18 +3614,6 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
-
-[[package]]
-name = "nix"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
-dependencies = [
- "bitflags",
- "cfg-if",
- "cfg_aliases",
- "libc",
-]
 
 [[package]]
 name = "nix"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2488,7 +2488,7 @@ dependencies = [
 [[package]]
 name = "ic-bn-lib"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic-bn-lib?rev=777a5fa779eb0f1ade616127dd97fc0846fb49ee#777a5fa779eb0f1ade616127dd97fc0846fb49ee"
+source = "git+https://github.com/dfinity/ic-bn-lib?rev=5d2046fb74f9c981ab7afa1c9e95d8dd96dac2e1#5d2046fb74f9c981ab7afa1c9e95d8dd96dac2e1"
 dependencies = [
  "ahash",
  "anyhow",
@@ -2721,6 +2721,7 @@ dependencies = [
  "ic-http-certification 3.0.3",
  "ic-http-gateway",
  "ic-transport-types 0.40.0",
+ "instant-acme",
  "itertools 0.14.0",
  "lazy_static",
  "maxminddb",
@@ -4705,7 +4706,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,15 +29,15 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
- "getrandom 0.2.16",
+ "getrandom 0.3.3",
  "once_cell",
  "version_check",
- "zerocopy 0.7.35",
+ "zerocopy",
 ]
 
 [[package]]
@@ -397,7 +397,7 @@ dependencies = [
  "log",
  "rustls-pki-types",
  "thiserror 1.0.69",
- "webpki-roots",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -563,9 +563,9 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.74"
+version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
+checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
 dependencies = [
  "addr2line",
  "cfg-if",
@@ -655,15 +655,23 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitfield"
-version = "0.15.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c821a6e124197eb56d907ccc2188eab1038fb919c914f47976e64dd8dbc855d1"
+checksum = "786e53b0c071573a28956cec19a92653e42de34c683e2f6e86c197a349fba318"
+dependencies = [
+ "bitfield-macros",
+]
 
 [[package]]
-name = "bitflags"
-version = "1.3.2"
+name = "bitfield-macros"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+checksum = "07805405d3f1f3a55aab895718b488821d40458f9188059909091ae0935c344a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
 
 [[package]]
 name = "bitflags"
@@ -896,9 +904,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.21"
+version = "1.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8691782945451c1c383942c4874dbe63814f61cb57ef773cda2972682b7bb3c0"
+checksum = "32db95edf998450acc7881c932f94cd9b05c87b4b2599e8bab064753da4acfd1"
 dependencies = [
  "jobserver",
  "libc",
@@ -1536,23 +1544,23 @@ dependencies = [
 
 [[package]]
 name = "dirs"
-version = "5.0.1"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
  "dirs-sys",
 ]
 
 [[package]]
 name = "dirs-sys"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1957,9 +1965,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -1986,7 +1994,7 @@ dependencies = [
  "futures-sink",
  "futures-timer",
  "futures-util",
- "getrandom 0.3.2",
+ "getrandom 0.3.3",
  "no-std-compat",
  "nonzero_ext",
  "parking_lot",
@@ -2143,7 +2151,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
 dependencies = [
  "async-trait",
- "bitflags 2.9.0",
+ "bitflags",
  "bytes",
  "cfg-if",
  "data-encoding",
@@ -2167,7 +2175,7 @@ dependencies = [
  "tokio-rustls",
  "tracing",
  "url",
- "webpki-roots",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -2212,7 +2220,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tracing",
- "webpki-roots",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -2368,7 +2376,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -2536,7 +2544,7 @@ dependencies = [
  "url",
  "uuid",
  "vrl",
- "webpki-root-certs",
+ "webpki-root-certs 0.26.11",
  "x509-parser 0.17.0",
  "zeroize",
 ]
@@ -2980,21 +2988,22 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "1.5.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
+checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
 dependencies = [
  "displaydoc",
+ "potential_utf",
  "yoke",
  "zerofrom",
  "zerovec",
 ]
 
 [[package]]
-name = "icu_locid"
-version = "1.5.0"
+name = "icu_locale_core"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
+checksum = "0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -3004,30 +3013,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "icu_locid_transform"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
-dependencies = [
- "displaydoc",
- "icu_locid",
- "icu_locid_transform_data",
- "icu_provider",
- "tinystr",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid_transform_data"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7515e6d781098bf9f7205ab3fc7e9709d34554ae0b21ddbcb5febfa4bc7df11d"
-
-[[package]]
 name = "icu_normalizer"
-version = "1.5.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
+checksum = "436880e8e18df4d7bbc06d58432329d6458cc84531f7ac5f024e93deadb37979"
 dependencies = [
  "displaydoc",
  "icu_collections",
@@ -3035,65 +3024,52 @@ dependencies = [
  "icu_properties",
  "icu_provider",
  "smallvec",
- "utf16_iter",
- "utf8_iter",
- "write16",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_normalizer_data"
-version = "1.5.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5e8338228bdc8ab83303f16b797e177953730f601a96c25d10cb3ab0daa0cb7"
+checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
 
 [[package]]
 name = "icu_properties"
-version = "1.5.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
+checksum = "2549ca8c7241c82f59c80ba2a6f415d931c5b58d24fb8412caa1a1f02c49139a"
 dependencies = [
  "displaydoc",
  "icu_collections",
- "icu_locid_transform",
+ "icu_locale_core",
  "icu_properties_data",
  "icu_provider",
- "tinystr",
+ "potential_utf",
+ "zerotrie",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_properties_data"
-version = "1.5.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85fb8799753b75aee8d2a21d7c14d9f38921b54b3dbda10f5a3c7a7b82dba5e2"
+checksum = "8197e866e47b68f8f7d95249e172903bec06004b18b2937f1095d40a0c57de04"
 
 [[package]]
 name = "icu_provider"
-version = "1.5.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
+checksum = "03c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af"
 dependencies = [
  "displaydoc",
- "icu_locid",
- "icu_provider_macros",
+ "icu_locale_core",
  "stable_deref_trait",
  "tinystr",
  "writeable",
  "yoke",
  "zerofrom",
+ "zerotrie",
  "zerovec",
-]
-
-[[package]]
-name = "icu_provider_macros"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
 ]
 
 [[package]]
@@ -3115,9 +3091,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -3293,7 +3269,7 @@ version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a"
 dependencies = [
- "getrandom 0.3.2",
+ "getrandom 0.3.3",
  "libc",
 ]
 
@@ -3416,7 +3392,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags",
  "libc",
 ]
 
@@ -3440,9 +3416,9 @@ checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "litemap"
-version = "0.7.5"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
+checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "lock_api"
@@ -3481,6 +3457,12 @@ checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
 dependencies = [
  "linked-hash-map",
 ]
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lz4_flex"
@@ -3639,7 +3621,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -4085,6 +4067,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
 
 [[package]]
+name = "potential_utf"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4096,7 +4087,7 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy 0.8.25",
+ "zerocopy",
 ]
 
 [[package]]
@@ -4253,9 +4244,9 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.11.7"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3bd15a6f2967aef83887dcb9fec0014580467e33720d073560cf015a5683012"
+checksum = "626214629cda6781b6dc1d316ba307189c85ba657213ce642d9c77670f8202c8"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -4273,12 +4264,13 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.11"
+version = "0.11.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcbafbbdbb0f638fe3f35f3c56739f77a8a1d070cb25603226c83339b391472b"
+checksum = "49df843a9161c85bb8aae55f101bc0bac8bcafd637a620d9122fd7e0b2f7422e"
 dependencies = [
  "bytes",
- "getrandom 0.3.2",
+ "getrandom 0.3.3",
+ "lru-slab",
  "rand 0.9.1",
  "ring",
  "rustc-hash",
@@ -4382,7 +4374,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
- "getrandom 0.3.2",
+ "getrandom 0.3.3",
 ]
 
 [[package]]
@@ -4464,7 +4456,7 @@ version = "11.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6df7ab838ed27997ba19a4664507e6f82b41fe6e20be42929332156e5e85146"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags",
 ]
 
 [[package]]
@@ -4512,18 +4504,18 @@ version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags",
 ]
 
 [[package]]
 name = "redox_users"
-version = "0.4.6"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
 dependencies = [
  "getrandom 0.2.16",
  "libredox",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -4639,7 +4631,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 0.26.11",
  "windows-registry",
 ]
 
@@ -4709,7 +4701,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -4722,7 +4714,7 @@ version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
@@ -4768,7 +4760,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.12",
- "webpki-roots",
+ "webpki-roots 0.26.11",
  "x509-parser 0.16.0",
 ]
 
@@ -4795,11 +4787,12 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
+checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
 dependencies = [
  "web-time",
+ "zeroize",
 ]
 
 [[package]]
@@ -4819,7 +4812,7 @@ dependencies = [
  "rustls-webpki",
  "security-framework",
  "security-framework-sys",
- "webpki-root-certs",
+ "webpki-root-certs 0.26.11",
  "windows-sys 0.59.0",
 ]
 
@@ -4937,7 +4930,7 @@ version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags",
  "core-foundation 0.10.0",
  "core-foundation-sys",
  "libc",
@@ -5120,14 +5113,14 @@ dependencies = [
 
 [[package]]
 name = "sev"
-version = "6.0.0"
+version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20ac277517d8fffdf3c41096323ed705b3a7c75e397129c072fb448339839d0f"
+checksum = "492a7043c77be9a4997a62e2426ea084849c73660efd402f1a33fea0ee75ebb4"
 dependencies = [
  "base64 0.22.1",
  "bincode",
  "bitfield",
- "bitflags 1.3.2",
+ "bitflags",
  "byteorder",
  "codicon",
  "dirs",
@@ -5507,7 +5500,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -5555,7 +5548,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7437ac7763b9b123ccf33c338a5cc1bac6f69b45a136c19bdd8a65e3916435bf"
 dependencies = [
  "fastrand",
- "getrandom 0.3.2",
+ "getrandom 0.3.3",
  "once_cell",
  "rustix 1.0.7",
  "windows-sys 0.59.0",
@@ -5691,9 +5684,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.7.6"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
+checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -5888,7 +5881,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "403fa3b783d4b626a8ad51d766ab03cb6d2dbfc46b1c5d4448395e6628dc9697"
 dependencies = [
  "async-compression",
- "bitflags 2.9.0",
+ "bitflags",
  "bytes",
  "futures-core",
  "http 1.3.1",
@@ -6146,12 +6139,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
-name = "utf16_iter"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
-
-[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6169,7 +6156,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
 dependencies = [
- "getrandom 0.3.2",
+ "getrandom 0.3.3",
  "serde",
 ]
 
@@ -6343,7 +6330,7 @@ version = "0.230.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "808198a69b5a0535583370a51d459baa14261dfab04800c4864ee9e1a14346ed"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags",
  "indexmap 2.9.0",
  "semver",
 ]
@@ -6392,18 +6379,36 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "0.26.10"
+version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c99403924bc5f23afefc319b8ac67ed0e50669f6e52a413314cccb1fdbc93ba0"
+checksum = "75c7f0ef91146ebfb530314f5f1d24528d7f0767efbfd31dce919275413e393e"
+dependencies = [
+ "webpki-root-certs 1.0.0",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01a83f7e1a9f8712695c03eabe9ed3fbca0feff0152f33f12593e5a6303cb1a4"
 dependencies = [
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.10"
+version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37493cadf42a2a939ed404698ded7fb378bf301b5011f973361779a3a74f8c93"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.0",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2853738d1cc4f2da3a225c18ec6c3721abb31961096e9dbf5ab35fa88b19cfdb"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -6882,20 +6887,14 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags",
 ]
 
 [[package]]
-name = "write16"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
-
-[[package]]
 name = "writeable"
-version = "0.5.5"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
 
 [[package]]
 name = "wslpath"
@@ -6957,9 +6956,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.7.5"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
+checksum = "5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -6969,9 +6968,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.7.5"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
+checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6981,31 +6980,11 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
-dependencies = [
- "zerocopy-derive 0.7.35",
-]
-
-[[package]]
-name = "zerocopy"
 version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
 dependencies = [
- "zerocopy-derive 0.8.25",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
+ "zerocopy-derive",
 ]
 
 [[package]]
@@ -7061,10 +7040,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "zerovec"
-version = "0.10.4"
+name = "zerotrie"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
+checksum = "36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a05eb080e015ba39cc9e23bbe5e7fb04d5fb040350f99f34e338d5fdd294428"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -7073,9 +7063,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.10.3"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
+checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ async-channel = "2.3.1"
 async-trait = "0.1.83"
 axum = { version = "0.8.1", features = ["macros"] }
 axum-extra = "0.10.0"
-bytes = "1.9.0"
+bytes = "1.10.0"
 candid = "0.10.10"
 clap = { version = "4.5.20", features = ["derive", "string", "env"] }
 clickhouse = { version = "0.13.1", features = [
@@ -22,7 +22,7 @@ clickhouse = { version = "0.13.1", features = [
     "inserter",
     "rustls-tls-ring",
     "rustls-tls-webpki-roots",
-] }
+], optional = true }
 console-subscriber = { version = "0.4.1", optional = true }
 ctrlc = { version = "3.4.5", features = ["termination"] }
 derive-new = "0.7.0"
@@ -39,7 +39,7 @@ hostname = "0.4.0"
 http = "1.3.1"
 http-body = "1.0.1"
 http-body-util = "0.1.2"
-humantime = "2.1.0"
+humantime = "2.2.0"
 ic-agent = { version = "0.40.0", features = [
     "ring",
     "_internal_dynamic-routing",
@@ -72,14 +72,14 @@ rustls = { version = "0.23.18", default-features = false, features = [
 serde = "1.0.214"
 serde_cbor = { version = "0.11.2", optional = true }
 serde_json = "1.0.132"
-sev = "6.0.0"
+sev = "6.1.0"
 sha2 = "0.10.8"
 strum = { version = "0.27.1", features = ["derive"] }
 thiserror = "2.0.3"
 tikv-jemallocator = "0.6.0"
 tikv-jemalloc-ctl = { version = "0.6.0", features = ["stats"] }
 time = { version = "0.3.36", features = ["macros", "serde"] }
-tokio = { version = "1.44.0", features = ["full", "tracing"] }
+tokio = { version = "1.45.0", features = ["full", "tracing"] }
 tokio-util = { version = "0.7.12", features = ["full"] }
 tower = { version = "0.5.1", features = ["limit"] }
 tower_governor = { version = "0.7" }
@@ -98,6 +98,7 @@ x509-parser = "0.17.0"
 zstd = "0.13.2"
 
 [features]
+clickhouse = ["dep:clickhouse"]
 bench = ["dep:ic-http-certification", "dep:rand_regex", "dep:serde_cbor"]
 tokio_console = ["console-subscriber"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,7 +113,7 @@ ic-certified-assets = { git = "https://github.com/dfinity/sdk.git", rev = "d6571
 ic-http-certification = "3.0.3"
 ic-transport-types = "0.40.0"
 mockall = "0.13.0"
-nix = "0.29.0"
+nix = { version = "0.30.0", features = ["signal"] }
 pocket-ic = "7.0.0"
 rand_regex = "0.17.0"
 serde_cbor = "0.11.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,17 +50,12 @@ ic-agent = { version = "0.40.0", features = [
     "ring",
     "_internal_dynamic-routing",
 ] }
-ic-bn-lib = { git = "https://github.com/dfinity/ic-bn-lib", rev = "5d2046fb74f9c981ab7afa1c9e95d8dd96dac2e1", features = [
+ic-bn-lib = { git = "https://github.com/dfinity/ic-bn-lib", rev = "d973c98ba30882592b4e0798e6dab7b3c651c10b", features = [
     "vector",
 ] }
 ic-http-certification = { version = "3.0.3", optional = true }
 ic-transport-types = "0.40.0"
 ic-http-gateway = "0.3.0"
-# TODO re-export from ic-bn-lib
-instant-acme = { version = "0.7.2", default-features = false, features = [
-    "ring",
-    "hyper-rustls",
-], optional = true }
 itertools = "0.14.0"
 lazy_static = "1.5.0"
 maxminddb = "0.26.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,12 @@ version = "0.2.0"
 description = "HTTP-to-IC gateway"
 edition = "2024"
 
+[features]
+clickhouse = ["dep:clickhouse"]
+acme = ["ic-bn-lib/acme_dns", "ic-bn-lib/acme_alpn"]
+bench = ["ic-http-certification", "rand_regex", "serde_cbor"]
+tokio_console = ["console-subscriber"]
+
 [dependencies]
 ahash = "0.8.11"
 anyhow = "1.0.93"
@@ -44,10 +50,17 @@ ic-agent = { version = "0.40.0", features = [
     "ring",
     "_internal_dynamic-routing",
 ] }
-ic-bn-lib = { git = "https://github.com/dfinity/ic-bn-lib", rev = "777a5fa779eb0f1ade616127dd97fc0846fb49ee" }
+ic-bn-lib = { git = "https://github.com/dfinity/ic-bn-lib", rev = "5d2046fb74f9c981ab7afa1c9e95d8dd96dac2e1", features = [
+    "vector",
+] }
 ic-http-certification = { version = "3.0.3", optional = true }
 ic-transport-types = "0.40.0"
 ic-http-gateway = "0.3.0"
+# TODO re-export from ic-bn-lib
+instant-acme = { version = "0.7.2", default-features = false, features = [
+    "ring",
+    "hyper-rustls",
+], optional = true }
 itertools = "0.14.0"
 lazy_static = "1.5.0"
 maxminddb = "0.26.0"
@@ -96,11 +109,6 @@ url = "2.5.3"
 uuid = { version = "1.16.0", features = ["v7"] }
 x509-parser = "0.17.0"
 zstd = "0.13.2"
-
-[features]
-clickhouse = ["dep:clickhouse"]
-bench = ["dep:ic-http-certification", "dep:rand_regex", "dep:serde_cbor"]
-tokio_console = ["console-subscriber"]
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports", "async_tokio"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,3 +136,7 @@ harness = false
 [[bench]]
 name = "vector"
 harness = false
+
+[[bench]]
+name = "http_gateway"
+harness = false

--- a/benches/http_gateway.rs
+++ b/benches/http_gateway.rs
@@ -1,0 +1,243 @@
+use std::{sync::Arc, time::Duration};
+
+use async_trait::async_trait;
+use axum::{Extension, extract::State};
+use bytes::Bytes;
+use candid::{CandidType, Encode};
+use criterion::{Criterion, Throughput, criterion_group, criterion_main};
+use fqdn::fqdn;
+use http::{
+    HeaderValue,
+    header::{
+        ACCEPT, ACCEPT_ENCODING, ACCEPT_LANGUAGE, ACCESS_CONTROL_REQUEST_HEADERS,
+        ACCESS_CONTROL_REQUEST_METHOD, ORIGIN, USER_AGENT,
+    },
+};
+use ic_agent::{
+    AgentError,
+    agent::{HttpService, route_provider::RoundRobinRouteProvider},
+};
+use ic_bn_lib::http::{ConnInfo, body::buffer_body};
+use ic_http_certification::HttpRequest;
+use ic_http_gateway::{CanisterRequest, HttpGatewayClientBuilder};
+use reqwest::{Request, Response};
+use uuid::Uuid;
+
+use ic_gateway::{
+    principal,
+    routing::{
+        CanisterId, RequestCtx, RequestType,
+        domain::Domain,
+        ic::handler::{HandlerState, handler},
+        middleware::request_id::RequestId,
+    },
+    test::generate_response,
+};
+
+#[derive(Debug, Clone, CandidType)]
+struct HttpRequestCandid<'a, H> {
+    /// The HTTP method string.
+    pub method: &'a str,
+    /// The URL that was visited.
+    pub url: &'a str,
+    /// The request headers.
+    pub headers: H,
+    /// The request body.
+    pub body: &'a [u8],
+    /// The certificate version.
+    pub certificate_version: Option<&'a u16>,
+}
+
+fn convert_request(request: CanisterRequest) -> HttpRequest<'static> {
+    let uri = request.uri();
+    let mut url = uri.path().to_string();
+    if let Some(query) = uri.query() {
+        url.push('?');
+        url.push_str(query);
+    }
+
+    HttpRequest::builder()
+        .with_method(request.method().clone())
+        .with_url(url)
+        .with_headers(
+            request
+                .headers()
+                .into_iter()
+                .map(|(name, value)| (name.to_string(), value.to_str().unwrap().to_string()))
+                .collect::<Vec<_>>(),
+        )
+        .with_body(request.body().to_vec())
+        .build()
+}
+
+fn encode_request(request: CanisterRequest) {
+    let req = convert_request(request);
+    let certificate_version = req.certificate_version();
+
+    let req = HttpRequestCandid {
+        method: req.method().as_ref(),
+        url: req.url(),
+        headers: req.headers(),
+        body: req.body(),
+        certificate_version: certificate_version.as_ref(),
+    };
+
+    let _ = Encode!(&req);
+}
+
+#[derive(Debug)]
+pub struct TestService;
+
+#[async_trait]
+impl HttpService for TestService {
+    async fn call<'a>(
+        &'a self,
+        _: &'a (dyn Fn() -> Result<Request, AgentError> + Send + Sync),
+        _: usize,
+    ) -> Result<Response, AgentError> {
+        Ok(generate_response(512))
+    }
+}
+
+fn add_headers<T>(req: &mut http::Request<T>) {
+    req.extensions_mut()
+        .insert(CanisterId(principal!("qoctq-giaaa-aaaaa-aaaea-cai")));
+
+    req.headers_mut().insert(USER_AGENT, HeaderValue::from_static("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36"));
+    req.headers_mut()
+        .insert(ACCEPT, HeaderValue::from_static("*/*"));
+    req.headers_mut().insert(
+        ACCEPT_LANGUAGE,
+        HeaderValue::from_static("en-US,en-GB;q=0.9,en;q=0.8,ru;q=0.7,de;q=0.6"),
+    );
+    req.headers_mut().insert(
+        ACCEPT_ENCODING,
+        HeaderValue::from_static("zip, deflate, br, zstd"),
+    );
+    req.headers_mut().insert(
+        ACCESS_CONTROL_REQUEST_HEADERS,
+        HeaderValue::from_static("content-type"),
+    );
+    req.headers_mut().insert(
+        ACCESS_CONTROL_REQUEST_METHOD,
+        HeaderValue::from_static("POST"),
+    );
+    req.headers_mut()
+        .insert(ORIGIN, HeaderValue::from_static("https://nns.ic0.app"));
+}
+
+fn create_request() -> axum::extract::Request {
+    let mut req = axum::extract::Request::new(axum::body::Body::from("X".repeat(512)));
+    add_headers(&mut req);
+    req
+}
+
+fn create_request_bytes() -> http::Request<Bytes> {
+    let mut req = http::Request::new(Bytes::from("X".repeat(512)));
+    add_headers(&mut req);
+    req
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("http_gateway");
+    group.throughput(Throughput::Elements(1));
+    group.significance_level(0.1);
+    group.sample_size(250);
+
+    rustls::crypto::ring::default_provider()
+        .install_default()
+        .unwrap();
+
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+
+    let http_service = Arc::new(TestService);
+
+    let agent = ic_agent::Agent::builder()
+        .with_arc_http_middleware(http_service)
+        .with_max_concurrent_requests(200000)
+        .with_route_provider(RoundRobinRouteProvider::new(vec!["http://foo.bar"]).unwrap())
+        .with_verify_query_signatures(false)
+        .build()
+        .unwrap();
+
+    let client = HttpGatewayClientBuilder::new()
+        .with_agent(agent)
+        .build()
+        .unwrap();
+    let state = Arc::new(HandlerState::new(
+        client,
+        false,
+        Duration::from_secs(60),
+        10 * 1024 * 1024,
+    ));
+
+    let ctx = Arc::new(RequestCtx {
+        authority: fqdn!("foo"),
+        domain: Domain {
+            name: fqdn!("foo"),
+            custom: false,
+            http: false,
+            api: false,
+        },
+        verify: false,
+        request_type: RequestType::Http,
+    });
+    let request_id = RequestId(Uuid::now_v7());
+    let canister_id = CanisterId(principal!("qoctq-giaaa-aaaaa-aaaea-cai"));
+    let conn_info = Arc::new(ConnInfo::default());
+
+    let mut req = axum::extract::Request::new(axum::body::Body::from("foobar"));
+    req.extensions_mut().insert(canister_id);
+
+    runtime.block_on(async {
+        let r = handler(
+            State(state.clone()),
+            Extension(conn_info.clone()),
+            Extension(request_id.clone()),
+            Extension(ctx.clone()),
+            req,
+        )
+        .await
+        .unwrap();
+
+        // Make sure we get the correct body
+        let body = buffer_body(r.into_body(), 100000, Duration::from_secs(10))
+            .await
+            .unwrap();
+        assert_eq!(body, "X".repeat(512));
+    });
+
+    group.bench_function("handler", |b| {
+        b.to_async(&runtime).iter_batched(
+            || create_request(),
+            |req| async {
+                handler(
+                    State(state.clone()),
+                    Extension(conn_info.clone()),
+                    Extension(request_id.clone()),
+                    Extension(ctx.clone()),
+                    req,
+                )
+                .await
+                .unwrap();
+            },
+            criterion::BatchSize::SmallInput,
+        )
+    });
+
+    group.bench_function("request_encode", |b| {
+        b.iter_batched(
+            || create_request_bytes(),
+            |r| {
+                encode_request(r);
+            },
+            criterion::BatchSize::SmallInput,
+        )
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -62,5 +62,5 @@ log "Asset canister WASM downloaded"
 export ASSET_CANISTER_DIR="${CANISTER_DIR}"
 
 log "Running all tests"
-cargo test --profile dev --workspace -- --nocapture || { log "Tests failed"; exit 1; }
+cargo test --all-features --profile dev --workspace -- --nocapture || { log "Tests failed"; exit 1; }
 log "All tests completed successfully"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -9,13 +9,14 @@ use clap::{Args, Parser};
 use fqdn::FQDN;
 use hickory_resolver::config::CLOUDFLARE_IPS;
 use humantime::parse_duration;
+#[cfg(feature = "acme")]
+use ic_bn_lib::tls::acme;
 use ic_bn_lib::{
     http::{
         self,
         shed::cli::{ShedSharded, ShedSystem},
     },
     parse_size, parse_size_decimal, parse_size_decimal_usize, parse_size_usize,
-    tls::acme,
 };
 use reqwest::Url;
 
@@ -62,6 +63,7 @@ pub struct Cli {
     #[command(flatten, next_help_heading = "Load")]
     pub load: Load,
 
+    #[cfg(feature = "acme")]
     #[command(flatten, next_help_heading = "ACME")]
     pub acme: Acme,
 
@@ -300,6 +302,7 @@ pub struct Policy {
     pub policy_denylist_poll_interval: Duration,
 }
 
+#[cfg(feature = "acme")]
 #[derive(Args)]
 pub struct Acme {
     /// If specified we'll try to obtain the certificate that is valid for all served domains using given ACME challenge.
@@ -389,6 +392,7 @@ pub struct Log {
     #[clap(env, long)]
     pub log_requests: bool,
 
+    #[cfg(feature = "clickhouse")]
     #[command(flatten, next_help_heading = "Clickhouse")]
     pub clickhouse: Clickhouse,
 
@@ -396,6 +400,7 @@ pub struct Log {
     pub vector: Vector,
 }
 
+#[cfg(feature = "clickhouse")]
 #[derive(Args, Clone)]
 pub struct Clickhouse {
     /// Setting this enables logging of HTTP requests to Clickhouse DB

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -90,7 +90,7 @@ pub struct Cli {
 #[derive(Args)]
 pub struct Network {
     /// Number of HTTP clients to create to spread the load over
-    #[clap(env, long, default_value = "16", value_parser = clap::value_parser!(u16).range(1..))]
+    #[clap(env, long, default_value = "4", value_parser = clap::value_parser!(u16).range(1..))]
     pub network_http_client_count: u16,
 
     /// Bypass verification of TLS certificates for all outgoing requests.
@@ -149,7 +149,8 @@ pub struct Ic {
     #[clap(env, long)]
     pub ic_use_k_top_api_nodes: Option<usize>,
 
-    /// Path to an IC root key. Must be DER-encoded. If not specified - hardcoded or fetched (see ic_root_key_fetch_unsafe) will be used.
+    /// Path to an IC root key. Must be DER-encoded.
+    /// If not specified - hardcoded or fetched (see `--ic-unsafe-root-key-fetch`) will be used.
     #[clap(env, long)]
     pub ic_root_key: Option<PathBuf>,
 
@@ -157,11 +158,11 @@ pub struct Ic {
     /// Unsafe, should be used only in test environments.
     /// If `ic_root_key` is specified then this option is ignored.
     #[clap(env, long)]
-    pub ic_root_key_fetch_unsafe: bool,
+    pub ic_unsafe_root_key_fetch: bool,
 
     /// Maximum number of request retries for connection failures and HTTP code 429.
     /// First attempt is not counted.
-    #[clap(env, long, default_value = "5")]
+    #[clap(env, long, default_value = "4")]
     pub ic_request_retries: usize,
 
     /// How long to wait between retries.
@@ -195,7 +196,8 @@ pub struct Ic {
 
 #[derive(Args)]
 pub struct Cert {
-    /// Read certificates from given directories, each certificate should be a pair .pem + .key files with the same base name
+    /// Read certificates from given directories
+    /// Each certificate should be a pair .pem + .key files with the same base name.
     #[clap(env, long, value_delimiter = ',')]
     pub cert_provider_dir: Vec<PathBuf>,
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -218,9 +218,9 @@ pub struct Cert {
     #[clap(env, long)]
     pub cert_default: Option<FQDN>,
 
-    /// Disable OCSP stapling
+    /// Enable OCSP stapling. Be advised that LetsEncrypt no longer supports it.
     #[clap(env, long)]
-    pub cert_ocsp_stapling_disable: bool,
+    pub cert_ocsp_stapling_enable: bool,
 }
 
 #[derive(Args)]

--- a/src/core.rs
+++ b/src/core.rs
@@ -101,6 +101,7 @@ pub async fn main(cli: &Cli) -> Result<(), Error> {
     let reqwest_client = bnhttp::client::clients_reqwest::new(http_client_opts)?;
 
     // Event sinks
+    #[cfg(feature = "clickhouse")]
     let clickhouse = if cli.log.clickhouse.log_clickhouse_url.is_some() {
         Some(Arc::new(
             metrics::Clickhouse::new(&cli.log.clickhouse).context("unable to init Clickhouse")?,
@@ -172,6 +173,7 @@ pub async fn main(cli: &Cli) -> Result<(), Error> {
         http_client.clone(),
         Arc::clone(&route_provider),
         &registry,
+        #[cfg(feature = "clickhouse")]
         clickhouse.clone(),
         vector.clone(),
     )?;
@@ -247,6 +249,7 @@ pub async fn main(cli: &Cli) -> Result<(), Error> {
     tasks.stop().await;
 
     // Clickhouse/Vector should stop last to ensure that all requests are finished & flushed
+    #[cfg(feature = "clickhouse")]
     if let Some(v) = clickhouse {
         v.stop().await;
     }

--- a/src/core.rs
+++ b/src/core.rs
@@ -202,7 +202,9 @@ pub async fn main(cli: &Cli) -> Result<(), Error> {
         let rustls_cfg = tls::setup(
             cli,
             &mut tasks,
+            #[cfg(feature = "acme")]
             domains.clone(),
+            #[cfg(feature = "acme")]
             Arc::new(dns_resolver),
             issuer_certificate_providers,
             &registry,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,9 @@ pub mod test;
 mod tls;
 
 pub use crate::cli::Cli;
-pub use metrics::{Clickhouse, Vector};
+pub use metrics::Vector;
+#[cfg(feature = "clickhouse")]
+pub use metrics::clickhouse::Clickhouse;
 pub use routing::domain::ProvidesCustomDomains;
 
 pub use core::main;

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "clickhouse")]
 pub mod clickhouse;
 pub mod runner;
 pub mod vector;
@@ -31,6 +32,7 @@ use prometheus::{
     register_int_counter_vec_with_registry,
 };
 use serde_json::json;
+use time::OffsetDateTime;
 use tower_http::compression::CompressionLayer;
 use tracing::info;
 
@@ -44,10 +46,10 @@ use crate::{
     },
 };
 
-pub use {
-    clickhouse::{Clickhouse, Row},
-    vector::Vector,
-};
+#[cfg(feature = "clickhouse")]
+use clickhouse::{Clickhouse, Row};
+
+pub use vector::Vector;
 
 const KB: f64 = 1024.0;
 
@@ -90,6 +92,7 @@ pub struct HttpMetrics {
     pub request_size: HistogramVec,
     pub response_size: HistogramVec,
 
+    #[cfg(feature = "clickhouse")]
     pub clickhouse: Option<Arc<Clickhouse>>,
     pub vector: Option<Arc<Vector>>,
 }
@@ -98,7 +101,7 @@ impl HttpMetrics {
     pub fn new(
         registry: &Registry,
         log_requests: bool,
-        clickhouse: Option<Arc<Clickhouse>>,
+        #[cfg(feature = "clickhouse")] clickhouse: Option<Arc<Clickhouse>>,
         vector: Option<Arc<Vector>>,
     ) -> Self {
         const LABELS_HTTP: &[&str] = &[
@@ -115,6 +118,7 @@ impl HttpMetrics {
 
         Self {
             log_requests,
+            #[cfg(feature = "clickhouse")]
             clickhouse,
             vector,
 
@@ -214,7 +218,7 @@ pub async fn middleware(
 
     // Execute the request
     let start = Instant::now();
-    let timestamp = time::OffsetDateTime::now_utc();
+    let timestamp = OffsetDateTime::now_utc();
     let mut response = next.run(request).await;
     let duration = start.elapsed();
 
@@ -385,6 +389,7 @@ pub async fn middleware(
             );
         }
 
+        #[cfg(feature = "clickhouse")]
         if let Some(v) = &state.clickhouse {
             let resp_meta = resp_meta.clone();
 

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -47,7 +47,7 @@ use crate::{
 };
 
 #[cfg(feature = "clickhouse")]
-use clickhouse::{Clickhouse, Row};
+pub use clickhouse::{Clickhouse, Row};
 
 pub use vector::Vector;
 

--- a/src/routing/mod.rs
+++ b/src/routing/mod.rs
@@ -48,11 +48,14 @@ use tracing::warn;
 
 use crate::{
     cli::Cli,
-    metrics::{self, Vector, clickhouse::Clickhouse},
+    metrics::{self, Vector},
     routing::middleware::{
         canister_match, cors, geoip, headers, rate_limiter, request_id, request_type, validate,
     },
 };
+
+#[cfg(feature = "clickhouse")]
+use crate::metrics::clickhouse::Clickhouse;
 
 use self::middleware::denylist;
 
@@ -185,7 +188,7 @@ pub fn setup_router(
     http_client: Arc<dyn Client>,
     route_provider: Arc<dyn RouteProvider>,
     registry: &Registry,
-    clickhouse: Option<Arc<Clickhouse>>,
+    #[cfg(feature = "clickhouse")] clickhouse: Option<Arc<Clickhouse>>,
     vector: Option<Arc<Vector>>,
 ) -> Result<Router, Error> {
     let custom_domain_storage = Arc::new(CustomDomainStorage::new(custom_domain_providers));
@@ -265,6 +268,7 @@ pub fn setup_router(
     let metrics_state = Arc::new(metrics::HttpMetrics::new(
         registry,
         cli.log.log_requests,
+        #[cfg(feature = "clickhouse")]
         clickhouse,
         vector,
     ));

--- a/src/test.rs
+++ b/src/test.rs
@@ -120,6 +120,7 @@ pub fn setup_test_router(tasks: &mut TaskManager) -> (Router, Vec<String>) {
         http_client,
         Arc::new(route_provider),
         &Registry::new(),
+        #[cfg(feature = "clickhouse")]
         None,
         None,
     )

--- a/src/test.rs
+++ b/src/test.rs
@@ -8,11 +8,11 @@ use clap::Parser;
 use fqdn::fqdn;
 use http::{
     StatusCode,
-    header::{ACCESS_CONTROL_ALLOW_ORIGIN, CONTENT_LENGTH, CONTENT_TYPE},
+    header::{CONTENT_LENGTH, CONTENT_TYPE},
 };
 use ic_agent::agent::route_provider::RoundRobinRouteProvider;
 use ic_bn_lib::tasks::TaskManager;
-use ic_http_certification::{HttpResponse, StatusCode as HttpCertificationStatusCode};
+use ic_http_certification::HttpResponse;
 use ic_transport_types::{QueryResponse, ReplyResponse};
 use prometheus::Registry;
 use rand::{Rng, thread_rng};
@@ -36,12 +36,10 @@ impl ProvidesCustomDomains for FakeDomainProvider {
     }
 }
 
-fn generate_response(response_size: usize) -> reqwest::Response {
+pub fn generate_response(response_size: usize) -> reqwest::Response {
     let response = HttpResponse::builder()
-        .with_status_code(HttpCertificationStatusCode::OK)
-        .with_headers(vec![("Content-Type".into(), "text/plain".into())])
+        .with_headers(vec![(CONTENT_TYPE.to_string(), "text/plain".into())])
         .with_body(b"X".repeat(response_size))
-        .with_upgrade(false)
         .build();
 
     let response_body = Encode!(&response).unwrap();
@@ -57,7 +55,6 @@ fn generate_response(response_size: usize) -> reqwest::Response {
         .status(StatusCode::OK)
         .header(CONTENT_TYPE, "application/cbor")
         .header(CONTENT_LENGTH, content_length)
-        .header(ACCESS_CONTROL_ALLOW_ORIGIN, "*")
         .body(cbor_data)
         .expect("Failed to build response")
         .try_into()
@@ -65,12 +62,12 @@ fn generate_response(response_size: usize) -> reqwest::Response {
 }
 
 #[derive(Debug)]
-struct TestClient;
+struct TestClient(pub usize);
 
 #[async_trait]
 impl ic_bn_lib::http::Client for TestClient {
     async fn execute(&self, _req: reqwest::Request) -> Result<reqwest::Response, reqwest::Error> {
-        Ok(generate_response(512))
+        Ok(generate_response(self.0))
     }
 }
 
@@ -113,7 +110,7 @@ pub fn setup_test_router(tasks: &mut TaskManager) -> (Router, Vec<String>) {
         })
         .collect::<Vec<_>>();
 
-    let http_client = Arc::new(TestClient);
+    let http_client = Arc::new(TestClient(512));
     let route_provider = RoundRobinRouteProvider::new(vec!["http://foo"]).unwrap();
 
     let router = setup_router(

--- a/src/tls/mod.rs
+++ b/src/tls/mod.rs
@@ -24,9 +24,9 @@ use {
             self, AcmeOptions, Challenge,
             acme::Acme,
             dns::{AcmeDns, DnsBackend, DnsManager, TokenManagerDns},
+            instant_acme::ChallengeType,
         },
     },
-    instant_acme::ChallengeType,
     std::{fs, time::Duration},
 };
 

--- a/src/tls/mod.rs
+++ b/src/tls/mod.rs
@@ -155,7 +155,7 @@ pub async fn setup(
 
     // Optionally wrap resolver with OCSP stapler
     let certificate_resolver: Arc<dyn ResolvesServerCertRustls> =
-        if cli.cert.cert_ocsp_stapling_disable {
+        if !cli.cert.cert_ocsp_stapling_enable {
             certificate_resolver
         } else {
             let stapler = Arc::new(Stapler::new_with_registry(certificate_resolver, registry));

--- a/src/tls/mod.rs
+++ b/src/tls/mod.rs
@@ -1,28 +1,34 @@
 pub mod cert;
 pub mod resolver;
 
-use std::{fs, sync::Arc, time::Duration};
+use std::sync::Arc;
 
-use anyhow::{Context, Error, anyhow, bail};
+use anyhow::{Error, bail};
 use async_trait::async_trait;
-use fqdn::FQDN;
 use ic_bn_lib::{
-    http::{ALPN_ACME, dns::Resolves},
     tasks::{Run, TaskManager},
-    tls::{
-        self,
-        acme::{
-            self, Acme, AcmeOptions, Challenge,
-            dns::{AcmeDns, DnsBackend, DnsManager, TokenManagerDns},
-            instant_acme::ChallengeType,
-        },
-        prepare_server_config,
-    },
+    tls::{self, prepare_server_config},
 };
 use ocsp_stapler::Stapler;
 use prometheus::Registry;
 use rustls::server::{ResolvesServerCert as ResolvesServerCertRustls, ServerConfig};
 use tokio_util::sync::CancellationToken;
+
+#[cfg(feature = "acme")]
+use {
+    anyhow::{Context, anyhow},
+    fqdn::FQDN,
+    ic_bn_lib::{
+        http::{ALPN_ACME, dns::Resolves},
+        tls::acme::{
+            self, AcmeOptions, Challenge,
+            acme::Acme,
+            dns::{AcmeDns, DnsBackend, DnsManager, TokenManagerDns},
+        },
+    },
+    instant_acme::ChallengeType,
+    std::{fs, time::Duration},
+};
 
 use crate::{
     cli::Cli,
@@ -46,6 +52,7 @@ impl Run for OcspStaplerWrapper {
     }
 }
 
+#[cfg(feature = "acme")]
 async fn setup_acme(
     cli: &Cli,
     tasks: &mut TaskManager,
@@ -106,8 +113,8 @@ async fn setup_acme(
 pub async fn setup(
     cli: &Cli,
     tasks: &mut TaskManager,
-    domains: Vec<FQDN>,
-    dns_resolver: Arc<dyn Resolves>,
+    #[cfg(feature = "acme")] domains: Vec<FQDN>,
+    #[cfg(feature = "acme")] dns_resolver: Arc<dyn Resolves>,
     custom_domain_providers: Vec<Arc<dyn ProvidesCertificates>>,
     registry: &Registry,
 ) -> Result<ServerConfig, Error> {
@@ -128,14 +135,24 @@ pub async fn setup(
     cert_providers.extend(custom_domain_providers);
 
     // Prepare ACME if configured
+    #[cfg(feature = "acme")]
     let acme_resolver = if let Some(v) = &cli.acme.acme_challenge {
         Some(setup_acme(cli, tasks, domains, v, dns_resolver).await?)
     } else {
         None
     };
 
-    if acme_resolver.is_none() && cert_providers.is_empty() {
-        bail!("No ACME or certificate providers specified - HTTPS cannot be used");
+    #[cfg(feature = "acme")]
+    {
+        if acme_resolver.is_none() && cert_providers.is_empty() {
+            bail!("No ACME or certificate providers specified - HTTPS cannot be used");
+        }
+    }
+    #[cfg(not(feature = "acme"))]
+    {
+        if cert_providers.is_empty() {
+            bail!("No certificate providers specified - HTTPS cannot be used");
+        }
     }
 
     // Create certificate aggregator that combines all providers
@@ -148,7 +165,10 @@ pub async fn setup(
 
     // Set up certificate resolver
     let certificate_resolver = Arc::new(AggregatingResolver::new(
+        #[cfg(feature = "acme")]
         acme_resolver,
+        #[cfg(not(feature = "acme"))]
+        None,
         vec![cert_storage],
         resolver::Metrics::new(registry),
     ));
@@ -168,11 +188,15 @@ pub async fn setup(
 
     let mut tls_opts: tls::Options = (&cli.http_server).into();
     tls_opts.tls_versions = vec![&rustls::version::TLS13, &rustls::version::TLS12];
-    tls_opts.additional_alpn = if cli.acme.acme_challenge == Some(Challenge::Alpn) {
-        vec![ALPN_ACME.to_vec()]
-    } else {
-        vec![vec![]]
-    };
+
+    #[cfg(feature = "acme")]
+    {
+        tls_opts.additional_alpn = if cli.acme.acme_challenge == Some(Challenge::Alpn) {
+            vec![ALPN_ACME.to_vec()]
+        } else {
+            vec![vec![]]
+        };
+    }
 
     // Generate Rustls config
     let config = prepare_server_config(tls_opts, certificate_resolver, registry);

--- a/unit-tests.sh
+++ b/unit-tests.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-cargo test -- --skip all_intergration_tests
+cargo test --all-features -- --skip all_intergration_tests


### PR DESCRIPTION
* Adds `http_gateway` benchmark to measure the `ic-agent` + `ic-http-gateway` + others performance
* Lowers the default number of HTTP clients to 4 since we raised the HTTP2 streams on API BNs
* Disable OCSP by default
* Make Clickhouse logging optional (hidden under a feature) since we don't use it currently (only Vector)
* Run release build on DFINITY runners to speed it up (hope it works)
* Misc changes