### PR TITLE
feat(NODE-1947): Add pre-renderer proxying

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3085,6 +3085,7 @@ dependencies = [
  "ic-http-certification 3.2.0",
  "ic-http-gateway-protocol",
  "ic-transport-types 0.47.2",
+ "isbot",
  "itertools 0.14.0",
  "lazy_static",
  "maxminddb",
@@ -3116,6 +3117,7 @@ dependencies = [
  "tracing-serde",
  "tracing-subscriber",
  "url",
+ "urlencoding",
  "uuid",
  "wat",
  "woothee",
@@ -3615,6 +3617,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "isbot"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98d665d8689fd01bd1572c10fd58cf38a811f56c2d00b5ec5c0c50dc1eee956"
+dependencies = [
+ "regex",
+]
 
 [[package]]
 name = "itertools"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ ic-custom-domains-base = "0.1"
 ic-http-certification = { version = "3.1.0", optional = true }
 ic-transport-types = "0.47"
 ic-http-gateway-protocol = { package = "ic-http-gateway-protocol", git = "https://github.com/dfinity/ic-http-gateway-protocol", tag = "v0.5.1" }
+isbot = "0.1"
 itertools = "0.14.0"
 lazy_static = "1.5.0"
 maxminddb = "0.27.0"
@@ -96,6 +97,7 @@ tracing-subscriber = { version = "0.3.18", features = [
     "json",
 ] }
 url = "2.5.3"
+urlencoding = "2.1.3"
 # DO NOT upgrade, this breaks monorepo compatibility
 # Read https://github.com/uuid-rs/uuid/releases/tag/1.13.0
 uuid = { version = "=1.12.1", features = ["v7"] }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3,6 +3,7 @@ use std::{net::SocketAddr, path::PathBuf, time::Duration};
 use ::http::HeaderValue;
 use clap::{Args, Parser};
 use fqdn::FQDN;
+use http::Uri;
 use humantime::parse_duration;
 #[cfg(feature = "acme")]
 use ic_bn_lib_common::types::acme::{AcmeUrl, Challenge, DnsBackend};
@@ -97,8 +98,8 @@ pub struct Cli {
     #[command(flatten, next_help_heading = "Shedding Latency")]
     pub shed_latency: ShedShardedCli<RequestType>,
 
-    #[command(flatten, next_help_heading = "Caffeine")]
-    pub caffeine: Caffeine,
+    #[command(flatten, next_help_heading = "Prerender")]
+    pub prerender: Prerender,
 
     #[cfg(all(target_os = "linux", feature = "sev-snp"))]
     #[command(flatten, next_help_heading = "SEV-SNP")]
@@ -566,15 +567,23 @@ pub struct RateLimit {
 }
 
 #[derive(Args)]
-pub struct Caffeine {
-    /// Caffeine domain that serves the apps
-    #[clap(env, long, default_value = "caffeine.xyz")]
-    pub caffeine_domain: FQDN,
-
-    /// URL of the server-side renderer for Caffeine.
-    /// If not specified - proxying to renderer is not enabled.
+pub struct Prerender {
+    /// Domains that are eligible for pre-prender.
+    /// If no domains specified - pre-render is not active.
     #[clap(env, long)]
-    pub caffeine_renderer_url: Option<Url>,
+    pub prerender_domains: Vec<FQDN>,
+
+    /// URL of the server-side renderer
+    #[clap(env, long)]
+    pub prerender_url: Option<Uri>,
+
+    /// Secret to authenticate with a pre-renderer
+    #[clap(env, long)]
+    pub prerender_secret: Option<HeaderValue>,
+
+    /// Timeout for executing pre-render request
+    #[clap(env, long, default_value = "1m", value_parser = parse_duration)]
+    pub prerender_timeout: Duration,
 }
 
 #[cfg(test)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -97,6 +97,9 @@ pub struct Cli {
     #[command(flatten, next_help_heading = "Shedding Latency")]
     pub shed_latency: ShedShardedCli<RequestType>,
 
+    #[command(flatten, next_help_heading = "Caffeine")]
+    pub caffeine: Caffeine,
+
     #[cfg(all(target_os = "linux", feature = "sev-snp"))]
     #[command(flatten, next_help_heading = "SEV-SNP")]
     pub sev_snp: ic_bn_lib_common::types::utils::SevSnpCli,
@@ -560,6 +563,18 @@ pub struct RateLimit {
     /// Bypass token for rate-limiter that should be sent in `x-ratelimit-bypass-token` header
     #[clap(env, long)]
     pub rate_limit_bypass_token: Option<String>,
+}
+
+#[derive(Args)]
+pub struct Caffeine {
+    /// Caffeine domain that serves the apps
+    #[clap(env, long, default_value = "caffeine.xyz")]
+    pub caffeine_domain: FQDN,
+
+    /// URL of the server-side renderer for Caffeine.
+    /// If not specified - proxying to renderer is not enabled.
+    #[clap(env, long)]
+    pub caffeine_renderer_url: Option<Url>,
 }
 
 #[cfg(test)]

--- a/src/routing/middleware/is_bot.rs
+++ b/src/routing/middleware/is_bot.rs
@@ -1,0 +1,33 @@
+use std::{ops::Deref, sync::Arc};
+
+use axum::{
+    extract::{Request, State},
+    middleware::Next,
+    response::Response,
+};
+use http::header::USER_AGENT;
+use isbot::Bots;
+
+#[derive(Clone, Debug)]
+pub struct IsBot(pub bool);
+
+#[derive(Default)]
+pub struct IsBotState {
+    bots: Bots,
+}
+
+pub async fn middleware(
+    State(state): State<Arc<IsBotState>>,
+    mut request: Request,
+    next: Next,
+) -> Response {
+    let ua = request
+        .headers()
+        .get(USER_AGENT)
+        .and_then(|x| x.to_str().ok());
+
+    let is_bot = IsBot(ua.is_some_and(|x| state.bots.is_bot(x)));
+    request.extensions_mut().insert(is_bot);
+
+    next.run(request).await
+}

--- a/src/routing/middleware/is_bot.rs
+++ b/src/routing/middleware/is_bot.rs
@@ -1,4 +1,4 @@
-use std::{ops::Deref, sync::Arc};
+use std::sync::Arc;
 
 use axum::{
     extract::{Request, State},

--- a/src/routing/middleware/is_bot.rs
+++ b/src/routing/middleware/is_bot.rs
@@ -11,9 +11,23 @@ use isbot::Bots;
 #[derive(Clone, Debug)]
 pub struct IsBot(pub bool);
 
-#[derive(Default)]
 pub struct IsBotState {
     bots: Bots,
+}
+
+impl Default for IsBotState {
+    fn default() -> Self {
+        let mut bots = Bots::default();
+        bots.append(&["GoogleOther"]);
+
+        Self { bots }
+    }
+}
+
+impl IsBotState {
+    pub fn is_bot(&self, ua: &str) -> bool {
+        self.bots.is_bot(ua)
+    }
 }
 
 pub async fn middleware(
@@ -26,8 +40,50 @@ pub async fn middleware(
         .get(USER_AGENT)
         .and_then(|x| x.to_str().ok());
 
-    let is_bot = IsBot(ua.is_some_and(|x| state.bots.is_bot(x)));
+    let is_bot = IsBot(ua.is_some_and(|x| state.is_bot(x)));
     request.extensions_mut().insert(is_bot);
 
     next.run(request).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_bot() {
+        let state = IsBotState::default();
+
+        let bots = &[
+            "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/W.X.Y.Z Mobile Safari/537.36 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)",
+            "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; Googlebot/2.1; +http://www.google.com/bot.html) Chrome/W.X.Y.Z Safari/537.36",
+            "Googlebot-Image/1.0",
+            "Googlebot-Video/1.0",
+            "Mozilla/5.0 (X11; Linux x86_64; Storebot-Google/1.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/W.X.Y.Z Safari/537.36",
+            "Mozilla/5.0 (Linux; Android 8.0; Pixel 2 Build/OPD3.170816.012; Storebot-Google/1.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/W.X.Y.Z Mobile Safari/537.36",
+            "Mozilla/5.0 (compatible; Google-InspectionTool/1.0;)",
+            "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/W.X.Y.Z Mobile Safari/537.36 (compatible; Google-InspectionTool/1.0;)",
+            "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/W.X.Y.Z Mobile Safari/537.36 (compatible; GoogleOther)",
+            "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; GPTBot/1.3; +https://openai.com/gptbot)",
+            "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko); compatible; ChatGPT-User/1.0; +https://openai.com/bot",
+            "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm) Chrome/116.0.1938.76 Safari/537.36",
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36; compatible; OAI-SearchBot/1.3; +https://openai.com/searchbot",
+            "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; ClaudeBot/1.0; +claudebot@anthropic.com)",
+        ];
+
+        for ua in bots {
+            assert!(state.is_bot(ua))
+        }
+
+        let browsers = &[
+            "Mozilla/5.0 (Linux; Android 15; SM-S931B Build/AP3A.240905.015.A2; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/127.0.6533.103 Mobile Safari/537.36",
+            "Mozilla/5.0 (Linux; Android 15; SM-S931U Build/AP3A.240905.015.A2; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/132.0.6834.163 Mobile Safari/537.36",
+            "Mozilla/5.0 (Android 15; Mobile; SM-G556B/DS; rv:130.0) Gecko/130.0 Firefox/130.0",
+            "Mozilla/5.0 (Windows NT 6.3; WOW64; Trident/7.0; rv:11.0) like Gecko",
+        ];
+
+        for ua in browsers {
+            assert!(!state.is_bot(ua))
+        }
+    }
 }

--- a/src/routing/middleware/mod.rs
+++ b/src/routing/middleware/mod.rs
@@ -4,6 +4,8 @@ pub mod cors;
 pub mod denylist;
 pub mod geoip;
 pub mod headers;
+pub mod is_bot;
 pub mod preprocess;
+pub mod redirector;
 pub mod request_id;
 pub mod validate;

--- a/src/routing/middleware/mod.rs
+++ b/src/routing/middleware/mod.rs
@@ -6,6 +6,6 @@ pub mod geoip;
 pub mod headers;
 pub mod is_bot;
 pub mod preprocess;
-pub mod redirector;
+pub mod prerender;
 pub mod request_id;
 pub mod validate;

--- a/src/routing/middleware/prerender.rs
+++ b/src/routing/middleware/prerender.rs
@@ -11,11 +11,11 @@ use derive_new::new;
 use fqdn::{FQDN, Fqdn};
 use http::{
     HeaderName, HeaderValue, Method, Uri,
-    header::{CONNECTION, CONTENT_ENCODING, CONTENT_LENGTH, TRANSFER_ENCODING, USER_AGENT},
+    header::{CONNECTION, CONTENT_ENCODING, TRANSFER_ENCODING, USER_AGENT},
     uri::Authority,
 };
 use http_body_util::Full;
-use ic_bn_lib::hname;
+use ic_bn_lib::{hname, hval};
 use ic_bn_lib_common::traits::http::ClientHttp;
 use tokio::time::timeout;
 
@@ -26,11 +26,11 @@ use crate::routing::{
 };
 
 const HEADER_SECRET: HeaderName = hname!("x-worker-secret");
+const HEADER_X_PRE_RENDERED: HeaderName = hname!("x-pre-rendered");
 
-const HEADERS_TO_REMOVE: [HeaderName; 5] = [
+const HEADERS_TO_REMOVE: [HeaderName; 4] = [
     CONTENT_ENCODING,
     TRANSFER_ENCODING,
-    CONTENT_LENGTH,
     CONNECTION,
     hname!("keep-alive"),
 ];
@@ -97,7 +97,7 @@ impl PrerenderState {
             return false;
         }
 
-        if self.domains.iter().all(|x| !authority.is_subdomain_of(x)) {
+        if !self.domains.iter().any(|x| authority.is_subdomain_of(x)) {
             return false;
         }
 
@@ -113,8 +113,7 @@ impl PrerenderState {
             return false;
         }
 
-        let path = uri.path();
-        if is_static_asset(path) {
+        if is_static_asset(uri.path()) {
             return false;
         }
 
@@ -122,17 +121,21 @@ impl PrerenderState {
     }
 
     /// Encodes the URI to be usable as a query parameter and attaches it to the render URI
-    fn create_renderer_uri(&self, uri: Uri, authority: &Fqdn) -> Result<Uri, anyhow::Error> {
+    fn create_renderer_uri(
+        &self,
+        original_uri: Uri,
+        authority: &Fqdn,
+    ) -> Result<Uri, anyhow::Error> {
         // Inject authority into URI since it's missing in Axum
-        let mut parts = uri.into_parts();
-        let authority = Authority::from_str(&authority.to_string())?;
+        let mut parts = original_uri.into_parts();
+        let authority = Authority::from_maybe_shared(Bytes::from(authority.to_string()))?;
         parts.authority = Some(authority);
-        let uri = Uri::from_parts(parts)?;
+        let original_uri = Uri::from_parts(parts)?.to_string();
 
-        let encoded_uri = urlencoding::encode(&uri.to_string()).to_string();
-        let render_uri = Uri::from_str(&format!("{}?url={encoded_uri}", self.url))?;
+        let original_uri_encoded = urlencoding::encode(&original_uri);
+        let renderer_uri = Uri::from_str(&format!("{}?url={original_uri_encoded}", self.url))?;
 
-        Ok(render_uri)
+        Ok(renderer_uri)
     }
 
     /// Executes the render request with fallbacks
@@ -155,6 +158,9 @@ impl PrerenderState {
                 HEADERS_TO_REMOVE.iter().for_each(|x| {
                     v.headers_mut().remove(x);
                 });
+
+                // Add marker to show that it was pre-rendered
+                v.headers_mut().insert(HEADER_X_PRE_RENDERED, hval!("1"));
 
                 v
             }

--- a/src/routing/middleware/prerender.rs
+++ b/src/routing/middleware/prerender.rs
@@ -180,8 +180,10 @@ pub async fn middleware(
     next: Next,
 ) -> Result<Response, ErrorCause> {
     if !state.should_render(&ctx.authority, &uri, request.method(), is_bot.0) {
+        println!("not-pre-rendering");
         return Ok(next.run(request).await);
     }
+    println!("pre-rendering");
 
     // Prepare the request to send to the renderer
     let mut render_request = Request::new(Full::new(Bytes::new()));
@@ -205,9 +207,25 @@ pub async fn middleware(
 mod tests {
     use std::str::FromStr;
 
-    use crate::test::TestClient;
+    use crate::{
+        routing::{
+            domain::{CustomDomainStorage, DomainResolver},
+            middleware::{
+                is_bot::{self, IsBotState},
+                validate::{self, ValidateState},
+            },
+        },
+        test::{FakeDomainProvider, TestClient},
+    };
+    use async_trait::async_trait;
+    use axum::{Router, body::Body, middleware::from_fn_with_state, response::IntoResponse};
     use fqdn::fqdn;
+    use http::{Request, StatusCode};
+    use http_body_util::BodyExt;
     use ic_bn_lib::hval;
+    use ic_bn_lib_common::types::http::Error as HttpError;
+    use prometheus::Registry;
+    use tower::{ServiceBuilder, ServiceExt};
 
     use super::*;
 
@@ -333,6 +351,177 @@ mod tests {
                 )
                 .unwrap(),
             "https://prerenderer.caffeine.tech/render?url=http%3A%2F%2Ffoo.caffeine.abc%2Fbar%2Fbaz%3Fq%3D1"
+        );
+    }
+
+    #[derive(Debug)]
+    pub struct TestClientPrerender(StatusCode, String, bool);
+
+    #[async_trait]
+    impl ClientHttp<Full<Bytes>> for TestClientPrerender {
+        async fn execute(&self, _req: Request<Full<Bytes>>) -> Result<Response, HttpError> {
+            if self.2 {
+                return Err(HttpError::BodyTimedOut);
+            }
+
+            Ok((self.0, self.1.clone()).into_response())
+        }
+    }
+
+    fn create_router(cli: Arc<dyn ClientHttp<Full<Bytes>>>) -> Router {
+        let resolver = DomainResolver::new(
+            vec![fqdn!("caffeine.xyz"), fqdn!("caffeine.ai")],
+            vec![],
+            vec![],
+            Arc::new(CustomDomainStorage::new(
+                vec![Arc::new(FakeDomainProvider(vec![]))],
+                &Registry::new(),
+            )),
+            false,
+        );
+
+        let svc = ServiceBuilder::new()
+            .layer(from_fn_with_state(
+                ValidateState::new(Arc::new(resolver), false, false),
+                validate::middleware,
+            ))
+            .layer(from_fn_with_state(
+                Arc::new(IsBotState::default()),
+                is_bot::middleware,
+            ))
+            .layer(from_fn_with_state(
+                Arc::new(PrerenderState::new(
+                    vec![fqdn!("caffeine.xyz")],
+                    Uri::from_str("https://prerenderer.caffeine.tech/render").unwrap(),
+                    hval!(""),
+                    Duration::ZERO,
+                    cli,
+                )),
+                middleware,
+            ));
+
+        Router::new().fallback(|| async { "direct" }).layer(svc)
+    }
+
+    #[tokio::test]
+    async fn test_prerender_middleware_prerender_normal() {
+        let cli = Arc::new(TestClientPrerender(
+            StatusCode::OK,
+            "pre-rendered".into(),
+            false,
+        ));
+
+        let router = create_router(cli);
+
+        let mut req = Request::new(Body::empty());
+        *req.uri_mut() = Uri::from_static("https://caffeine.xyz/foo/bar/baz?a=b&c=d");
+        req.headers_mut()
+            .insert(USER_AGENT, hval!("Googlebot-Image/1.0"));
+
+        let resp = router.oneshot(req).await.unwrap();
+        assert!(resp.status().is_success());
+        let body = resp.into_body();
+        assert_eq!(
+            String::from_utf8_lossy(body.collect().await.unwrap().to_bytes().as_ref()),
+            "pre-rendered"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_prerender_middleware_prerenderer_error() {
+        let cli = Arc::new(TestClientPrerender(
+            StatusCode::OK,
+            "pre-rendered".into(),
+            true,
+        ));
+
+        let router = create_router(cli);
+
+        let mut req = Request::new(Body::empty());
+        *req.uri_mut() = Uri::from_static("https://caffeine.xyz/foo/bar/baz?a=b&c=d");
+        req.headers_mut()
+            .insert(USER_AGENT, hval!("Googlebot-Image/1.0"));
+
+        let resp = router.oneshot(req).await.unwrap();
+        assert!(resp.status().is_success());
+        let body = resp.into_body();
+        assert_eq!(
+            String::from_utf8_lossy(body.collect().await.unwrap().to_bytes().as_ref()),
+            "direct"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_prerender_middleware_prerenderer_bad_status() {
+        let cli = Arc::new(TestClientPrerender(
+            StatusCode::BAD_GATEWAY,
+            "pre-rendered".into(),
+            false,
+        ));
+
+        let router = create_router(cli);
+
+        let mut req = Request::new(Body::empty());
+        *req.uri_mut() = Uri::from_static("https://caffeine.xyz/foo/bar/baz?a=b&c=d");
+        req.headers_mut()
+            .insert(USER_AGENT, hval!("Googlebot-Image/1.0"));
+
+        let resp = router.oneshot(req).await.unwrap();
+        assert!(resp.status().is_success());
+        let body = resp.into_body();
+        assert_eq!(
+            String::from_utf8_lossy(body.collect().await.unwrap().to_bytes().as_ref()),
+            "direct"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_prerender_middleware_direct_other_domain() {
+        let cli = Arc::new(TestClientPrerender(
+            StatusCode::OK,
+            "pre-rendered".into(),
+            false,
+        ));
+
+        let router = create_router(cli);
+
+        let mut req = Request::new(Body::empty());
+        *req.uri_mut() = Uri::from_static("https://caffeine.ai/foo/bar/baz?a=b&c=d");
+        req.headers_mut()
+            .insert(USER_AGENT, hval!("Googlebot-Image/1.0"));
+
+        let resp = router.oneshot(req).await.unwrap();
+        assert!(resp.status().is_success());
+        let body = resp.into_body();
+        assert_eq!(
+            String::from_utf8_lossy(body.collect().await.unwrap().to_bytes().as_ref()),
+            "direct"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_prerender_middleware_direct_not_bot() {
+        let cli = Arc::new(TestClientPrerender(
+            StatusCode::OK,
+            "pre-rendered".into(),
+            false,
+        ));
+
+        let router = create_router(cli);
+
+        let mut req = Request::new(Body::empty());
+        *req.uri_mut() = Uri::from_static("https://caffeine.xyz/foo/bar/baz?a=b&c=d");
+        req.headers_mut().insert(
+            USER_AGENT,
+            hval!("Mozilla/5.0 (Windows NT 6.3; WOW64; Trident/7.0; rv:11.0) like Gecko"),
+        );
+
+        let resp = router.oneshot(req).await.unwrap();
+        assert!(resp.status().is_success());
+        let body = resp.into_body();
+        assert_eq!(
+            String::from_utf8_lossy(body.collect().await.unwrap().to_bytes().as_ref()),
+            "direct"
         );
     }
 }

--- a/src/routing/middleware/prerender.rs
+++ b/src/routing/middleware/prerender.rs
@@ -180,10 +180,8 @@ pub async fn middleware(
     next: Next,
 ) -> Result<Response, ErrorCause> {
     if !state.should_render(&ctx.authority, &uri, request.method(), is_bot.0) {
-        println!("not-pre-rendering");
         return Ok(next.run(request).await);
     }
-    println!("pre-rendering");
 
     // Prepare the request to send to the renderer
     let mut render_request = Request::new(Full::new(Bytes::new()));

--- a/src/routing/middleware/prerender.rs
+++ b/src/routing/middleware/prerender.rs
@@ -1,22 +1,39 @@
-use std::{str::FromStr, sync::Arc};
+use std::{str::FromStr, sync::Arc, time::Duration};
 
 use axum::{
     Extension,
-    body::Body,
     extract::{OriginalUri, Request, State},
     middleware::Next,
     response::Response,
 };
+use bytes::Bytes;
 use derive_new::new;
 use fqdn::{FQDN, Fqdn};
-use http::{Uri, uri::Authority};
+use http::{
+    HeaderName, HeaderValue, Method, Uri,
+    header::{CONNECTION, CONTENT_ENCODING, CONTENT_LENGTH, TRANSFER_ENCODING, USER_AGENT},
+    uri::Authority,
+};
+use http_body_util::Full;
+use ic_bn_lib::hname;
 use ic_bn_lib_common::traits::http::ClientHttp;
+use tokio::time::timeout;
 
 use crate::routing::{
     RequestCtx,
     error_cause::{ClientError, ErrorCause},
     middleware::is_bot::IsBot,
 };
+
+const HEADER_SECRET: HeaderName = hname!("x-worker-secret");
+
+const HEADERS_TO_REMOVE: [HeaderName; 5] = [
+    CONTENT_ENCODING,
+    TRANSFER_ENCODING,
+    CONTENT_LENGTH,
+    CONNECTION,
+    hname!("keep-alive"),
+];
 
 const STATIC_ASSET_EXTENSIONS: &[&str] = &[
     ".js",
@@ -65,15 +82,22 @@ fn is_static_asset(path: &str) -> bool {
 }
 
 #[derive(new)]
-pub struct RedirectorState {
-    caffeine_domain: FQDN,
-    caffeine_renderer: Uri,
-    client: Arc<dyn ClientHttp<Body>>,
+pub struct PrerenderState {
+    domains: Vec<FQDN>,
+    url: Uri,
+    secret: HeaderValue,
+    timeout: Duration,
+    client: Arc<dyn ClientHttp<Full<Bytes>>>,
 }
 
-impl RedirectorState {
-    fn should_render(&self, authority: &Fqdn, uri: &Uri, is_bot: bool) -> bool {
-        if !authority.is_subdomain_of(&self.caffeine_domain) {
+impl PrerenderState {
+    /// Whether we should prerender this request or pass it through
+    fn should_render(&self, authority: &Fqdn, uri: &Uri, method: &Method, is_bot: bool) -> bool {
+        if method != Method::GET {
+            return false;
+        }
+
+        if self.domains.iter().all(|x| !authority.is_subdomain_of(x)) {
             return false;
         }
 
@@ -98,7 +122,7 @@ impl RedirectorState {
     }
 
     /// Encodes the URI to be usable as a query parameter and attaches it to the render URI
-    fn create_render_uri(&self, uri: Uri, authority: &Fqdn) -> Result<Uri, anyhow::Error> {
+    fn create_renderer_uri(&self, uri: Uri, authority: &Fqdn) -> Result<Uri, anyhow::Error> {
         // Inject authority into URI since it's missing in Axum
         let mut parts = uri.into_parts();
         let authority = Authority::from_str(&authority.to_string())?;
@@ -106,31 +130,69 @@ impl RedirectorState {
         let uri = Uri::from_parts(parts)?;
 
         let encoded_uri = urlencoding::encode(&uri.to_string()).to_string();
-        let render_uri = Uri::from_str(&format!("{}?url={encoded_uri}", self.caffeine_renderer))?;
+        let render_uri = Uri::from_str(&format!("{}?url={encoded_uri}", self.url))?;
 
         Ok(render_uri)
+    }
+
+    /// Executes the render request with fallbacks
+    async fn render_request(
+        &self,
+        render_request: Request<Full<Bytes>>,
+        request: Request,
+        next: Next,
+    ) -> Response {
+        let render_result = timeout(self.timeout, self.client.execute(render_request)).await;
+        match render_result {
+            Ok(Ok(mut v)) => {
+                // If the request succeeded - check return code
+                if !v.status().is_success() {
+                    // Otherwise pass the request as usual
+                    return next.run(request).await;
+                }
+
+                // Remove certain headers from the response
+                HEADERS_TO_REMOVE.iter().for_each(|x| {
+                    v.headers_mut().remove(x);
+                });
+
+                v
+            }
+
+            // If we timed out or the request failed - forward as usual
+            Err(_) | Ok(Err(_)) => next.run(request).await,
+        }
     }
 }
 
 pub async fn middleware(
-    State(state): State<Arc<RedirectorState>>,
+    State(state): State<Arc<PrerenderState>>,
     Extension(ctx): Extension<Arc<RequestCtx>>,
     Extension(is_bot): Extension<IsBot>,
     OriginalUri(uri): OriginalUri,
     request: Request,
     next: Next,
 ) -> Result<Response, ErrorCause> {
-    if !state.should_render(&ctx.authority, &uri, is_bot.0) {
+    if !state.should_render(&ctx.authority, &uri, request.method(), is_bot.0) {
         return Ok(next.run(request).await);
     }
 
     // Prepare the request to send to the renderer
-    let mut proxy_request = Request::new(Body::empty());
-    let encoded_uri = state
-        .create_render_uri(uri, &ctx.authority)
+    let mut render_request = Request::new(Full::new(Bytes::new()));
+    let renderer_uri = state
+        .create_renderer_uri(uri, &ctx.authority)
         .map_err(|e| ErrorCause::Client(ClientError::MalformedRequest(e.to_string())))?;
+    *render_request.uri_mut() = renderer_uri;
+    *render_request.method_mut() = Method::GET;
+    render_request
+        .headers_mut()
+        .insert(HEADER_SECRET, state.secret.clone());
+    if let Some(v) = request.headers().get(USER_AGENT) {
+        render_request.headers_mut().insert(USER_AGENT, v.clone());
+    }
 
-    Ok(next.run(request).await)
+    // Execute the render request
+    Ok(state.render_request(render_request, request, next).await)
 }
 
 #[cfg(test)]
@@ -139,6 +201,7 @@ mod tests {
 
     use crate::test::TestClient;
     use fqdn::fqdn;
+    use ic_bn_lib::hval;
 
     use super::*;
 
@@ -165,9 +228,11 @@ mod tests {
 
     #[test]
     fn test_should_render() {
-        let state = RedirectorState::new(
-            fqdn!("caffeine.xyz"),
+        let state = PrerenderState::new(
+            vec![fqdn!("caffeine.xyz"), fqdn!("caffeine.abc")],
             Uri::from_str("http://foo/bar").unwrap(),
+            hval!(""),
+            Duration::ZERO,
             Arc::new(TestClient(1)),
         );
 
@@ -175,6 +240,13 @@ mod tests {
         assert!(state.should_render(
             &fqdn!("foo.caffeine.xyz"),
             &Uri::from_static("http://foo/script.php"),
+            &Method::GET,
+            true
+        ));
+        assert!(state.should_render(
+            &fqdn!("bar.caffeine.abc"),
+            &Uri::from_static("http://foo/script.php"),
+            &Method::GET,
             true
         ));
 
@@ -182,6 +254,7 @@ mod tests {
         assert!(!state.should_render(
             &fqdn!("foo.caffeine.foo"),
             &Uri::from_static("http://foo/script.php"),
+            &Method::GET,
             true
         ));
 
@@ -189,6 +262,7 @@ mod tests {
         assert!(!state.should_render(
             &fqdn!("foo.caffeine.xyz"),
             &Uri::from_static("http://foo/logo.png"),
+            &Method::GET,
             true
         ));
 
@@ -196,6 +270,15 @@ mod tests {
         assert!(!state.should_render(
             &fqdn!("foo.caffeine.xyz"),
             &Uri::from_static("http://foo/script.php"),
+            &Method::GET,
+            false
+        ));
+
+        // wrong method
+        assert!(!state.should_render(
+            &fqdn!("foo.caffeine.xyz"),
+            &Uri::from_static("http://foo/script.php"),
+            &Method::POST,
             false
         ));
 
@@ -203,28 +286,32 @@ mod tests {
         assert!(!state.should_render(
             &fqdn!("foo-draft.caffeine.xyz"),
             &Uri::from_static("http://foo/script.php"),
+            &Method::GET,
             true
         ));
 
         assert!(!state.should_render(
             &fqdn!("foo-draft-foo.caffeine.xyz"),
             &Uri::from_static("http://foo/script.php"),
+            &Method::GET,
             true
         ));
     }
 
     #[test]
     fn test_create_render_uri() {
-        let state = RedirectorState::new(
-            fqdn!("caffeine.xyz"),
+        let state = PrerenderState::new(
+            vec![fqdn!("caffeine.xyz")],
             Uri::from_str("https://prerenderer.caffeine.tech/render").unwrap(),
+            hval!(""),
+            Duration::ZERO,
             Arc::new(TestClient(1)),
         );
 
         // ok
         assert_eq!(
             state
-                .create_render_uri(
+                .create_renderer_uri(
                     Uri::from_static("https://foo/bar/baz?q=1"),
                     &fqdn!("foo.caffeine.xyz")
                 )
@@ -232,15 +319,14 @@ mod tests {
             "https://prerenderer.caffeine.tech/render?url=https%3A%2F%2Ffoo.caffeine.xyz%2Fbar%2Fbaz%3Fq%3D1"
         );
 
-        // bad authority
         assert_eq!(
             state
-                .create_render_uri(
-                    Uri::from_static("://foo/bar/baz?q=1"),
-                    &fqdn!("foo.caffeine.xyz")
+                .create_renderer_uri(
+                    Uri::from_static("http://foo/bar/baz?q=1"),
+                    &fqdn!("foo.caffeine.abc")
                 )
                 .unwrap(),
-            "https://prerenderer.caffeine.tech/render?url=https%3A%2F%2Ffoo.caffeine.xyz%2Fbar%2Fbaz%3Fq%3D1"
+            "https://prerenderer.caffeine.tech/render?url=http%3A%2F%2Ffoo.caffeine.abc%2Fbar%2Fbaz%3Fq%3D1"
         );
     }
 }

--- a/src/routing/middleware/redirector.rs
+++ b/src/routing/middleware/redirector.rs
@@ -1,0 +1,246 @@
+use std::{str::FromStr, sync::Arc};
+
+use axum::{
+    Extension,
+    body::Body,
+    extract::{OriginalUri, Request, State},
+    middleware::Next,
+    response::Response,
+};
+use derive_new::new;
+use fqdn::{FQDN, Fqdn};
+use http::{Uri, uri::Authority};
+use ic_bn_lib_common::traits::http::ClientHttp;
+
+use crate::routing::{
+    RequestCtx,
+    error_cause::{ClientError, ErrorCause},
+    middleware::is_bot::IsBot,
+};
+
+const STATIC_ASSET_EXTENSIONS: &[&str] = &[
+    ".js",
+    ".mjs",
+    ".cjs",
+    ".css",
+    ".map",
+    ".json",
+    ".xml",
+    ".txt",
+    ".webmanifest",
+    ".ico",
+    ".png",
+    ".jpg",
+    ".jpeg",
+    ".gif",
+    ".webp",
+    ".avif",
+    ".svg",
+    ".bmp",
+    ".tiff",
+    ".heic",
+    ".woff",
+    ".woff2",
+    ".ttf",
+    ".otf",
+    ".eot",
+    ".mp4",
+    ".webm",
+    ".ogv",
+    ".mov",
+    ".mp3",
+    ".wav",
+    ".ogg",
+    ".flac",
+    ".pdf",
+    ".zip",
+    ".gz",
+    ".br",
+    ".tar",
+    ".wasm",
+];
+
+fn is_static_asset(path: &str) -> bool {
+    STATIC_ASSET_EXTENSIONS.iter().any(|x| path.ends_with(*x))
+}
+
+#[derive(new)]
+pub struct RedirectorState {
+    caffeine_domain: FQDN,
+    caffeine_renderer: Uri,
+    client: Arc<dyn ClientHttp<Body>>,
+}
+
+impl RedirectorState {
+    fn should_render(&self, authority: &Fqdn, uri: &Uri, is_bot: bool) -> bool {
+        if !authority.is_subdomain_of(&self.caffeine_domain) {
+            return false;
+        }
+
+        if authority
+            .labels()
+            .next()
+            .is_some_and(|x| x.contains("-draft"))
+        {
+            return false;
+        }
+
+        if !is_bot {
+            return false;
+        }
+
+        let path = uri.path();
+        if is_static_asset(path) {
+            return false;
+        }
+
+        true
+    }
+
+    /// Encodes the URI to be usable as a query parameter and attaches it to the render URI
+    fn create_render_uri(&self, uri: Uri, authority: &Fqdn) -> Result<Uri, anyhow::Error> {
+        // Inject authority into URI since it's missing in Axum
+        let mut parts = uri.into_parts();
+        let authority = Authority::from_str(&authority.to_string())?;
+        parts.authority = Some(authority);
+        let uri = Uri::from_parts(parts)?;
+
+        let encoded_uri = urlencoding::encode(&uri.to_string()).to_string();
+        let render_uri = Uri::from_str(&format!("{}?url={encoded_uri}", self.caffeine_renderer))?;
+
+        Ok(render_uri)
+    }
+}
+
+pub async fn middleware(
+    State(state): State<Arc<RedirectorState>>,
+    Extension(ctx): Extension<Arc<RequestCtx>>,
+    Extension(is_bot): Extension<IsBot>,
+    OriginalUri(uri): OriginalUri,
+    request: Request,
+    next: Next,
+) -> Result<Response, ErrorCause> {
+    if !state.should_render(&ctx.authority, &uri, is_bot.0) {
+        return Ok(next.run(request).await);
+    }
+
+    // Prepare the request to send to the renderer
+    let mut proxy_request = Request::new(Body::empty());
+    let encoded_uri = state
+        .create_render_uri(uri, &ctx.authority)
+        .map_err(|e| ErrorCause::Client(ClientError::MalformedRequest(e.to_string())))?;
+
+    Ok(next.run(request).await)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use crate::test::TestClient;
+    use fqdn::fqdn;
+
+    use super::*;
+
+    #[test]
+    fn test_is_static_asset() {
+        for path in [
+            "/foo/img.png",
+            "/foo/img.gif",
+            "/bar/img.png?a=b",
+            "/foo/img.woff2?a=b&c=d#foo",
+        ] {
+            assert!(is_static_asset(Uri::from_str(path).unwrap().path()));
+        }
+
+        for path in [
+            "/script.php",
+            "/bar/foo.dat",
+            "/foo/x.foo",
+            "/foo/bar.faz2?a=b&c=d#foo",
+        ] {
+            assert!(!is_static_asset(Uri::from_str(path).unwrap().path()));
+        }
+    }
+
+    #[test]
+    fn test_should_render() {
+        let state = RedirectorState::new(
+            fqdn!("caffeine.xyz"),
+            Uri::from_str("http://foo/bar").unwrap(),
+            Arc::new(TestClient(1)),
+        );
+
+        // ok
+        assert!(state.should_render(
+            &fqdn!("foo.caffeine.xyz"),
+            &Uri::from_static("http://foo/script.php"),
+            true
+        ));
+
+        // wrong domain
+        assert!(!state.should_render(
+            &fqdn!("foo.caffeine.foo"),
+            &Uri::from_static("http://foo/script.php"),
+            true
+        ));
+
+        // static asset
+        assert!(!state.should_render(
+            &fqdn!("foo.caffeine.xyz"),
+            &Uri::from_static("http://foo/logo.png"),
+            true
+        ));
+
+        // not bot
+        assert!(!state.should_render(
+            &fqdn!("foo.caffeine.xyz"),
+            &Uri::from_static("http://foo/script.php"),
+            false
+        ));
+
+        // draft
+        assert!(!state.should_render(
+            &fqdn!("foo-draft.caffeine.xyz"),
+            &Uri::from_static("http://foo/script.php"),
+            true
+        ));
+
+        assert!(!state.should_render(
+            &fqdn!("foo-draft-foo.caffeine.xyz"),
+            &Uri::from_static("http://foo/script.php"),
+            true
+        ));
+    }
+
+    #[test]
+    fn test_create_render_uri() {
+        let state = RedirectorState::new(
+            fqdn!("caffeine.xyz"),
+            Uri::from_str("https://prerenderer.caffeine.tech/render").unwrap(),
+            Arc::new(TestClient(1)),
+        );
+
+        // ok
+        assert_eq!(
+            state
+                .create_render_uri(
+                    Uri::from_static("https://foo/bar/baz?q=1"),
+                    &fqdn!("foo.caffeine.xyz")
+                )
+                .unwrap(),
+            "https://prerenderer.caffeine.tech/render?url=https%3A%2F%2Ffoo.caffeine.xyz%2Fbar%2Fbaz%3Fq%3D1"
+        );
+
+        // bad authority
+        assert_eq!(
+            state
+                .create_render_uri(
+                    Uri::from_static("://foo/bar/baz?q=1"),
+                    &fqdn!("foo.caffeine.xyz")
+                )
+                .unwrap(),
+            "https://prerenderer.caffeine.tech/render?url=https%3A%2F%2Ffoo.caffeine.xyz%2Fbar%2Fbaz%3Fq%3D1"
+        );
+    }
+}

--- a/src/routing/mod.rs
+++ b/src/routing/mod.rs
@@ -59,8 +59,14 @@ use crate::{
     api::setup_api_router,
     cli::Cli,
     metrics::{self},
-    routing::ic::subnets_info::SubnetsInfo,
-    routing::middleware::{canister_match, cors, geoip, headers, preprocess, request_id, validate},
+    routing::{
+        ic::subnets_info::SubnetsInfo,
+        middleware::{
+            canister_match, cors, geoip, headers,
+            is_bot::{self, IsBotState},
+            preprocess, request_id, validate,
+        },
+    },
 };
 use domain::{CustomDomainStorage, DomainResolver};
 use middleware::{
@@ -519,7 +525,11 @@ pub async fn setup_router(
         .layer(load_shedder_system_mw)
         .layer(from_fn_with_state(validate_state, validate::middleware))
         .layer(concurrency_limit_mw)
-        .layer(load_shedder_latency_mw);
+        .layer(load_shedder_latency_mw)
+        .layer(from_fn_with_state(
+            Arc::new(IsBotState::default()),
+            is_bot::middleware,
+        ));
 
     let api_hostname = cli.api.api_hostname.clone().map(|x| x.to_string());
 

--- a/src/routing/mod.rs
+++ b/src/routing/mod.rs
@@ -6,7 +6,7 @@ pub mod proxy;
 
 use std::{net::IpAddr, ops::Deref, str::FromStr, sync::Arc, time::Duration};
 
-use anyhow::{Context, Error};
+use anyhow::{Context, Error, anyhow};
 use arc_swap::ArcSwapOption;
 use axum::{
     Extension, Router,
@@ -64,7 +64,9 @@ use crate::{
         middleware::{
             canister_match, cors, geoip, headers,
             is_bot::{self, IsBotState},
-            preprocess, request_id, validate,
+            preprocess,
+            prerender::{self, PrerenderState},
+            request_id, validate,
         },
     },
 };
@@ -384,7 +386,7 @@ pub async fn setup_router(
         cli.ic.ic_request_max_size,
     ));
     let state_api = Arc::new(proxy::ApiProxyState::new(
-        http_client_hyper,
+        http_client_hyper.clone(),
         route_provider,
         cli.ic.ic_request_retries,
         cli.ic.ic_request_retry_interval,
@@ -508,6 +510,31 @@ pub async fn setup_router(
         cli.misc.disable_html_error_messages,
     ));
 
+    let prerender_mw = if !cli.prerender.prerender_domains.is_empty() {
+        let url = cli
+            .prerender
+            .prerender_url
+            .clone()
+            .ok_or_else(|| anyhow!("Prerender requires an URL"))?;
+        let secret = cli
+            .prerender
+            .prerender_secret
+            .clone()
+            .ok_or_else(|| anyhow!("Prerender requires a secret"))?;
+
+        let state = PrerenderState::new(
+            cli.prerender.prerender_domains.clone(),
+            url,
+            secret,
+            cli.prerender.prerender_timeout,
+            http_client_hyper,
+        );
+
+        Some(from_fn_with_state(Arc::new(state), prerender::middleware))
+    } else {
+        None
+    };
+
     // Common layers for all routes
     let common_layers = ServiceBuilder::new()
         .layer(from_fn_with_state(
@@ -529,7 +556,8 @@ pub async fn setup_router(
         .layer(from_fn_with_state(
             Arc::new(IsBotState::default()),
             is_bot::middleware,
-        ));
+        ))
+        .layer(option_layer(prerender_mw));
 
     let api_hostname = cli.api.api_hostname.clone().map(|x| x.to_string());
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -78,7 +78,7 @@ pub fn generate_response(response_size: usize) -> Response<AxumBody> {
 }
 
 #[derive(Debug, Clone)]
-struct TestClient(pub usize);
+pub struct TestClient(pub usize);
 
 #[async_trait]
 impl Client for TestClient {
@@ -90,6 +90,13 @@ impl Client for TestClient {
 #[async_trait]
 impl ClientHttp<Full<Bytes>> for TestClient {
     async fn execute(&self, _req: Request<Full<Bytes>>) -> Result<Response<AxumBody>, HttpError> {
+        Ok(generate_response(self.0))
+    }
+}
+
+#[async_trait]
+impl ClientHttp<AxumBody> for TestClient {
+    async fn execute(&self, _req: Request<AxumBody>) -> Result<Response<AxumBody>, HttpError> {
         Ok(generate_response(self.0))
     }
 }


### PR DESCRIPTION
Currently for Caffeine to allow crawlers like GoogleBot to index the site.

If the request is to one of the configured domains, then we check if the request is eligible for pre-rendering and proxy it to the pre-render worker. If it's not eligible or the pre-render request fails - then we forward it as-is to the canister.

Conditions:
* GET
* `User-Agent` is a bot (new `is_bot` middleware handles that)
* Not a static asset
* Not a draft app
