### PR TITLE
Update `ic-bn-lib` and other crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2619,7 +2619,7 @@ dependencies = [
 [[package]]
 name = "ic-bn-lib"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic-bn-lib?rev=1bbbc813d463a91ee642bb40d34b88e7ef3a53fb#1bbbc813d463a91ee642bb40d34b88e7ef3a53fb"
+source = "git+https://github.com/dfinity/ic-bn-lib?rev=3b99c44fae99d09cc6d78f0879d87dce0eb8768e#3b99c44fae99d09cc6d78f0879d87dce0eb8768e"
 dependencies = [
  "ahash",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2619,7 +2619,7 @@ dependencies = [
 [[package]]
 name = "ic-bn-lib"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic-bn-lib?rev=275127a22a3c45a8f8b994c4961af34882fb685d#275127a22a3c45a8f8b994c4961af34882fb685d"
+source = "git+https://github.com/dfinity/ic-bn-lib?rev=1bbbc813d463a91ee642bb40d34b88e7ef3a53fb#1bbbc813d463a91ee642bb40d34b88e7ef3a53fb"
 dependencies = [
  "ahash",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,9 +138,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.99"
+version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
+checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "arc-swap"
@@ -281,11 +281,11 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19634d6336019ef220f09fd31168ce5c184b295cbf80345437cc36094ef223ca"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
 dependencies = [
- "async-lock",
+ "autocfg",
  "cfg-if",
  "concurrent-queue",
  "futures-io",
@@ -294,7 +294,7 @@ dependencies = [
  "polling",
  "rustix",
  "slab",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -846,9 +846,9 @@ checksum = "ade8366b8bd5ba243f0a58f036cc0ca8a2f069cff1a2351ef1cac6b083e16fc0"
 
 [[package]]
 name = "candid"
-version = "0.10.18"
+version = "0.10.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae495fbaf9ee8f4f7898affbd3df85dba8598bfa4ffaca24726c42aa4beb7b1"
+checksum = "3ea81e16df186fae1979175058f05dfbfac6e2fdf3b161edcbdc440ef09232cf"
 dependencies = [
  "anyhow",
  "binread",
@@ -869,9 +869,9 @@ dependencies = [
 
 [[package]]
 name = "candid_derive"
-version = "0.10.18"
+version = "0.10.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7388be3b345b1a2ad30e529619b4db0d1955852afb56da821fa6a805f7cbf6be"
+checksum = "2e6d499625531c41f474e55160a40313b33d002262ddaae40cade71bcc3bc75a"
 dependencies = [
  "lazy_static",
  "proc-macro2",
@@ -887,9 +887,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.36"
+version = "1.2.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5252b3d2648e5eedbc1a6f501e3c795e07025c1e93bbf8bbdd6eef7f447a6d54"
+checksum = "80f41ae168f955c12fb8960b057d70d0ca153fb83182b57d86380443527be7e9"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -999,9 +999,9 @@ checksum = "93a719913643003b84bd13022b4b7e703c09342cd03b679c4641c7d2e50dc34d"
 
 [[package]]
 name = "clap"
-version = "4.5.47"
+version = "4.5.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eac00902d9d136acd712710d71823fb8ac8004ca445a89e73a41d45aa712931"
+checksum = "e2134bb3ea021b78629caa971416385309e0131b351b25e01dc16fb54e1b5fae"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1009,9 +1009,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.47"
+version = "4.5.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ad9bbf750e73b5884fb8a211a9424a1906c1e156724260fdae972f31d70e1d6"
+checksum = "c2ba64afa3c0a6df7fa517765e31314e983f51dda798ffba27b988194fb65dc9"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1419,6 +1419,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+dependencies = [
+ "darling_core 0.21.3",
+ "darling_macro 0.21.3",
+]
+
+[[package]]
 name = "darling_core"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1447,6 +1457,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.11.1",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1464,6 +1488,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+dependencies = [
+ "darling_core 0.21.3",
  "quote",
  "syn 2.0.106",
 ]
@@ -1785,9 +1820,9 @@ dependencies = [
 
 [[package]]
 name = "fancy-regex"
-version = "0.16.1"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf04c5ec15464ace8355a7b440a33aece288993475556d461154d7a62ad9947c"
+checksum = "998b056554fbe42e03ae0e152895cd1a7e1002aec800fdc6635d20270260c46f"
 dependencies = [
  "bit-set",
  "regex-automata",
@@ -1830,9 +1865,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fd99930f64d146689264c637b5af2f0233a933bef0d8570e2526bf9e083192d"
+checksum = "1ced73b1dacfc750a6db6c0a0c3a3853c8b41997e2e2c563dc90804ae6867959"
 
 [[package]]
 name = "fixedbitset"
@@ -2105,7 +2140,7 @@ dependencies = [
  "js-sys",
  "libc",
  "r-efi",
- "wasi 0.14.5+wasi-0.2.4",
+ "wasi 0.14.7+wasi-0.2.4",
  "wasm-bindgen",
 ]
 
@@ -2161,7 +2196,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.3.1",
- "indexmap 2.11.1",
+ "indexmap 2.11.4",
  "slab",
  "tokio",
  "tokio-util",
@@ -2210,6 +2245,12 @@ dependencies = [
  "equivalent",
  "foldhash",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
 
 [[package]]
 name = "hdrhistogram"
@@ -2415,9 +2456,9 @@ dependencies = [
 
 [[package]]
 name = "humantime"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b112acc8b3adf4b107a8ec20977da0273a8c386765a3ec0229bd500a1443f9f"
+checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "hyper"
@@ -2477,9 +2518,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d9b05277c7e8da2c93a568989bb6207bef0112e8d17df7a6eda4a3cf143bc5e"
+checksum = "3c6995591a8f1380fcb4ba966a252a4b29188d51d2b89e3a252f5305be65aea8"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -2503,9 +2544,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.63"
+version = "0.1.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
+checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -2513,7 +2554,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.62.0",
 ]
 
 [[package]]
@@ -2578,7 +2619,7 @@ dependencies = [
 [[package]]
 name = "ic-bn-lib"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic-bn-lib?rev=2bdc7cfc23e70ac5eb28f7a5223dc07b6d7d41c9#2bdc7cfc23e70ac5eb28f7a5223dc07b6d7d41c9"
+source = "git+https://github.com/dfinity/ic-bn-lib?rev=275127a22a3c45a8f8b994c4961af34882fb685d#275127a22a3c45a8f8b994c4961af34882fb685d"
 dependencies = [
  "ahash",
  "anyhow",
@@ -2636,6 +2677,7 @@ dependencies = [
  "sev",
  "sha1",
  "sha2 0.10.9",
+ "socket2 0.6.0",
  "strum 0.27.2",
  "strum_macros 0.27.2",
  "systemstat",
@@ -3245,13 +3287,14 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.11.1"
+version = "2.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "206a8042aec68fa4a62e8d3f7aa4ceb508177d9324faf261e1959e495b7a1921"
+checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.0",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -3439,9 +3482,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.78"
+version = "0.3.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0b063578492ceec17683ef2f8c5e89121fbd0b172cbc280635ab7567db2738"
+checksum = "852f13bec5eba4ba9afbeb93fd7c13fe56147f055939ae21c43a29a0ecb2702e"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -3552,9 +3595,9 @@ checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
 name = "libredox"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "391290121bad3d37fbddad76d8f5d1c1c314cfc646d143d7e07a3086ddff0ce3"
+checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
 dependencies = [
  "bitflags",
  "libc",
@@ -4157,7 +4200,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
  "fixedbitset",
- "indexmap 2.11.1",
+ "indexmap 2.11.4",
 ]
 
 [[package]]
@@ -4291,16 +4334,16 @@ dependencies = [
 
 [[package]]
 name = "polling"
-version = "3.10.0"
+version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5bd19146350fe804f7cb2669c851c03d69da628803dab0d98018142aaa5d829"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -4858,7 +4901,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c11639076bf147be211b90e47790db89f4c22b6c8a9ca6e960833869da67166"
 dependencies = [
  "aho-corasick",
- "indexmap 2.11.1",
+ "indexmap 2.11.4",
  "itertools 0.13.0",
  "nohash",
  "regex",
@@ -4935,9 +4978,9 @@ dependencies = [
 
 [[package]]
 name = "resolv-conf"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95325155c684b1c89f7765e30bc1c42e4a6da51ca513615660cb8a62ef9a88e3"
+checksum = "6b3789b30bd25ba102de4beabd95d21ac45b69b1be7d14522bab988c526d6799"
 
 [[package]]
 name = "rfc6979"
@@ -5008,9 +5051,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.31"
+version = "0.23.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ebcbd2f03de0fc1122ad9bb24b127a5a6cd51d72604a3f3c50ac459762b6cc"
+checksum = "cd3c25631629d034ce7cd9940adc9d45762d46de2b0f57193c4443b92c6d4d40"
 dependencies = [
  "brotli",
  "brotli-decompressor",
@@ -5109,9 +5152,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.4"
+version = "0.103.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a17884ae0c1b773f1ccd2bd4a8c72f16da897310a98b0e84bf349ad5ead92fc"
+checksum = "8572f3c2cb9934231157b45499fc41e1f58c589fdfb81a844ba873265e80f8eb"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -5235,9 +5278,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b369d18893388b345804dc0007963c99b7d665ae71d275812d828c6f089640"
+checksum = "cc198e42d9b7510827939c9a15f5062a0c913f3371d765977e586d2fe6c16f4a"
 dependencies = [
  "bitflags",
  "core-foundation 0.10.1",
@@ -5258,16 +5301,17 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.226"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "0dca6411025b24b60bfa7ec1fe1f8e710ac09782dca409ee8237ba74b51295fd"
 dependencies = [
+ "serde_core",
  "serde_derive",
 ]
 
@@ -5282,11 +5326,12 @@ dependencies = [
 
 [[package]]
 name = "serde_bytes"
-version = "0.11.17"
+version = "0.11.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8437fd221bde2d4ca316d61b90e337e9e702b3820b87d63caa9ba6c02bd06d96"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
 dependencies = [
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -5300,10 +5345,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_derive"
-version = "1.0.219"
+name = "serde_core"
+version = "1.0.226"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "ba2ba63999edb9dac981fb34b3e5c0d111a69b0924e253ed29d83f7c99e966a4"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.226"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8db53ae22f34573731bafa1db20f04027b2d25e02d8205921b569171699cdb33"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5323,24 +5377,26 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.143"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
+checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
 dependencies = [
  "itoa",
  "memchr",
  "ryu",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "serde_path_to_error"
-version = "0.1.17"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59fab13f937fa393d08645bf3a84bdfe86e296747b506ada67bb15f10f218b2a"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
 dependencies = [
  "itoa",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -5379,15 +5435,15 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.14.0"
+version = "3.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2c45cd61fefa9db6f254525d46e392b852e0e61d9a1fd36e5bd183450a556d5"
+checksum = "c522100790450cf78eeac1507263d0a350d4d5b30df0c8e1fe051a10c22b376e"
 dependencies = [
  "base64 0.22.1",
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.11.1",
+ "indexmap 2.11.4",
  "schemars 0.9.0",
  "schemars 1.0.4",
  "serde",
@@ -5399,11 +5455,11 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.14.0"
+version = "3.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de90945e6565ce0d9a25098082ed4ee4002e047cb59892c318d66821e14bb30f"
+checksum = "327ada00f7d64abaac1e55a6911e90cf665aa051b9a561c7006c157f4633135e"
 dependencies = [
- "darling 0.20.11",
+ "darling 0.21.3",
  "proc-macro2",
  "quote",
  "syn 2.0.106",
@@ -5415,7 +5471,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.11.1",
+ "indexmap 2.11.4",
  "itoa",
  "ryu",
  "serde",
@@ -5428,7 +5484,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b4db627b98b36d4203a7b458cf3573730f2bb591b28871d916dfa9efabfd41f"
 dependencies = [
- "indexmap 2.11.1",
+ "indexmap 2.11.4",
  "itoa",
  "ryu",
  "serde",
@@ -5962,11 +6018,12 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.43"
+version = "0.3.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83bde6f1ec10e72d583d91623c939f623002284ef622b87de38cfd546cbf2031"
+checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
 dependencies = [
  "deranged",
+ "itoa",
  "num-conv",
  "powerfmt",
  "serde",
@@ -6069,9 +6126,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.2"
+version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
+checksum = "05f63835928ca123f1bef57abbcd23bb2ba0ac9ae1235f1e65bda0d06e7786bd"
 dependencies = [
  "rustls",
  "tokio",
@@ -6192,7 +6249,7 @@ checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap 2.11.1",
+ "indexmap 2.11.4",
  "pin-project-lite",
  "slab",
  "sync_wrapper",
@@ -6575,27 +6632,27 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
-version = "0.14.5+wasi-0.2.4"
+version = "0.14.7+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4494f6290a82f5fe584817a676a34b9d6763e8d9d18204009fb31dceca98fd4"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
 dependencies = [
  "wasip2",
 ]
 
 [[package]]
 name = "wasip2"
-version = "1.0.0+wasi-0.2.4"
+version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03fa2761397e5bd52002cd7e73110c71af2109aca4e521a9f40473fe685b0a24"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
  "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.101"
+version = "0.2.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e14915cadd45b529bb8d1f343c4ed0ac1de926144b746e2710f9cd05df6603b"
+checksum = "ab10a69fbd0a177f5f649ad4d8d3305499c42bab9aef2f7ff592d0ec8f833819"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -6606,9 +6663,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.101"
+version = "0.2.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e28d1ba982ca7923fd01448d5c30c6864d0a14109560296a162f80f305fb93bb"
+checksum = "0bb702423545a6007bbc368fde243ba47ca275e549c8a28617f56f6ba53b1d1c"
 dependencies = [
  "bumpalo",
  "log",
@@ -6620,9 +6677,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.51"
+version = "0.4.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ca85039a9b469b38336411d6d6ced91f3fc87109a2a27b0c197663f5144dffe"
+checksum = "a0b221ff421256839509adbb55998214a70d829d3a28c69b4a6672e9d2a42f67"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -6633,9 +6690,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.101"
+version = "0.2.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c3d463ae3eff775b0c45df9da45d68837702ac35af998361e2c84e7c5ec1b0d"
+checksum = "fc65f4f411d91494355917b605e1480033152658d71f722a90647f56a70c88a0"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -6643,9 +6700,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.101"
+version = "0.2.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bb4ce89b08211f923caf51d527662b75bdc9c9c7aab40f86dcb9fb85ac552aa"
+checksum = "ffc003a991398a8ee604a401e194b6b3a39677b3173d6e74495eb51b82e99a32"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6656,9 +6713,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.101"
+version = "0.2.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f143854a3b13752c6950862c906306adb27c7e839f7414cec8fea35beab624c1"
+checksum = "293c37f4efa430ca14db3721dfbe48d8c33308096bd44d80ebaa775ab71ba1cf"
 dependencies = [
  "unicode-ident",
 ]
@@ -6693,7 +6750,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c9d90bb93e764f6beabf1d02028c70a2156a6583e63ac4218dd07ef733368b0"
 dependencies = [
  "bitflags",
- "indexmap 2.11.1",
+ "indexmap 2.11.4",
  "semver",
 ]
 
@@ -6721,9 +6778,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.78"
+version = "0.3.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77e4b637749ff0d92b8fad63aa1f7cff3cbe125fd49c175cd6345e7272638b12"
+checksum = "fbe734895e869dc429d78c4b433f8d17d95f8d05317440b4fad5ab2d33e596dc"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6810,7 +6867,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
  "windows-collections",
- "windows-core",
+ "windows-core 0.61.2",
  "windows-future",
  "windows-link 0.1.3",
  "windows-numerics",
@@ -6822,7 +6879,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
- "windows-core",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -6834,8 +6891,21 @@ dependencies = [
  "windows-implement",
  "windows-interface",
  "windows-link 0.1.3",
- "windows-result",
- "windows-strings",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57fe7168f7de578d2d8a05b07fd61870d2e73b4020e9f49aa00da8471723497c"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.2.0",
+ "windows-result 0.4.0",
+ "windows-strings 0.5.0",
 ]
 
 [[package]]
@@ -6844,7 +6914,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
- "windows-core",
+ "windows-core 0.61.2",
  "windows-link 0.1.3",
  "windows-threading",
 ]
@@ -6889,7 +6959,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
- "windows-core",
+ "windows-core 0.61.2",
  "windows-link 0.1.3",
 ]
 
@@ -6900,8 +6970,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
 dependencies = [
  "windows-link 0.1.3",
- "windows-result",
- "windows-strings",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
 ]
 
 [[package]]
@@ -6914,12 +6984,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-result"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7084dcc306f89883455a206237404d3eaf961e5bd7e0f312f7c91f57eb44167f"
+dependencies = [
+ "windows-link 0.2.0",
+]
+
+[[package]]
 name = "windows-strings"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7218c655a553b0bed4426cf54b20d7ba363ef543b52d515b3e48d7fd55318dda"
+dependencies = [
+ "windows-link 0.2.0",
 ]
 
 [[package]]
@@ -7240,9 +7328,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.45.1"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c573471f125075647d03df72e026074b7203790d41351cd6edc96f46bcccd36"
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "writeable"
@@ -7292,9 +7380,9 @@ dependencies = [
 
 [[package]]
 name = "xattr"
-version = "1.5.1"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af3a19837351dc82ba89f8a125e22a3c475f05aba604acc023d62b2739ae2909"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
  "rustix",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ http = "1.3.1"
 http-body = "1.0.1"
 http-body-util = "0.1.2"
 humantime = "2.2.0"
-ic-bn-lib = { git = "https://github.com/dfinity/ic-bn-lib", rev = "2bdc7cfc23e70ac5eb28f7a5223dc07b6d7d41c9", features = [
+ic-bn-lib = { git = "https://github.com/dfinity/ic-bn-lib", rev = "275127a22a3c45a8f8b994c4961af34882fb685d", features = [
     "vector",
     "cert-providers",
     "clients-hyper",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ http = "1.3.1"
 http-body = "1.0.1"
 http-body-util = "0.1.2"
 humantime = "2.2.0"
-ic-bn-lib = { git = "https://github.com/dfinity/ic-bn-lib", rev = "275127a22a3c45a8f8b994c4961af34882fb685d", features = [
+ic-bn-lib = { git = "https://github.com/dfinity/ic-bn-lib", rev = "1bbbc813d463a91ee642bb40d34b88e7ef3a53fb", features = [
     "vector",
     "cert-providers",
     "clients-hyper",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ http = "1.3.1"
 http-body = "1.0.1"
 http-body-util = "0.1.2"
 humantime = "2.2.0"
-ic-bn-lib = { git = "https://github.com/dfinity/ic-bn-lib", rev = "1bbbc813d463a91ee642bb40d34b88e7ef3a53fb", features = [
+ic-bn-lib = { git = "https://github.com/dfinity/ic-bn-lib", rev = "3b99c44fae99d09cc6d78f0879d87dce0eb8768e", features = [
     "vector",
     "cert-providers",
     "clients-hyper",

--- a/repro-env.lock
+++ b/repro-env.lock
@@ -1,29 +1,29 @@
 [container]
-image = "docker.io/library/archlinux@sha256:6e644b0d7ac1543ce6368d0cd9f919d6d234c718a721fdabd132f50acb0488b2"
+image = "docker.io/library/archlinux@sha256:8fe9851fcd8bd23ea0e6bfa99483d8778e40b45e0fd7bb8188c94cbdd8c25a38"
 
 [[package]]
 name = "abseil-cpp"
-version = "20250512.1-1"
+version = "20250814.0-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/a/abseil-cpp/abseil-cpp-20250512.1-1-x86_64.pkg.tar.zst"
-sha256 = "9de67a852d2813e39e4ca1f42fa2011fab585f7f373620116310167db579218a"
-signature = "iQIzBAABCgAdFiEE8AuW0VIoAT/8nJ0Dk7EdqkwZfj0FAmhRmDgACgkQk7EdqkwZfj3L8hAA1ZrovdVkfoEXL8QHCye5gpGaE3L4zkh6sl4YX556W5V9gVkghXyBsPkKRyUpKFFodJ+Vzva6ncNDNM/MnLageLfPcVbwQ+fyCcb6ptmyzN45YTFxqSA56aSKPA9NTB2v8H5cMj6t1bpwChAigG1uU9k0QzcivDF8ivhsecTUH8Xs3vYG7pIbL8kIJBA/9oyu1HHBvi40owBBwtYBniADumfNN6M0hTyEIfea+Wt2p6HW0w6IsR9TpZU9NxaNP1X2JYSdn0FMif2Q6roVIURCdfHQdJcNCUkM4c0dibH+uD6R0QBj/NfQ4gGjDi2tq0fKYVcP/B3Bcc8yaZ/XWe/cvAtsqlMommXYpFMWfTF/TRWD9OtdLzSG8+DYunBQ9rAsmcTm+KDzzMU/AJ3suHuQGw9OecZn5+t6N+dmIfU3VhiPPbLUQn+H/VHVEYFQf+33A4eaiWgL8k/T0yIwdiu7Y3ebKhLnvD+T4Iinz8yjuN78aUUi6hDDPN4kVqzMZx+lJj9UaQ/rBszwef/ZOhS8ktpvSl7RWvQEboewy2Dsnr6vewofyvSjfK95Kp0lI3YZirnwM3wSoyoTQ+EGMlG263xerJpsN6cPhhrBQmPTbP8P68xpcJYqrme1Nt/H2+0tDKtrsgDowCO8J3mjc3JhriNRI1lZZWZikx3/UCTs7qU="
+url = "https://archive.archlinux.org/packages/a/abseil-cpp/abseil-cpp-20250814.0-1-x86_64.pkg.tar.zst"
+sha256 = "449828fc00ead4f4addade5393680f7f0f0795e7b35c001377807e1706e92a74"
+signature = "iQIzBAABCgAdFiEE8AuW0VIoAT/8nJ0Dk7EdqkwZfj0FAmik7I8ACgkQk7EdqkwZfj3GBBAAwP7yhn4pVLLEhSy00z+f2qg6yef6vHUaCgVJVXWfOyroO6hblWdFmw8NXw+1u0LuxPfnQwo50xCMMpaIJxki/2JlRUzTpmCgk63Pyey2mBnUqL2UQdvKfYy0YjDGJSTyiX6uovHZ5oTVQp2WlQoS2Kv5HSdWlmuURINsQArrfjnDDCwiyq0yNoW2SfwDjDIAwROrq74BHMcLJ6nq2gZP/1q8935ZeK+j0ROdIGaBFcAGKZvdnGzvWnpU/iyrHnzf+874EhSqiH8XQxBhrjBWvgoqd5cY7ZDgvHcZQvKdxbnt5uZDbV2v2FR6YWMeNfRLbFhcpflS/BKK+callLQtmhNp0TzJx6pqlPshuaOaZOc62QQ5gy9LSvjUj5lWnwfrkx1INltzU2RE63ccCX8MQ2nq8+PAKFODzsGWa+liqheqOnlYdgJrij/mWxegj+NDPWsEqprIsVOWE0sK+OqMDrH72fTw6ArcWe04asaLkRKiQKA/obSg92A/bcPX4AD0z8Blls71DrLgn5ffcbO4znCKxj7nNdUo2f8uvscN2+4wP3E2i7UjadxU3aJnoZOGasIMCQ6kNWua0+h0A65SCk46QisZI3aoobyQL7VQYhxpXK3fezvsB+WTIv9LJo3m65YdrjFTJgXBZY4K9//pCpvI9hbwbok8YDFU1jhZFrY="
 
 [[package]]
 name = "binutils"
-version = "2.44+r94+gfe459e33c676-1"
+version = "2.45+r29+g2b2e51a31ec7-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/b/binutils/binutils-2.44+r94+gfe459e33c676-1-x86_64.pkg.tar.zst"
-sha256 = "dae1c7ad6100da0abf20171879dc1ef9b486f0498260b4d496e526b49287d39c"
-signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCaBB9K18UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCkMbAP0XYt1YCNB0OOe0jkhK7MAH7K0krqEjcFRk6c1pKfslzQEAxb9iCNJi700zsLGLUNduRUsNe2AnZRPeAVefR0/hXww="
+url = "https://archive.archlinux.org/packages/b/binutils/binutils-2.45+r29+g2b2e51a31ec7-1-x86_64.pkg.tar.zst"
+sha256 = "9b4e769969e6b659868466582179adf9fc51dcdd622561e8feb5feb393faab65"
+signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCaJyzVF8UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCuAUAQDxsvXdPvY8+iaMBTGS8VC+fCzquULwmaHYltelv2vb5gD/TZ/2gh5J7JLH0XRu+BlhMYaV5gRaIiuEWUX1H2WkKAY="
 
 [[package]]
 name = "cmake"
-version = "4.0.3-1"
+version = "4.1.1-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/c/cmake/cmake-4.0.3-1-x86_64.pkg.tar.zst"
-sha256 = "4c3fc1ee51a40109951ef1c69f8c7fff36c2d034eb7923fb9ec953670930e65e"
-signature = "iQEzBAABCgAdFiEEFRnVq6Zb9vwrc8dWek52CV2KUuQFAmhLNr8ACgkQek52CV2KUuTu9Af/QDC9Kl+7/LFBXdrie1MWewFTxTigPjq/QnfyqzL+yWhiZTt8acfGCbUD7PjKyhu6bvaqNuZOl5orPnCdDjw1WOGM/agYXbg7pLRGtWIX7aWnjyNqneQfXzO0AqiTs43yPlCRTpuXC39CIal1bQ/dNoz4uZ+msZF0XzbnikrjgM09NZoG3JqEyoJJTWF0GW33+ICjxukTcF6pYpo4LgtRy8E3Mg9cI45Vrq2KnIFTdANaObczOXZ/Bl3WOr3IpwsNvwUHED7z+cZKixbQAPf/ApxiT/HRkTqOfe3hFwIX5/QgAIaajwzLXXSaOVql8F1ye4MvAhxp1tDI6+/f1kBPYw=="
+url = "https://archive.archlinux.org/packages/c/cmake/cmake-4.1.1-1-x86_64.pkg.tar.zst"
+sha256 = "f1ad78e6dc49049b65ece0d9511d217296b55cf5408442f74f1f80cc5b0ce146"
+signature = "iQEzBAABCgAdFiEEFRnVq6Zb9vwrc8dWek52CV2KUuQFAmiviOcACgkQek52CV2KUuRJywf/YdDMyqJQBaLAtB7idH6VwDUl0sLxU0ix7uNfLeH/SAn0+2Sh+ooSZ0MEoZ44SmoPkr7Pff//7WpwGFyfXnrYMVsvByMqw21IFGri7DC9KudvCv8Wh7afUYoyqTlUSRAwqakH7a//xwHnspOAfLj/v85DbCgrptyBACUNbekPWq2+4t5gaDI3ViZoVOcPvR0pf59ULKR6PGgNRit7MHD8cxLMVZ43LtWhhEuhX5f1KiXNt7zvkENxnXKZKFqj7/6MMHkTNsm/lvCNhmJtoqZ+5ySIcgYs0zQwIExVd6sn/gJO42HaFAcB1YAkoTP4f/XKLHdFFASCqyf6ugTP2CfSlw=="
 
 [[package]]
 name = "cppdap"
@@ -34,12 +34,12 @@ sha256 = "29796195345f80920d6e018d53cd0f92eb7b7d379849d262a0dbcd4b1fa573ef"
 signature = "iQEzBAABCAAdFiEEFRnVq6Zb9vwrc8dWek52CV2KUuQFAmaDH8sACgkQek52CV2KUuRK9Qf8CfghNmb2AN0lgBcvxo38BgOIfBUlC/Zyd2yymxInhogQNgj5xKGDF9ZsLzTXNuGx1s5LDrjLsyLHgJgWIg39sfdAepQtZ1kJPm5MmmIqFMwvVmQ1tPUBOgAQSWs8XL4ssYvYuN23npSh+RhkYC62GhCsJm6CXjSCpksV+F4mHnOik/khw6rPb2hj7kzi+k5x5N2G5+qm9cOcKQLgtkX0lefsAkg5ZjH1qZm3Twa0p/2xMc8cigHtdm5TTTqH9nhKk68eOTAFJvr1T9oo/UxKuQm8pOofjTcKpECFpRpGy+nkxADI08pwvFDN44GE4QAnecpchRleWnnzghh87KExIw=="
 
 [[package]]
-name = "device-mapper"
-version = "2.03.33-1"
+name = "expat"
+version = "2.7.2-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/d/device-mapper/device-mapper-2.03.33-1-x86_64.pkg.tar.zst"
-sha256 = "541b20d7ffabc28f1a1831549683419d05795b65732c2d9aae70ddb273e0b92b"
-signature = "iHUEABYKAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCaF5kvwAKCRBtQr3RFuAGj88lAQDQZVb4OMAzopcOgjudS+k3tHhumrw+/Z8eeI97kzo9vQD/aPemXWrJnWriSTsmIfAwB8RUNHCfH5oepUIl/o/JiQg="
+url = "https://archive.archlinux.org/packages/e/expat/expat-2.7.2-1-x86_64.pkg.tar.zst"
+sha256 = "e6471869b10ca292d40aff2ee48d441b5c03e0c11da66bb5768dd4610429b619"
+signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCaMqolV8UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCq4TAQCvOyOw5SQO4y5y9kNIYdLBsYvfsnBqgLqnA7URJO7tAgD+MgJ3YHDX+OpW/WWedlosDLGNdaga8cWQQdf3Y7Moqg8="
 
 [[package]]
 name = "gc"
@@ -51,11 +51,11 @@ signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCZt6oQl8UgAAAAAAuAChpc3N
 
 [[package]]
 name = "gcc"
-version = "15.1.1+r7+gf36ec88aa85a-1"
+version = "15.2.1+r22+gc4e96a094636-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/g/gcc/gcc-15.1.1+r7+gf36ec88aa85a-1-x86_64.pkg.tar.zst"
-sha256 = "d8bc5c74e9b58c281c0aca51cc3f6b18cff37cdac5d24ea7f67488eeb6caa27a"
-signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCaBB8ql8UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCqOVAP987LpB7oRJy0pLySNFrUb73byPmEw91N/aQFrDX1IrWwD/TTXyyc1ulsVNhoEDk7MKS+NzMAaJX/f1gz2pQFeeCAU="
+url = "https://archive.archlinux.org/packages/g/gcc/gcc-15.2.1+r22+gc4e96a094636-1-x86_64.pkg.tar.zst"
+sha256 = "fda9f88e73477e7201a7d8a012b949b1d0c53660b4598e2252930190598f7a05"
+signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCaJyzFV8UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCtN8AP9GVil5dJ5FQ7GTYEH3KblDVoXX5Szl5Ihzbh0IJs+9hQEAl1ezL2qACtBZSZKeOqQzBtf/PHrDNdLQfwSTRvx6MwI="
 
 [[package]]
 name = "gtest"
@@ -106,14 +106,6 @@ sha256 = "9b4167ade67f899d5f4d1e0d3e8e8f18b5edfdd076f5aeffd100cb3093117987"
 signature = "iQEzBAABCAAdFiEEW34/txt/EDKaHAOrdx32Yn7faB8FAme8RWMACgkQdx32Yn7faB9bnQf+N2KYErONnv0FLvqScucx7dhD+DNMqRFEEruhqsnAtP9KZzRePYMys6Uhn4TlIysatDnz6qy2UMeXuLOKDAYXMz4M37lfRT6YsBzbNj93FQlVrfelM/ap6U3vGBnHUVv8zqPoI6SgF+qqRuDJtoE3DR6TiiHgYm2oHRR/0NwF9S3hxqVkc+Ebmz7VTTlXW0x/g2uOKRqPyJR17GCuVrRWW/B0eIYrNIVVTE9jcMVKC5Uil+OAYd1bPoTQRgolw/Vp13QnHyUC4u8OwM3yl1b3CWjdRkwz7ImS+K5aF6z9/bUGzPwM1WmPkiz4TNeYHqxnKAQ9GnSLZOJBv1rMl3mI+g=="
 
 [[package]]
-name = "libffi"
-version = "3.5.1-1"
-system = "archlinux"
-url = "https://archive.archlinux.org/packages/l/libffi/libffi-3.5.1-1-x86_64.pkg.tar.zst"
-sha256 = "2a5df57eb1ec875b8fd825baf5eb70db2d487d7652532415b4bba38037afbb1e"
-signature = "iHUEABYKAB0WIQRizHP4hOUpV7L92IObeih9mi7GCAUCaEm7ZQAKCRCbeih9mi7GCJLOAQDTxEno4J3sJuB592gJUhX2S5d0JFtTrZDzWntw+r4HhwEA17P2JG5jlWj3xE3SUe4Z+6jXZNnWyt9ygybhcK+XQgk="
-
-[[package]]
 name = "libisl"
 version = "0.27-1"
 system = "archlinux"
@@ -130,6 +122,22 @@ sha256 = "10554706eb15ed2186fbd55fd5db8fa5919788ac9a75d26c0b9ef5bdfca9d470"
 signature = "iQEzBAABCAAdFiEEFRnVq6Zb9vwrc8dWek52CV2KUuQFAmaHCZwACgkQek52CV2KUuRjbAf/TmL9cCMXYTGsNmR2om6kT7XjczfZoFR9AM0FSTUNy5AuNZNUUCfm6ie6F4rFwHc3nETOSojScOZauZlcNiLrVriHYYFSZ8EhKiCJCo68a7KTbceBNoBuT6AEIpGMpIMti/cvWhu8VXl5JIRo8LNPBzDih05aCDUJ2nayKPYNHalDayu87sDXzJYXuzC8KD7XmUa7Kirn0ZpA4VZXc8CUjYYvn0wvRwLKQP4WMpszxmblQWjMVbQxh7dwC+gPtqIANVjoGKMRfr6QpT03XXIEaTBKbMsxeYFvwn+y2JN30t6oFI6LJADZ22VwimEzu06u+x9c+3+pr4k7Py43OCOGmg=="
 
 [[package]]
+name = "libnghttp2"
+version = "1.67.1-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/l/libnghttp2/libnghttp2-1.67.1-1-x86_64.pkg.tar.zst"
+sha256 = "df24c5e19b92f61e69d04474b7800bbc27b85a89a397e825299b75af94397f8d"
+signature = "iHUEABYKAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCaMf/GAAKCRBtQr3RFuAGj4tgAP9optRXgpckjwG5mzrE5lwIgml3cxUHQSJE7MNgC1XO5gEAn6NxV0p+XQ3LgvwMwx3rPF+WfRkavbOdpdqXAG0mjww="
+
+[[package]]
+name = "libp11-kit"
+version = "0.25.9-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/l/libp11-kit/libp11-kit-0.25.9-1-x86_64.pkg.tar.zst"
+sha256 = "f96c352633835109408e485e9c58825cf5ff5b37d044e98d04f5aeb11198ec7c"
+signature = "iHUEABYKAB0WIQSDvIiJNRtd67toQW64rAhgDxCM3wUCaMx7sAAKCRC4rAhgDxCM390OAP9oCNU2eljkRvGF2jZCmOTDNpAbAuGxkIgMhQN17bevmgD/bc5ZHg82WFmshUuUQEiZk+LbdnsIdQ64iDTEixpKLws="
+
+[[package]]
 name = "libuv"
 version = "1.51.0-1"
 system = "archlinux"
@@ -138,12 +146,28 @@ sha256 = "4a4e992621b881a221becb6b9669bb4092ffebec8d87bd90f235866356cc5c35"
 signature = "iHUEABYKAB0WIQRUwf0nM2HqUUojd5Pylr3lA2jGzgUCaAuLRwAKCRDylr3lA2jGzrT/AP43Gr5SSjnTzsFRn9PXhiwSxSD9n3wnk+MY0BWz1QKiYwD/XYWd0OVkTq6LSIbIBsmp5msI8fCiYMyVKNBHimfBNAU="
 
 [[package]]
-name = "llvm-libs"
-version = "20.1.6-3"
+name = "libxml2"
+version = "2.15.0-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/l/llvm-libs/llvm-libs-20.1.6-3-x86_64.pkg.tar.zst"
-sha256 = "8d4acca31bc792edf8292fff74083ef6db6eb9a140607a7bebf0463381c89bd9"
-signature = "iHUEABYKAB0WIQQhkbiUMbrAqLlt6T0kR0DRfH/Q7AUCaEHAwQAKCRAkR0DRfH/Q7JoKAP0bL8CyIQVLIiQkQv0Y2P97eLWo29rf37JfBFyXCIJuYQD/a12Lp2DdLIvN1FkPntRuHrlskcDYFxflImqVC+Jc/Ag="
+url = "https://archive.archlinux.org/packages/l/libxml2/libxml2-2.15.0-1-x86_64.pkg.tar.zst"
+sha256 = "07c19890f8cac4ae2c278ed0d8d4b8818c58051a5affd44f8159a03ef260880c"
+signature = "iHUEABYKAB0WIQSDvIiJNRtd67toQW64rAhgDxCM3wUCaMiKiAAKCRC4rAhgDxCM3zfFAQDsPi8egDHHQ2DyFgCjgOrmgWvhlbGxYQhzWPTNePhS3AEAgB9W71U/LVg3l6Y7PDS6sA67SK1UM+dpTTd54ZaYeAM="
+
+[[package]]
+name = "lld"
+version = "20.1.8-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/l/lld/lld-20.1.8-1-x86_64.pkg.tar.zst"
+sha256 = "f47e53d7608c833816b9b7861f9e57ad167c409edca84e3dc12ecfc1cdd1b8a8"
+signature = "iHUEABYKAB0WIQQhkbiUMbrAqLlt6T0kR0DRfH/Q7AUCaHD35AAKCRAkR0DRfH/Q7HcLAP97Od3+nJywTuaB5zlLrbQlejy07o9DnAMzjDYjqcXl1QEAqgrSt+VPYuQHjGAycDorm/UXKM68tfKtb6+9MQ4t+gU="
+
+[[package]]
+name = "llvm-libs"
+version = "20.1.8-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/l/llvm-libs/llvm-libs-20.1.8-1-x86_64.pkg.tar.zst"
+sha256 = "710e552406edbc6badab91a2ce47bb12a6c3ebf85758448d953211be7d610486"
+signature = "iHUEABYKAB0WIQQhkbiUMbrAqLlt6T0kR0DRfH/Q7AUCaHDyPwAKCRAkR0DRfH/Q7C//AP0QZI74leY5F/0H7cGtB6zCumtdRfW/cRMtybHzUfyRDAEA6KPlQheFLXQKNCHTp0LrrzIh/vk0n1a+iQnNZ7td8wc="
 
 [[package]]
 name = "lua"
@@ -170,12 +194,36 @@ sha256 = "b858891e1c97517cab07a7c060affc47bef7819266e0157554d59f3ecad79fef"
 signature = "iQJLBAABCgA1FiEEiee5MxxK59f699MFwTIpOVS75K0FAmg/nssXHHNwdXB5a2luQGFyY2hsaW51eC5vcmcACgkQwTIpOVS75K0KiQ/+N+8Vg90QUuC+EsFzt4kFOkD74IZjPDSyfsNbIgP1y8curfRtZJDR+hcWzYQEbHB6jjVBZeAgVlEaYQQsSWCXthcXslEfNyCP3FWp5hNC6VFibfZhZbg45T4P/4lCd1UuOdY02UmX8yo8rmmltCYPk/AGvoi89nAwRRhj8UU30pQfufouha2jJ178Lgv8eT6qqUjS5KCkaeheg3yUPb1W6br4Lm55owk3GtVxe2hQ2hMmJU3Dzavy80PBZb0bD5JvPQJ0R13IET5+Qn/a7XkJL1oxPmCM+TLcdobnCYNjXXNL1egYKoeaqYvMa95VPnXysjlIVcijBB2xpHaMd5x47y73c6yfBmrp3zYqEZcV4ZmpUG8bCq3XL8IUq29wDkI7W02vNyUYsbyBox37a0eG5orLR2K2Oj6bH2xJl2PcJC9HMoLvoCopQlU3+xUAEjbYQVpoMdryuJUQfmYjDOCZOG6ilYoM0burw9naf0yE/17wKIVZegAOtYcKIN731NGgKCWgfJ25/kqSWFjAPQLGFrtUbJuJ5UX3vCmUz8uG0KLGXdoNPssI2W1zEFDjANWGxXKk2s1ysAMCtnDqOTfmmxqlyYTIdjtT5fBbgQyjtXYi3+ktqnsgulS/Fq/ST99+5/z/HRqAJY06pjrmDgR/wNC4kzWEF5YSCe12KWU/zpk="
 
 [[package]]
-name = "protobuf"
-version = "31.1-1"
+name = "openssl"
+version = "3.5.3-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/p/protobuf/protobuf-31.1-1-x86_64.pkg.tar.zst"
-sha256 = "031cfb69df101b81629dbfa77f6e541efe918b967a2f84172e1be0710e0d902a"
-signature = "iQIzBAABCgAdFiEE8AuW0VIoAT/8nJ0Dk7EdqkwZfj0FAmhKlBUACgkQk7EdqkwZfj2STxAA3b4bXXEoppapcLhtd+HfXt4YGglUu4VP4psxXN45HH6Hzj4O2Hge3Z5mqjp2k7Pm1DHZQuov0kAvWiV1EYS6ZAyrNy5OzY/7GK7NUYgJqotVav57AsB3qORVinbTu26S++NGqImbAcH0n3lLivL8rEtq4a3MD2Vnj25ALHgKkKTvrkEJ8L7kU0MqsvJxuPariztJaDZN1T6qz3VRR6J3RMl5UKZRMxGofpG1WE7JaSqaaIKqD6In2f8KT0Rd7B5fCh2qGJ9pybuDWUPLoJntBcw3gVPfj3DhnE3lJ4rcmUBE/cjBUORE9qxbVldVnr6+8rQP4F929g7x7tAkpB31vDXxQ7hrS2+dEmLQR854DEJH2EIXHBw1NdC07ChuS0og2EiHEDnrd92nsjrnZwG+W+bUssnYZWpW8431UGbE5gd8fMx7GyI+Aiq0uXV/CeSlqAmimHfR23M+PY4+9P+p4zCsP8DB6xIfCiHXbqh6luW24wCVAlbgtUpdfMXMZxTgKdhrnzjaOgKJmA7eca5KJnV1u5IkJqsyIeddr3KTLcbKwCYxBlLcvhfNdGfQYCtaBJQMveOThiHtQQAwgEehSF2VzJ2kvvtAVixU2KElH111g1vSQobxa7EANxI5FCY/Ucg81VtfER6bD76JdKhxoInbz5pWNnKdpopeOV27Hsc="
+url = "https://archive.archlinux.org/packages/o/openssl/openssl-3.5.3-1-x86_64.pkg.tar.zst"
+sha256 = "9790a771d472ec25a627d644ed36bc43357c7c61e21885476030ce2cdf51ead1"
+signature = "iHUEABYKAB0WIQQ+gMoai4n2nLpX2Yp2pe+QVESaXAUCaMmANAAKCRB2pe+QVESaXJIFAP9JP8w7qDxQfCtIVF7fMN51bc4DJvteEss7hpPimasIfwD8C0rfCJZPFoPWIfsSBMh5pGp3xRtMIei9+HccB23VTAA="
+
+[[package]]
+name = "p11-kit"
+version = "0.25.9-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/p/p11-kit/p11-kit-0.25.9-1-x86_64.pkg.tar.zst"
+sha256 = "50bb5b7c611b599994d1fe26880d133f37d3257f8cd9d6eac6e120b1a95b88d1"
+signature = "iHUEABYKAB0WIQSDvIiJNRtd67toQW64rAhgDxCM3wUCaMx7rgAKCRC4rAhgDxCM31OlAP9WpwkoNZaVlM5iuVdWSgSS1Z4NET41hBlstGsHFcRcXgEA5UC+LdCKcVkKBKVTaCdFDzGm9Hyn2J//L3xmHLQxvgs="
+
+[[package]]
+name = "pinentry"
+version = "1.3.2-2"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/p/pinentry/pinentry-1.3.2-2-x86_64.pkg.tar.zst"
+sha256 = "0b5fe2bc694ba9490689a6a45e5482f791879d531e2ac335fecc4f4166c3529e"
+signature = "iQIzBAABCgAdFiEELjbYYgIhSC/EXLfyqRdkdZMmtEAFAmikcdkACgkQqRdkdZMmtEAUaRAAnP3ZTlECFIYrQWAMDH2IF9S+JOcK8hYOz8a4sVZG8+IW2zfJLr71CoSzZ1eSZ7g8USxM8bFeJScx2OEcz/BKvgolkd9YkyVp4s500SfJMS/WQv64Hns1DU3iqvxnK0z/yRUxD0kTmmDojUaQvuXygPvHYGP/emfO/fBtDTCxlK3osbIfn9MYLYSSthHIzXqhHl7SsoaHnflM3eUKj3IZlm6/KEhNm9GOcbiuOLnE9ONBZzvU7VJxSjTXJhyzua8vKbMO4ge/E8r+h5VdYc4gOJVxh7UppETcOXRzm7gE2BkutdRaKHxrljZ1FXGwGPLyJQ/d+wutXwe9sP6sk7jiIpHLzpO+1IdA6F/LKTFV+ewz4VViQgDXf0nN6J3UFpGWzPmiCTvY6rN8JQLRtvWLBNLljNCnCJUcLtOauZo3X40Pt+qlOTqX5ftv4Q1gW8ConPVBEljWl7fW5NXWxInWg7Qa3QdvkxJP+rHJ6cK87haecYmIcZ057ejLgzN7Kr++RM7SNrcrFZVwrUcKjbZvD/BdEuLQ2OpZZ8U8cR324I4jyCHa2r17MUQ6KMtm0dyoLQHGqrXUp7jaX6wptZ+WXltjJ9OmBqLS8S/wfY9jFt8JiEy6/hjPp/1lBOVx2iZOZMMTxqAlld23P25jGC/gZxJcoUiS7LIZrSKMPJBN248="
+
+[[package]]
+name = "protobuf"
+version = "32.0-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/p/protobuf/protobuf-32.0-1-x86_64.pkg.tar.zst"
+sha256 = "408ababaedb4158714ca33137dea6b60d3ccfbc2d560f670186ddb8c3e177007"
+signature = "iQIzBAABCgAdFiEE8AuW0VIoAT/8nJ0Dk7EdqkwZfj0FAmik9VQACgkQk7EdqkwZfj1F1w//QDp0ud1JhB0T+vrMYIA3nPnuXL9oqH8UYVKPOphTdZ9xIYR6a5d4NIwF2mS8Hrk0eJwIiEsMoST7XDKrCPWFttfjN2jzDx7pDGlHM5pOnoGMekgCriGHhOx5ZblAMV8dd0Z+uN60d/ihnZWCxWCYSyCfqy7Duih8IM8/TmPniztc5WotHkKEcKg5SA4u8VJ0pI6Dy4ViJB5WozncRJyAxVOzutR9xgBs/uOpc8Tu905owcgsCjzMSGzqatZwiyMlBrCrC7gnJIE/DzKR9b99BX4KfOrvtETwcQ+cVsIpqbtjNkCK7wtSQKoYTbTTV1Ykr4gFwlq5ZZHuZWJFU+Td6c9e4aybfz51UGsaSu2WElsUmO6MUWDlNefiuh+70fUPc/kfwGEPrxX9MpDxTuOYfO/aAcB/3MZe4kfHRRsuoX/PJfoCK07RPnDDM/48q0zBk8werDleKioC/PZs7hcr1hRaGs4CsNooTiW5robPv+Dsr2/daTftgoTgWdQGqKvPWPqKpxIfaii2kq2qdhMG5PukY4oCvspS/RU5EB7UjYg86TJRMLMA49xF18zwIumq8ZNHc7BBu6YJwSb4sy4oaC13sHEQv8dE6uOA+tgRGSD1tbnYS5/P7gW3n3Petr227mKCcb6y4YVhRWd2OK+kZ1cMYraQZ4Bc4ymbodQWfy0="
 
 [[package]]
 name = "rhash"
@@ -187,24 +235,48 @@ signature = "iQTHBAABCgCxFiEE5VD//9SF4mShcX4wkBwcMg6w1F0FAmUt0ElfFIAAAAAALgAoaXN
 
 [[package]]
 name = "rust"
-version = "1:1.88.0-1"
+version = "1:1.90.0-2"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/r/rust/rust-1:1.88.0-1-x86_64.pkg.tar.zst"
-sha256 = "93d186e05091ca1bc858b5f8cea760b9664e0135c9fb9d92e1bd8daca33d27f2"
-signature = "iHUEABYKAB0WIQSDvIiJNRtd67toQW64rAhgDxCM3wUCaF3bkwAKCRC4rAhgDxCM3xHqAQDwNH58ci6yFvpgZ4D1TisX2rIsqaDageva4GMP0TTr8QD/bAkMqKcSp+hRtbqwJOtGLm1CrIVSB9HXzAnsEL49Dwc="
+url = "https://archive.archlinux.org/packages/r/rust/rust-1:1.90.0-2-x86_64.pkg.tar.zst"
+sha256 = "1d29a7e18c845e0f6345a32be7473ff57dde368259815c4082461f438684284d"
+signature = "iHUEABYKAB0WIQSDvIiJNRtd67toQW64rAhgDxCM3wUCaM2YUQAKCRC4rAhgDxCM35Q7AQCDVTiMvlQ+NQn1sZWWjcDR0u+KFwII6RQVZv4l8dK39QEA5kPATVBNT5mxDRd34sDgr47WEo0gjttSyaZjCUtjIgA="
 
 [[package]]
 name = "rust-musl"
-version = "1:1.88.0-1"
+version = "1:1.90.0-2"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/r/rust-musl/rust-musl-1:1.88.0-1-x86_64.pkg.tar.zst"
-sha256 = "a197b251a90fe9b4c140f015fd4cab10719bbe2ad6edee2566738a5ca32c547f"
-signature = "iHUEABYKAB0WIQSDvIiJNRtd67toQW64rAhgDxCM3wUCaF3blgAKCRC4rAhgDxCM30K8AQCq1OK/3srVQoB+URYvdJ6qiL3K52mPWJAnrIdMWRILSgD+IFdgdwro2BHFUUd4oBEIA2rR8VisXoJG6MlZHJ9tSAI="
+url = "https://archive.archlinux.org/packages/r/rust-musl/rust-musl-1:1.90.0-2-x86_64.pkg.tar.zst"
+sha256 = "a5960b44374f9670a69c1e191fb0b53ea197444b39d883f45b628a7c19906d51"
+signature = "iHUEABYKAB0WIQSDvIiJNRtd67toQW64rAhgDxCM3wUCaM2YVAAKCRC4rAhgDxCM38AGAQCWLX+v6XvjcXNddD7lQlcGR0t0MgDUxKbWdrPq3q5wmQEAj6q4MfKDd35rtAYnGMLddIvzJ4SefJ2//2FzQ7XoNwA="
 
 [[package]]
 name = "sqlite"
-version = "3.50.2-1"
+version = "3.50.4-2"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/s/sqlite/sqlite-3.50.2-1-x86_64.pkg.tar.zst"
-sha256 = "07765fbac51a31aba81dcbb2c0c583cb333a7c17908d69b0a5f21235136785ba"
-signature = "iQEzBAABCgAdFiEErcih/MFeAdRTEEGelGV6sg8qCSsFAmhgKuYACgkQlGV6sg8qCSsg+wgApSmukLC/vtF1j7ewZTEEDMjFUf1Iw/qHZzqVvuN3o5eOmp+qhpwCatENqDBPNyL83CTUh14BMVYrrdCDEszKyBeUED6RDWanAS5moni4wqK3sPMZujX5CbFA5/6DA8S2IWWyoUBzQW7d+iMK4utoOjDEz6BAYDnqLyalmeyzA9zFPk0mhbISmipfEqARdLDomR+WJKqbsrOH/VTnMhLhkMeLc52Cy/BAHUewcJRK0JmFbUPZ3375nMwWZPVEIkMmwGCiIC+xLp3+LJFjP3Na5mH+U0AqYqDhlD9EhReQseA+485KeJo3swOZ/EMjQO9df14ex49MDg4oUcElu5ie3A=="
+url = "https://archive.archlinux.org/packages/s/sqlite/sqlite-3.50.4-2-x86_64.pkg.tar.zst"
+sha256 = "a105275542632ba9e40729777ba13ec2fdb9980eaad83e61d64203c666985d5c"
+signature = "iQEzBAABCgAdFiEErcih/MFeAdRTEEGelGV6sg8qCSsFAmjFT6oACgkQlGV6sg8qCSt4NwgAirfjWMtQyzz23EyXOflsaehy8XnPogytHCbR3Qmc//2GA+2OUOx9OET61rzC4l94snEeF7TP0ffcNuFx1Qiw8r9K0tIToI1TLFjtbupln03HAa0jJL27a8bCcR7wd/JGSG0vGSaT+2gp78J4eU0EdJ/2Ma0Vih/fKaifH7ug/vBE7HNxWEoGvKABDFHAKHCQxIwm9nSQMoWXd0+ThCzrWpkbE3XOEkQL3jE3ovYewHewchrTrryzD/VkfJlb260/r+v0UCgHrXdmiGTeEeCdH+SY0lZpmnaSDHnNZ4s624e6pnOjZyUzvp+RY6zpaufo6UxBX1qJNiv4yU5o5v3ilg=="
+
+[[package]]
+name = "systemd"
+version = "258-2"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/s/systemd/systemd-258-2-x86_64.pkg.tar.zst"
+sha256 = "63f46ade1b8927e0b9118d06c44e035b26ba78df0e4b14ff0e69a63630d2d38c"
+signature = "iHUEABYKAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCaM081AAKCRBtQr3RFuAGj2JZAQC2qTY03U4kJl3+QAwQ2IRgudTUSQQIIJuJiHKeMWQ9ggEAr5k60blqYeCBdTjHLpFKIcfvpbjWH86zwaBSUWTzxwY="
+
+[[package]]
+name = "systemd-libs"
+version = "258-2"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/s/systemd-libs/systemd-libs-258-2-x86_64.pkg.tar.zst"
+sha256 = "4bf427e683c679f1e7fbae2f21b0cbac54462a4ca0ecf9bcf02325f8635c40f2"
+signature = "iHUEABYKAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCaM081AAKCRBtQr3RFuAGj0meAQCauSboVaibw6xTTi/oTzociUHzDDyv36oaWooSsF+P3gD/VOAqLtYdpxfyUcifah7Xaj9qhEUzsEqL4mBy/vm3XAk="
+
+[[package]]
+name = "systemd-sysvcompat"
+version = "258-2"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/s/systemd-sysvcompat/systemd-sysvcompat-258-2-x86_64.pkg.tar.zst"
+sha256 = "c99ad5f11363f1193a1958ce6f0c27037bae9c646eab176a7c7094630a13b3de"
+signature = "iHUEABYKAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCaM081AAKCRBtQr3RFuAGj+ojAQDMz/ZMD5uFxeU90pg2KeYJ3x0q4uUBbtQDUN2SXzao6AEA7/EcypMklLuXH0Tj/fITXUfYQ+xKh9UU38ZhOfJLBwo="

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -87,7 +87,7 @@ log "Asset canister WASM downloaded"
 export ASSET_CANISTER_DIR="${CANISTER_DIR}"
 
 log "Running unit tests using all feature combinations"
-cargo test-all-features --all-features --profile dev --workspace -- --nocapture --skip all_intergration_tests || { log "Unit tests failed"; exit 1; }
+cargo all-features test --all-features --profile dev --workspace -- --nocapture --skip all_intergration_tests || { log "Unit tests failed"; exit 1; }
 log "Unit tests completed successfully"
 
 log "Running integration tests with all features enabled"

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -16,7 +16,7 @@ readonly CARGO_TARGET_DIR="${WORKDIR}/target/debug"
 log() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $*" >&2; }
 
 log "Downloading PocketIC v${POCKETIC_VERSION}"
-curl -fsSL --retry 3 --retry-delay 5 "${POCKETIC_URL}" -o pocket-ic.gz || {
+curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors "${POCKETIC_URL}" -o pocket-ic.gz || {
   log "Failed to download PocketIC"
   exit 1
 }
@@ -40,7 +40,7 @@ for COMMIT in ${IC_COMMITS}
 do
   log "Trying commit ${COMMIT}"
   URL="https://download.dfinity.systems/ic/${COMMIT}/binaries/x86_64-linux/ic-boundary.gz"
-  if curl -fsSL --retry 3 --retry-delay 5 -o ic-boundary.gz ${URL}; then
+  if curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors -o ic-boundary.gz ${URL}; then
     OK=1
     break
   fi
@@ -62,7 +62,7 @@ log "ic-gateway build completed"
 
 log "Downloading asset canister WASM"
 mkdir -p "${CANISTER_DIR}" || { log "Failed to create canister directory"; exit 1; }
-curl -fsSL --retry 3 --retry-delay 5 "${ASSET_WASM_URL}" -o "${CANISTER_DIR}/assetstorage.wasm.gz" || {
+curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors "${ASSET_WASM_URL}" -o "${CANISTER_DIR}/assetstorage.wasm.gz" || {
   log "Failed to download asset canister WASM"
   exit 1
 }
@@ -74,7 +74,7 @@ log "Asset canister WASM downloaded"
 
 log "Downloading large assets canister WASM"
 mkdir -p "${CANISTER_DIR}" || { log "Failed to create canister directory"; exit 1; }
-curl -fsSL --retry 3 --retry-delay 5 "${LARGE_ASSETS_WASM_URL}" -o "${CANISTER_DIR}/largeassets.wasm.gz" || {
+curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors "${LARGE_ASSETS_WASM_URL}" -o "${CANISTER_DIR}/largeassets.wasm.gz" || {
   log "Failed to download large assets canister WASM"
   exit 1
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.89.0"
+channel = "1.90.0"
 targets = ["x86_64-unknown-linux-musl"]
 profile = "default"


### PR DESCRIPTION
Updates `ic-bn-lib` to incorporate latest keepalive & other fixes.