### PR TITLE
Fix CORS reply when there's no canister id

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -863,9 +863,9 @@ checksum = "ade8366b8bd5ba243f0a58f036cc0ca8a2f069cff1a2351ef1cac6b083e16fc0"
 
 [[package]]
 name = "candid"
-version = "0.10.13"
+version = "0.10.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a253bab4a9be502c82332b60cbeee6202ad0692834efeec95fae9f29db33d692"
+checksum = "f9d90f5a1426d0489283a0bd5da9ed406fb3e69597e0d823dcb88a1965bb58d2"
 dependencies = [
  "anyhow",
  "binread",
@@ -904,9 +904,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.22"
+version = "1.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32db95edf998450acc7881c932f94cd9b05c87b4b2599e8bab064753da4acfd1"
+checksum = "5f4ac86a9e5bc1e2b3449ab9d7d3a6a405e3d1bb28d7b9be8614f55846ae3766"
 dependencies = [
  "jobserver",
  "libc",
@@ -2395,9 +2395,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497bbc33a26fdd4af9ed9c70d63f61cf56a938375fbb32df34db9b1cd6d643f2"
+checksum = "cf9f1e950e0d9d1d3c47184416723cf29c0d1f93bd8cccf37e4beb6b44f31710"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -3044,9 +3044,9 @@ checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
 
 [[package]]
 name = "icu_properties"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2549ca8c7241c82f59c80ba2a6f415d931c5b58d24fb8412caa1a1f02c49139a"
+checksum = "016c619c1eeb94efb86809b015c58f479963de65bdb6253345c1a1276f22e32b"
 dependencies = [
  "displaydoc",
  "icu_collections",
@@ -3060,9 +3060,9 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8197e866e47b68f8f7d95249e172903bec06004b18b2937f1095d40a0c57de04"
+checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
 
 [[package]]
 name = "icu_provider"
@@ -6483,15 +6483,15 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
-version = "0.61.1"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46ec44dc15085cea82cf9c78f85a9114c463a369786585ad2882d1ff0b0acf40"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
  "windows-implement",
  "windows-interface",
  "windows-link",
  "windows-result",
- "windows-strings 0.4.1",
+ "windows-strings 0.4.2",
 ]
 
 [[package]]
@@ -6556,9 +6556,9 @@ dependencies = [
 
 [[package]]
 name = "windows-result"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b895b5356fc36103d0f64dd1e94dfa7ac5633f1c9dd6e80fe9ec4adef69e09d"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
  "windows-link",
 ]
@@ -6574,9 +6574,9 @@ dependencies = [
 
 [[package]]
 name = "windows-strings"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a7ab927b2637c19b3dbe0965e75d8f2d30bdd697a1516191cad2ec4df8fb28a"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link",
 ]

--- a/repro-env.lock
+++ b/repro-env.lock
@@ -1,29 +1,29 @@
 [container]
-image = "docker.io/library/archlinux@sha256:95e914e8b16eb07c8660c4352c1530a52dcf829038f1f65233543fee28a78d6a"
+image = "docker.io/library/archlinux@sha256:c0965d07320c79ca2e3a1cc9e303757f6b0055aa0437571523f5eedf78b15690"
 
 [[package]]
 name = "abseil-cpp"
-version = "20250127.1-1"
+version = "20250127.1-2"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/a/abseil-cpp/abseil-cpp-20250127.1-1-x86_64.pkg.tar.zst"
-sha256 = "d3a1fce77ef8f63abeb7055519f74e7e2f2d52471823bead61349983965a7cd9"
-signature = "iQIzBAABCAAdFiEE8AuW0VIoAT/8nJ0Dk7EdqkwZfj0FAmfcdqMACgkQk7EdqkwZfj2sJhAAx7qBTHru8W2S8hLNp1Il8exvwlW1Mo7yE8ssSgoWfSeIDIHTFYgNhPrlnJrHeSjL9hgFoj6vMttDMCs1aMCLXJLZUfpaB7NJl9c3cnFC6XZ14qfz0PH/r5ZUMTRGPpbBfTMmErya8zN2oYwlXXTJTT2LO7+UFZc/bR/OIjqBxqUK+mMed0XMe/bz9JY/Mk5g9gHgNINyOjrlzrZu8XjmeazIstTrW+4Xmj41Bzs4Lv6xzITR1V49xMLtaaIt8lEPcsIRhDSOF2QZ1TsA9ZfhgNAXgSMrJDghySxfut0Fp10aGmhzWKdafbaTEgYz5wlMbfI7CVWYbgcNbF/UdTHlBNL091gmna0Wxo3gIfunoh9q65+Lde8dnEo2FBO8n97aCizEAe7QiG5FW6KznDKFcOnkWh9UIq7UY8BLUTFlRAs5+NtSf9FX0PCSBNf4G35SS7cOe5Mrt5mEFHp+cG5+aR5AsIpjSPRvo/yjX3N4qCWVUHqEGASi2jixtWeIXLc9rqEwnY1AJW3Gh/FOpbzbXIGy1PImRHClj3rFibgw8J/jlADPdKwfY4mdCo8JO2/KcYlRst+AT21l9A8gq1/gGdBAXEQo5M5pAfdLcwdvkCHQFKbjvRX1+kMwb8sJfzRFRSrl4+jFnZkTSqbQnhFXvwMly9nie1QHZKSobcdLTqE="
+url = "https://archive.archlinux.org/packages/a/abseil-cpp/abseil-cpp-20250127.1-2-x86_64.pkg.tar.zst"
+sha256 = "2c8ddc0a1de464dcf946bafe0919a7fd050cced0b36a05d587d57802743f3a70"
+signature = "iQIzBAABCAAdFiEE8AuW0VIoAT/8nJ0Dk7EdqkwZfj0FAmggmkIACgkQk7EdqkwZfj1pHhAAsEwnEGTiKuoaHhazO/0NnACVgZw3+8+4hSPm+MVHxT4u7IeybFvD0WAvFwKx7xFN2aAxqoTq8T0qq3/AKk12m5kmc1mj00iNN0ZkFxrZcVBg0HczXgGjWnU+9mkA6Oh2usQADNQ524uM/FnE16ADdhePXRabe2Ptcl3BCtW49bDZsW0d2eom041dSHNHVRH4NiPYI31REZUZRGXBWNal25U2+pljJaPi8qGu/j7QofGUSt9oBGMDZ1U//ymfO+7noEIMaVAFzOTHyj5OE3mvS8TPNQSOFm2gqfJkNY1GBZLMoz7Ob5IOb0d1k/90YNjOiPxM7V35ZvQMGSMKfpVuhn7ShUKWCBttofaGyPMtsAcbe/r1f8E4olEOpdHrSLqE8dMK8c72rQE5g6QknaCeqlzyFsrx9i8wFheBacr2diKDKC7ogvxY++XZgJsZ43bRKUafu2MIfi93/KvXIc8MYZaOssTc7zE2rlNqMBlwSKfxczdHEmwTmPXAKilfleOBdMHlPO4mvpv0T7ZLb1lO5pR9NsGfVxa/HWu052Drr8kMChWAodzDtBhIjynz0m5uavaUbO/3I4mKTJcGGlESlaT7nbUxG9X7LTzOON+lH32lyrtAQ+OE2JFoIN+fQfpWc3/L4ewlIOdNFXDFohSe4zhXiXR8ra2bUCKrS0TyCcc="
 
 [[package]]
 name = "binutils"
-version = "2.44-1"
+version = "2.44+r94+gfe459e33c676-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/b/binutils/binutils-2.44-1-x86_64.pkg.tar.zst"
-sha256 = "8c14a56397669fefff067ec2c08aeccb944372be4f4cdb6fed0991ca18c4fb02"
-signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCZ6dOK18UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCjeoAP9btSaBFNMd2M64KII1QXneh2x9+xVvLiz3YZ1kbNMknwEA4+KjPA7GZGgq1HWZsjLuTUWzu4M2D6WBXXfH9HLbiQ0="
+url = "https://archive.archlinux.org/packages/b/binutils/binutils-2.44+r94+gfe459e33c676-1-x86_64.pkg.tar.zst"
+sha256 = "dae1c7ad6100da0abf20171879dc1ef9b486f0498260b4d496e526b49287d39c"
+signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCaBB9K18UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCkMbAP0XYt1YCNB0OOe0jkhK7MAH7K0krqEjcFRk6c1pKfslzQEAxb9iCNJi700zsLGLUNduRUsNe2AnZRPeAVefR0/hXww="
 
 [[package]]
 name = "cmake"
-version = "4.0.0-1"
+version = "4.0.2-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/c/cmake/cmake-4.0.0-1-x86_64.pkg.tar.zst"
-sha256 = "a7ba0bb3baeab3d2675d2fa40621e93b4e9f03363e4d8334c4198748d670b912"
-signature = "iQEzBAABCAAdFiEEFRnVq6Zb9vwrc8dWek52CV2KUuQFAmfl1o8ACgkQek52CV2KUuSxigf/anhYH5ssf10BThAsAXdKj6Y4MF3QfWfEn2PTCOHDWsCght2IMW05iFpJkg6qF1bF6dxmTaAyC4mATSYylwqdpKwBjEVHFamR8YP+M8bLt1jphDB9rnTuzkMXLg6B+TGIH1zIvyEfud6Y8cUpyoQ9KyoAER+o/oOEfGDHfCwp/aF44nSqm9+NVkEUt/UbYL0rGdl2lpp7KYTAI89N2WTYfwaZf2p0NwhHTzrrb1alqpQtwAcZ4M4SGK1PpA9foG4OrGNgZCV4jkRAAZeTfyxHaW4D7S6Zkw+DWnhc3MKAADLYGLaRrxyGW3ZxOFSSfVPymgOxb89onJbUzo8yMFqFgw=="
+url = "https://archive.archlinux.org/packages/c/cmake/cmake-4.0.2-1-x86_64.pkg.tar.zst"
+sha256 = "23ada670edf3dad3aff6902b708149dd09c793b75d42a7be43b275e9150c9f14"
+signature = "iQEzBAABCAAdFiEEFRnVq6Zb9vwrc8dWek52CV2KUuQFAmgdIFoACgkQek52CV2KUuSSbAf6A2kUNQKczCcmnZpe5CcxGxEUYLzwdiEp6wFC75TFFoJVVrTEFWaRmYxHdcwZpCY+WLtqsunqSsIWoKIFZylaX/HOXK2wXcVsR/1EYZnYOk/PA6CLy7Cv+qK82y/D5FMyzz6dsxRKo6D2yG0qoTwbdeqo7AFEibFTI8c8N/fwlySPVZ+WPhtOw/QUlDFo80+M8Wyd0wsa16Ds0rUzoddQPdX+PUiFd2sM4pWbZuQyYNWR4C0X0MsUUVgBlhoLEh+4Hi74HivWXMcS8Ljl4F5s07MHx2sZOEPiZsXkuCzizZ8k9cJAKiwhPAkKQmqsLDdi1mP6WoLE/UAgDxkH2jNj1g=="
 
 [[package]]
 name = "cppdap"
@@ -43,19 +43,27 @@ signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCZt6oQl8UgAAAAAAuAChpc3N
 
 [[package]]
 name = "gcc"
-version = "14.2.1+r753+g1cd744a6828f-1"
+version = "15.1.1+r7+gf36ec88aa85a-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/g/gcc/gcc-14.2.1+r753+g1cd744a6828f-1-x86_64.pkg.tar.zst"
-sha256 = "2f5d57f8047bd95dc8ca89878e276968e485fec552a1d6222cbe7d4b020e5b8f"
-signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCZ6dOMl8UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCs1BAQDhgm29sxvOmglFqaPf7w14Smqpbd/q83FwqUZX5fyqPwD+Obh+eLgaLHPq2DwHGH8TPoFEHlbMhU82pk2DkvU6qQE="
+url = "https://archive.archlinux.org/packages/g/gcc/gcc-15.1.1+r7+gf36ec88aa85a-1-x86_64.pkg.tar.zst"
+sha256 = "d8bc5c74e9b58c281c0aca51cc3f6b18cff37cdac5d24ea7f67488eeb6caa27a"
+signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCaBB8ql8UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCqOVAP987LpB7oRJy0pLySNFrUb73byPmEw91N/aQFrDX1IrWwD/TTXyyc1ulsVNhoEDk7MKS+NzMAaJX/f1gz2pQFeeCAU="
+
+[[package]]
+name = "gnupg"
+version = "2.4.7-2"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/g/gnupg/gnupg-2.4.7-2-x86_64.pkg.tar.zst"
+sha256 = "8aa9017276cdac3ff06771fb3ddeac822ac1d8a7a149b88b0e30bbeacd049b8a"
+signature = "iHUEABYKAB0WIQRizHP4hOUpV7L92IObeih9mi7GCAUCaCjHnAAKCRCbeih9mi7GCCoyAQDf+iD99CZzeO8hjwosLyA3/DOUIDrwv/MnEXCVPGs5pQEAz0sabha7ulhj1rETlfDwCWYhDkVzWrMLSNFcZZyLnQk="
 
 [[package]]
 name = "gtest"
-version = "1.16.0-2"
+version = "1.17.0-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/g/gtest/gtest-1.16.0-2-x86_64.pkg.tar.zst"
-sha256 = "a0c9593ce6c76ea30f9f91b7b6030c1e3d14c8ad8565ca2cb69cfa1ee57173b4"
-signature = "iHUEABYKAB0WIQTrPXZP9dh+CBij4OXwXowSExrrXgUCZ9GaTgAKCRDwXowSExrrXvD4AQDWbSNdFTNdp3I9WCQy8sLXfICZoFN6gw7wN3euegdNVwEA5czbhR/9ldu4gqIGV+1Sx5Dgig0dxiaKjj6VGQJ06wQ="
+url = "https://archive.archlinux.org/packages/g/gtest/gtest-1.17.0-1-x86_64.pkg.tar.zst"
+sha256 = "e8be39f1917ae843c58128c302e583b0c570df1c8c6106239cec4c84c9b73317"
+signature = "iHUEABYKAB0WIQTrPXZP9dh+CBij4OXwXowSExrrXgUCaCCWOQAKCRDwXowSExrrXn22AP97xO8YH+V5imcJeYLJ3XZIbVh2ylHeuyJfQ5T3htys4AEAnVqyhN9n7oELrWay8yDm9qk3pOi4XH+JI/Sd28N96gQ="
 
 [[package]]
 name = "guile"
@@ -115,19 +123,19 @@ signature = "iQEzBAABCAAdFiEEFRnVq6Zb9vwrc8dWek52CV2KUuQFAmaHCZwACgkQek52CV2KUuR
 
 [[package]]
 name = "libuv"
-version = "1.50.0-1"
+version = "1.51.0-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/l/libuv/libuv-1.50.0-1-x86_64.pkg.tar.zst"
-sha256 = "17eb6461e46288773040d4369f2e62b553d706712e396c2b5f85e1d947c7c082"
-signature = "iHUEABYKAB0WIQRUwf0nM2HqUUojd5Pylr3lA2jGzgUCZ4f+igAKCRDylr3lA2jGzoNLAQDVLLPhyIMpi2uHuysginDBdukF1iofHbYhtVDlXPF5BAEAwRRAflxK7eFkDJi4x6FIu/RGM3U5zuHGy8V3guedBAQ="
+url = "https://archive.archlinux.org/packages/l/libuv/libuv-1.51.0-1-x86_64.pkg.tar.zst"
+sha256 = "4a4e992621b881a221becb6b9669bb4092ffebec8d87bd90f235866356cc5c35"
+signature = "iHUEABYKAB0WIQRUwf0nM2HqUUojd5Pylr3lA2jGzgUCaAuLRwAKCRDylr3lA2jGzrT/AP43Gr5SSjnTzsFRn9PXhiwSxSD9n3wnk+MY0BWz1QKiYwD/XYWd0OVkTq6LSIbIBsmp5msI8fCiYMyVKNBHimfBNAU="
 
 [[package]]
 name = "llvm-libs"
-version = "19.1.7-1"
+version = "19.1.7-2"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/l/llvm-libs/llvm-libs-19.1.7-1-x86_64.pkg.tar.zst"
-sha256 = "44de8dac4c85c2297d8a8b9b4f8a71d422bd2452b6b0f442859f92c5319daad3"
-signature = "iQEzBAABCAAdFiEEhs/8qRjPOvRxR1iAUeixSKmZnDQFAmeLq+kACgkQUeixSKmZnDSQcgf/UE3HidSGyn485QxUdNk6ffxyRMIxQixiaMPVcFQlTCNoC2c3oN/Y9bp5qWN2Oydh5J17nVy6el5mpVzaSFrVA05cFP0eoOIy1RrlC2ko54icSmchRyD1bGHfwBNlurkCU5y1AQqbo+5Exfg31Vj5NsXdDst5E51WfP37/NxZ9holoXk17Lb5vcgQ/GTgmzEWL7Gt+CF5X0AkPCOejBtBrzcSWM2T4s6dGatM45PCTSWHzgLbi9RuZwd2y0jPZPPocvsmxoi1q0KhjteCXWJpn/HpksmiiRNIG1RN9uV7Vp9f0rVEoWaf1VbdzNyXrdoRFxdxg1Nt0en9VrwhMuX4Mg=="
+url = "https://archive.archlinux.org/packages/l/llvm-libs/llvm-libs-19.1.7-2-x86_64.pkg.tar.zst"
+sha256 = "0f5e99321833980a38a7a4ec3a5ea2b0a8110d1f5ef84b947fa0bf3ee1c50328"
+signature = "iQIzBAABCAAdFiEE8AuW0VIoAT/8nJ0Dk7EdqkwZfj0FAmgIIPUACgkQk7EdqkwZfj2V5w//Sr7h17okNamx2nJpVbManLs0rhgyssl3Qp6/lcxiXeH81lD1onTZMYjyDghiFOSrNy/MDPy+x2w3wpsxLB76QfpshRk2YWU8qKGPVtJBrFJ/82CZre+gdmXx1ifxUP/bsBlxCVMah9App3saAlRZvE9AWSRBH3c+eH6+V6dfYUKQ7+AvFguKMyliyugQ7xr79NqfAkoxBE763HGcKjdnZY27nkDl+cDn0fJRxX1aY/fzCbCOZWPYNKiKk8EMIsY8TEVLlqtFpxy29qVjTKFxur6d3+weiU15rgWcgTMHBCUITlmmAY1/8VZ+tLUi1hWyH+oEqG06Oka3wm2eMjzppKwABSYqCyfX7NXrdFHI6p/enJ5ykzToo/Vd/yRHrzGBHf/hWxFX4TyFeEDrXiRe6ncka55rfMz4WHRvMUeluzDeLpSUAPT4ayn+Kz9o0YWmh90sqOS51N6UzydqXMcD8J37tBHyGZk3xqZ39vBnVzQyQ1uFfSOjpvKM9p65t8B5o95JVjH+U1hfNLAwKZXhy8x8hOfqdfIjevs5VzsNwe/ibhd23Bp+cHGHFdHb6w6MSsaA1pQxH6FCgSClOlGVNZ2/yNH6d0c7wd0Y3FC+upLh2xgYLhyHvUBHsS2ShhHORbz3CbDYhrnc2X1BmqmqZ38UkWmrYqcMHNqtXsL7OCg="
 
 [[package]]
 name = "lua"
@@ -155,11 +163,11 @@ signature = "iQIzBAABCAAdFiEEM+u4qOHFZTZFsSMqRaZQ4mOMU20FAmfw+foACgkQRaZQ4mOMU20
 
 [[package]]
 name = "protobuf"
-version = "30.1-1"
+version = "30.2-3"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/p/protobuf/protobuf-30.1-1-x86_64.pkg.tar.zst"
-sha256 = "098c34a8c4b05371d539656bcf1beeece8ff1b4abd768e43472db291ae25dfe3"
-signature = "iQIzBAABCAAdFiEE8AuW0VIoAT/8nJ0Dk7EdqkwZfj0FAmfceE4ACgkQk7EdqkwZfj1R+BAAvDBN2bFpI+94EbYspT/pa0RLSIwPKwkISrnrP6vNmEqPY2bJ47GTgnLzxZPAXFg3joz0CPO3ky++YC8Sjbhl1To4Lq4KkFxDVzKFA+8rUAhq/cx3nuLXsRmGvSynZOacmx8J3djVn4umLjGo2Rp4AZspXZyFTTvvVdfl7aRazKOvT/HNshgkQ6mCZ2tTgoL2yq1oVGWL2yiLLPp+yKjl68jeMRcttzzC1LEFLjX/pVFPos/e2qrGrEpi8F9ue03aVhcMAlR8GNTzqHpXA6MiVdH2/oET0Mb7B0dA7/XjhY3Hu8eJyCrO7xn7i0vYLZHnfjdCv6DfXD0jEI+i9QuceIxO0LGHgZR+WiI7USitCLCWIISq0/whA2FcUfa2Jrs6bYjy5mvR9WRxTKQT128DdbhAjihbhI+FkKrw92zmA3zQbD7scGxZkrYI991ZdUQvSnjjJijTjSs8DukzspwIuGFZejyzRQgRIBUmRcobEDth/qii6gtI6TuEugWqUHuYty8GLrEXCUSJbl83fnFjXq1CZrw8V1fedgtz99M/IlMwQn1QlY/V6OCT01E0GbrOcvGklCVAy29ShoQf3hYQcjq8UZx131VohNCg9SscEuH5ZB/Z1+NJpB1tqaObp8OR/DL7ZNKaG46Yc0evkjIbydLOhS+CNRu07rPePfAWXFY="
+url = "https://archive.archlinux.org/packages/p/protobuf/protobuf-30.2-3-x86_64.pkg.tar.zst"
+sha256 = "382a4ce6224a6f72e6bde84bae6f3100ede25b44c415c1476eb66adbacde0201"
+signature = "iHUEABYKAB0WIQQ4EAwkN2zV9u1P9LRpGEAMJwMEDAUCaCJPkgAKCRBpGEAMJwMEDHYpAQCJGdF08WvLI6b6kaft+MTIOSSycbbwj5+IYolHAyw2FwD/TPrsRLQpbZ7GP7CknCt65g3LhwrvPTKcF7AmofY8ugs="
 
 [[package]]
 name = "rhash"
@@ -171,16 +179,16 @@ signature = "iQTHBAABCgCxFiEE5VD//9SF4mShcX4wkBwcMg6w1F0FAmUt0ElfFIAAAAAALgAoaXN
 
 [[package]]
 name = "rust"
-version = "1:1.86.0-1"
+version = "1:1.87.0-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/r/rust/rust-1:1.86.0-1-x86_64.pkg.tar.zst"
-sha256 = "068e69debc5399f3bca4d2f22e4d18f342e26a4bfc27d75c7a22c46d0994bc4b"
-signature = "iHUEABYKAB0WIQSDvIiJNRtd67toQW64rAhgDxCM3wUCZ+7R1QAKCRC4rAhgDxCM3zazAQCPiiljZzSuOJ3MzuQEX6f+hSdBtqPOvsFhKWXEFUclTgEA4is9meUGm2LOIwaZiS2G5ayBHIc+sE3rbgfzit5I4gI="
+url = "https://archive.archlinux.org/packages/r/rust/rust-1:1.87.0-1-x86_64.pkg.tar.zst"
+sha256 = "e9e0f7eeb47cf43bd5decdd15127cdaaea6b5c8a310cca5556aeddab325a6c66"
+signature = "iHUEABYKAB0WIQSDvIiJNRtd67toQW64rAhgDxCM3wUCaCc9PQAKCRC4rAhgDxCM34ihAP0Z5Wne2SbqaAb+sdFTWCNprBUamGiRA3xILksmX1vdHwEA2H3DhUBRbAI1kfihvFWQvtQkbE/wATBpTtsfM3WwXQM="
 
 [[package]]
 name = "rust-musl"
-version = "1:1.86.0-1"
+version = "1:1.87.0-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/r/rust-musl/rust-musl-1:1.86.0-1-x86_64.pkg.tar.zst"
-sha256 = "d04878119d851114a767dcac9c2d5d9f7f1900f52dd82f61e5131ba28c439e3d"
-signature = "iHUEABYKAB0WIQSDvIiJNRtd67toQW64rAhgDxCM3wUCZ+7R2AAKCRC4rAhgDxCM32UEAP4sGffPU+2aYl+JpXAFUC4WOjzxC4g/hVxgTdO90hiMhQD+NRkoHV0xtteBU3LGJpMquAfAkqoAmyIs0iuLig2XlAE="
+url = "https://archive.archlinux.org/packages/r/rust-musl/rust-musl-1:1.87.0-1-x86_64.pkg.tar.zst"
+sha256 = "8b0e9da166c173d9572d1e713ede64606a01652db4b02a1476a7163df872b18c"
+signature = "iHUEABYKAB0WIQSDvIiJNRtd67toQW64rAhgDxCM3wUCaCc9QAAKCRC4rAhgDxCM39DHAP4w+YUCSrxeesxSTdVWqhHJntA6ydjr6QAfdYaVpAGCVAEA1HTO6uUtrEvdg7fvqxzaoSK1BFWD5O0f0oEIXO0OaQE="

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.86.0"
+channel = "1.87.0"
 targets = ["x86_64-unknown-linux-musl"]
 profile = "default"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -580,7 +580,7 @@ pub struct Cors {
     pub cors_canister_passthrough: bool,
 
     /// Maximum number of canisters to cache that replied incorrectly to the OPTIONS request
-    #[clap(env, long, default_value = "1m", value_parser = parse_size_decimal)]
+    #[clap(env, long, default_value = "10m", value_parser = parse_size_decimal)]
     pub cors_invalid_canisters_max: u64,
 
     /// Timeout for expiring invalid canisters from the cache

--- a/src/policy/denylist.rs
+++ b/src/policy/denylist.rs
@@ -82,7 +82,7 @@ impl Denylist {
 
         // If there's no country code info -> then we don't block by default
         // TODO discuss
-        country_code.is_some_and(|code| entry.iter().any(|x| *x == code.0))
+        country_code.is_some_and(|code| entry.contains(&code.0))
     }
 
     pub async fn update(&self) -> Result<usize, Error> {

--- a/src/routing/error_cause.rs
+++ b/src/routing/error_cause.rs
@@ -306,8 +306,7 @@ impl ErrorClientFacing {
                 let template = template.replace("{status_code}", self.status_code().as_str());
                 let template =
                     template.replace("{reason}", self.to_string().replace("_", " ").as_str());
-                let template = template.replace("{details}", self.details().as_str());
-                template
+                template.replace("{details}", self.details().as_str())
             }
         }
     }

--- a/src/routing/middleware/cors.rs
+++ b/src/routing/middleware/cors.rs
@@ -130,6 +130,7 @@ impl CorsStateHttp {
         })
     }
 
+    /// Applies missing CORS headers to the response
     fn apply_cors(&self, method: Method, response: &mut Response) {
         let hdr = response.headers_mut();
 
@@ -163,7 +164,7 @@ impl CorsStateHttp {
         }
     }
 
-    // Default response for OPTIONS request
+    /// Default response for OPTIONS request
     fn default_preflight_response(&self) -> Response {
         let mut response = Response::new(Body::empty());
         let hdr = response.headers_mut();


### PR DESCRIPTION
* Update deps
* Update Rust
* Change default `cors_invalid_canisters_max` to 10 million (that should take 300MB RAM or so)
* Fix Clippy advices