### PR TITLE
feat(BOUN-1401): Add `--cert-provider-file` CLI option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,12 +132,12 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.7"
+version = "3.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
+checksum = "6680de5231bd6ee4c6191b8a1325daa282b415391ec9d3a37bd34f2060dc73fa"
 dependencies = [
  "anstyle",
- "once_cell",
+ "once_cell_polyfill",
  "windows-sys 0.59.0",
 ]
 
@@ -2489,7 +2489,7 @@ dependencies = [
 [[package]]
 name = "ic-bn-lib"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic-bn-lib?rev=ec4a6b4abab2d94e09c4d5fee2d57d7bb1260835#ec4a6b4abab2d94e09c4d5fee2d57d7bb1260835"
+source = "git+https://github.com/dfinity/ic-bn-lib?rev=23b3b0b76795c9b75eed96742c2185da0ce9ee2a#23b3b0b76795c9b75eed96742c2185da0ce9ee2a"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3781,6 +3781,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2611b99ab098a31bdc8be48b4f1a285ca0ced28bd5b4f23e45efa8c63b09efa5"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
 name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4587,9 +4596,9 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "replace_with"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3a8614ee435691de62bcffcf4a66d91b3594bf1428a5722e79103249a095690"
+checksum = "51743d3e274e2b18df81c4dc6caf8a5b8e15dbe799e0dca05c7617380094e884"
 
 [[package]]
 name = "reqwest"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ ic-agent = { version = "0.40.0", features = [
     "ring",
     "_internal_dynamic-routing",
 ] }
-ic-bn-lib = { git = "https://github.com/dfinity/ic-bn-lib", rev = "ec4a6b4abab2d94e09c4d5fee2d57d7bb1260835", features = [
+ic-bn-lib = { git = "https://github.com/dfinity/ic-bn-lib", rev = "23b3b0b76795c9b75eed96742c2185da0ce9ee2a", features = [
     "vector",
 ] }
 ic-http-certification = { version = "3.0.3", optional = true }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -198,6 +198,11 @@ pub struct Ic {
 
 #[derive(Args)]
 pub struct Cert {
+    /// Read certificates from given files.
+    /// Each file should be PEM-encoded concatenated certificate chain with a private key.
+    #[clap(env, long, value_delimiter = ',')]
+    pub cert_provider_file: Vec<PathBuf>,
+
     /// Read certificates from given directories
     /// Each certificate should be a pair .pem + .key files with the same base name.
     #[clap(env, long, value_delimiter = ',')]

--- a/src/tls/cert/providers/file.rs
+++ b/src/tls/cert/providers/file.rs
@@ -1,0 +1,50 @@
+use std::path::PathBuf;
+
+use anyhow::{Context, Error};
+use async_trait::async_trait;
+
+use super::Pem;
+use crate::tls::cert::providers::ProvidesCertificates;
+
+/// Loads the certificate chain & private key from provided PEM-encoded file
+#[derive(derive_new::new)]
+pub struct Provider {
+    path: PathBuf,
+}
+
+impl std::fmt::Debug for Provider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "FileProvider({})", self.path.to_str().unwrap_or(""))
+    }
+}
+
+#[async_trait]
+impl ProvidesCertificates for Provider {
+    async fn get_certificates(&self) -> Result<Vec<Pem>, Error> {
+        let pem = std::fs::read(&self.path).context("unable to read the PEM file")?;
+        Ok(vec![Pem(pem)])
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::tls::cert::test::{CERT_1, KEY_1};
+
+    #[tokio::test]
+    async fn test() -> Result<(), Error> {
+        let dir = tempfile::tempdir()?;
+
+        let pemfile = dir.path().join("foobar.pem");
+        let pem = [KEY_1, CERT_1].concat();
+        std::fs::write(&pemfile, &pem)?;
+
+        let prov = Provider::new(pemfile);
+        let certs = prov.get_certificates().await?;
+
+        assert_eq!(certs.len(), 1);
+        assert_eq!(certs[0].0, pem);
+
+        Ok(())
+    }
+}

--- a/src/tls/cert/providers/issuer/mod.rs
+++ b/src/tls/cert/providers/issuer/mod.rs
@@ -210,10 +210,7 @@ impl ProvidesCertificates for CertificatesImporter {
             .as_ref()
             .clone()
             .into_iter()
-            .map(|x| Pem {
-                cert: x.pair.1,
-                key: x.pair.0,
-            })
+            .map(|x| Pem([x.pair.0, x.pair.1].concat()))
             .collect::<Vec<_>>();
 
         Ok(certs)

--- a/src/tls/cert/providers/mod.rs
+++ b/src/tls/cert/providers/mod.rs
@@ -1,7 +1,9 @@
 pub mod dir;
+pub mod file;
 pub mod issuer;
 
 pub use dir::Provider as Dir;
+pub use file::Provider as File;
 pub use issuer::CertificatesImporter as Issuer;
 
 use async_trait::async_trait;
@@ -12,10 +14,7 @@ use std::sync::Arc;
 use crate::{cli::Cli, routing::domain::ProvidesCustomDomains};
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct Pem {
-    pub cert: Vec<u8>,
-    pub key: Vec<u8>,
-}
+pub struct Pem(pub Vec<u8>);
 
 // Trait that the certificate providers should implement
 // It should return a vector of PEM-encoded cert-keys pairs

--- a/src/tls/mod.rs
+++ b/src/tls/mod.rs
@@ -126,6 +126,11 @@ pub async fn setup(
 
     let mut cert_providers: Vec<Arc<dyn ProvidesCertificates>> = vec![];
 
+    // Create File providers
+    for v in &cli.cert.cert_provider_file {
+        cert_providers.push(Arc::new(providers::File::new(v.clone())));
+    }
+
     // Create Dir providers
     for v in &cli.cert.cert_provider_dir {
         cert_providers.push(Arc::new(providers::Dir::new(v.clone())));


### PR DESCRIPTION
This would allow to load a single concatenated PEM file that contains both certificate chain & private key, e.g.
```
-----BEGIN PRIVATE KEY-----
...
-----END PRIVATE KEY-----
-----BEGIN CERTIFICATE-----
...
-----END CERTIFICATE-----
-----BEGIN CERTIFICATE-----
...
-----END CERTIFICATE-----
```

Internally refactor `Pem` type to also contain concatenated format, instead of cert/key separately.