### PR TITLE
feat: add canister ID inference from referer header

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -283,6 +283,12 @@ pub struct Domain {
     /// If canister id is present both in hostname and query params - then the hostname takes precedence.
     #[clap(env, long)]
     pub domain_canister_id_from_query_params: bool,
+
+    /// Whether to try to resolve canister id from the requests referer.
+    /// If a canister ID is present in multiple locations (hostname, query params, and referer),
+    /// then the resolution precedence is: hostname > query parameters > referer.
+    #[clap(env, long)]
+    pub domain_canister_id_from_referer: bool,
 }
 
 #[derive(Args)]

--- a/src/routing/middleware/validate.rs
+++ b/src/routing/middleware/validate.rs
@@ -8,8 +8,9 @@ use axum::{
 };
 use candid::Principal;
 use fqdn::FQDN;
+use http::header::REFERER;
 use ic_bn_lib::http::extract_authority;
-use url::form_urlencoded;
+use url::{Url, form_urlencoded};
 
 use crate::routing::{CanisterId, ErrorCause, RequestCtx, RequestType, domain::ResolvesDomain};
 
@@ -17,6 +18,7 @@ use crate::routing::{CanisterId, ErrorCause, RequestCtx, RequestType, domain::Re
 pub struct ValidateState {
     pub resolver: Arc<dyn ResolvesDomain>,
     pub canister_id_from_query_params: bool,
+    pub canister_id_from_referer: bool,
 }
 
 pub async fn middleware(
@@ -39,6 +41,16 @@ pub async fn middleware(
     if state.canister_id_from_query_params && lookup.canister_id.is_none() {
         lookup.canister_id = canister_id_from_query_params(&request)
             .map_err(|e| ErrorCause::CanisterIdIncorrect(e.to_string()))?
+    }
+
+    if state.canister_id_from_referer && lookup.canister_id.is_none() {
+        lookup.canister_id = match canister_id_from_referer_host(state.resolver, &request)
+            .map_err(|e| ErrorCause::CanisterIdIncorrect(e.to_string()))?
+        {
+            Some(id) => Some(id),
+            None => canister_id_from_referer_query_params(&request)
+                .map_err(|e| ErrorCause::CanisterIdIncorrect(e.to_string()))?,
+        };
     }
 
     // Inject canister_id separately if it was resolved
@@ -85,10 +97,57 @@ fn canister_id_from_query_params(request: &Request) -> Result<Option<Principal>,
     Ok(Some(id))
 }
 
+/// Tries to extract canister id from referer host
+fn canister_id_from_referer_host(
+    resolver: Arc<dyn ResolvesDomain>,
+    request: &Request,
+) -> Result<Option<Principal>, Error> {
+    // Extract the referer header
+    let Some(referer) = request.headers().get(REFERER).and_then(|x| x.to_str().ok()) else {
+        return Ok(None);
+    };
+
+    let Some(domain) = Url::parse(referer)
+        .ok()
+        .and_then(|url| url.host_str().map(|host| FQDN::from_str(host).ok()))
+        .flatten()
+    else {
+        return Ok(None);
+    };
+
+    let Some(lookup) = resolver.resolve(&domain) else {
+        return Ok(None);
+    };
+
+    Ok(lookup.canister_id)
+}
+
+/// Tries to extract canister id from referer query parameters
+fn canister_id_from_referer_query_params(request: &Request) -> Result<Option<Principal>, Error> {
+    // Extract the referer header
+    let Some(referer) = request.headers().get(REFERER).and_then(|x| x.to_str().ok()) else {
+        return Ok(None);
+    };
+
+    let Some(id) = Url::parse(referer).ok().and_then(|url| {
+        url.query_pairs()
+            .find(|(key, _)| key == "canisterId")
+            .map(|(_, value)| value.into_owned())
+    }) else {
+        return Ok(None);
+    };
+
+    let id = Principal::from_text(id)?;
+    Ok(Some(id))
+}
+
 #[cfg(test)]
 mod test {
     use axum::body::Body;
+    use fqdn::fqdn;
     use ic_bn_lib::principal;
+
+    use crate::routing::domain::{CustomDomainStorage, DomainResolver};
 
     use super::*;
 
@@ -131,5 +190,99 @@ mod test {
             .unwrap();
 
         assert_eq!(canister_id_from_query_params(&req).unwrap(), None);
+    }
+
+    #[test]
+    fn test_canister_id_from_referer_header_host() {
+        let domains_base = vec![fqdn!("foo.bar"), fqdn!("baz.boz")];
+        let domains_api = vec![fqdn!("foo-api.bar")];
+
+        let resolver = Arc::new(DomainResolver::new(
+            domains_base.clone(),
+            domains_api,
+            vec![],
+            Arc::new(CustomDomainStorage::new(vec![])),
+        ));
+
+        // good
+        let uri = "http://aaaaa-aa.foo.bar/?xyz=abc";
+
+        let req = Request::builder()
+            .uri(uri)
+            .header(REFERER, uri)
+            .body(Body::empty())
+            .unwrap();
+
+        assert_eq!(
+            canister_id_from_referer_host(resolver.clone(), &req).unwrap(),
+            Some(principal!("aaaaa-aa"))
+        );
+
+        // bad canister id
+        let uri = "http://aa.foo.bar/";
+
+        let req = Request::builder()
+            .uri(uri)
+            .header(REFERER, uri)
+            .body(Body::empty())
+            .unwrap();
+
+        assert_eq!(
+            canister_id_from_referer_host(resolver.clone(), &req).unwrap(),
+            None
+        );
+
+        // no canister id
+        let uri = "http://foo.bar/";
+
+        let req = Request::builder()
+            .uri(uri)
+            .header(REFERER, uri)
+            .body(Body::empty())
+            .unwrap();
+
+        assert_eq!(canister_id_from_referer_host(resolver, &req).unwrap(), None);
+    }
+
+    #[test]
+    fn test_canister_id_from_referer_header_query_params() {
+        // good
+        let uri = "http://foo.bar/?canisterId=aaaaa-aa";
+
+        let req = Request::builder()
+            .uri(uri)
+            .header(REFERER, uri)
+            .body(Body::empty())
+            .unwrap();
+
+        assert_eq!(
+            canister_id_from_referer_query_params(&req).unwrap(),
+            Some(principal!("aaaaa-aa"))
+        );
+
+        // good
+        let uri = "http://foo.bar/?foo=bar&canisterId=aaaaa-aa";
+
+        let req = Request::builder()
+            .uri(uri)
+            .header(REFERER, uri)
+            .body(Body::empty())
+            .unwrap();
+
+        assert_eq!(
+            canister_id_from_referer_query_params(&req).unwrap(),
+            Some(principal!("aaaaa-aa"))
+        );
+
+        // no canister id
+        let uri = "http://foo.bar/?foo=bar";
+
+        let req = Request::builder()
+            .uri(uri)
+            .header(REFERER, uri)
+            .body(Body::empty())
+            .unwrap();
+
+        assert_eq!(canister_id_from_referer_query_params(&req).unwrap(), None);
     }
 }

--- a/src/routing/mod.rs
+++ b/src/routing/mod.rs
@@ -492,6 +492,7 @@ pub async fn setup_router(
     let validate_state = ValidateState {
         resolver: domain_resolver,
         canister_id_from_query_params: cli.domain.domain_canister_id_from_query_params,
+        canister_id_from_referer: cli.domain.domain_canister_id_from_referer,
     };
 
     // Common layers for all routes


### PR DESCRIPTION
This is needed for local testing in dfx/PocketIC as not all browsers support localhost subdomains etc.