### PR TITLE
fix: inject host header if HTTP2 is used

### DIFF
--- a/src/routing/ic/handler.rs
+++ b/src/routing/ic/handler.rs
@@ -63,7 +63,8 @@ pub async fn handler(
     // Inject Host header into inner HTTP request.
     // HTTP2 lacks it, but canisters might expect it to be present.
     if parts.headers.get(HOST).is_none() {
-        if let Ok(v) = HeaderValue::from_bytes(ctx.authority.as_bytes()) {
+        let host = ctx.authority.to_string();
+        if let Ok(v) = HeaderValue::from_str(&host) {
             parts.headers.insert(HOST, v);
         }
     }


### PR DESCRIPTION
The error didn't manifest itself because I was not forcing `curl` to only use HTTP2 and it fell back to HTTP1.1. With HTTPS, it was forced to use HTTP2. The issue is that the FQDN contains "invisible" ASCII chars, while `HeaderValue::from_bytes` only accepts visible ones. My naive workaround is to go via a String.

Example:
* Actual hostname: `s5czn-yiaaa-aaaam-aanbq-cai.gateway.icp`
* FQDN printed to console: `FQDN("\x1bs5czn-yiaaa-aaaam-aanbq-cai\x07gateway\x03icp")`
* Bytes: `[27, 115, 53, 99, 122, 110, 45, 121, 105, 97, 97, 97, 45, 97, 97, 97, 97, 109, 45, 97, 97, 110, 98, 113, 45, 99, 97, 105, 7, 103, 97, 116, 101, 119, 97, 121, 3, 105, 99, 112, 0]`
* Resulting error: `InvalidHeaderValue`