### PR TITLE
Update crates & repro-env, remove deprecations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,7 +14,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "generic-array",
 ]
 
@@ -322,28 +322,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-stream"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
-dependencies = [
- "async-stream-impl",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-stream-impl"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "async-task"
 version = "4.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -423,38 +401,11 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.7.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
-dependencies = [
- "async-trait",
- "axum-core 0.4.5",
- "bytes",
- "futures-util",
- "http 1.4.0",
- "http-body",
- "http-body-util",
- "itoa",
- "matchit 0.7.3",
- "memchr",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "rustversion",
- "serde",
- "sync_wrapper",
- "tower 0.5.3",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "axum"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
- "axum-core 0.5.6",
+ "axum-core",
  "axum-macros",
  "bytes",
  "form_urlencoded",
@@ -465,7 +416,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "itoa",
- "matchit 0.8.4",
+ "matchit",
  "memchr",
  "mime",
  "percent-encoding",
@@ -476,30 +427,10 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tower 0.5.3",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "axum-core"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
-dependencies = [
- "async-trait",
- "bytes",
- "futures-util",
- "http 1.4.0",
- "http-body",
- "http-body-util",
- "mime",
- "pin-project-lite",
- "rustversion",
- "sync_wrapper",
- "tower-layer",
- "tower-service",
 ]
 
 [[package]]
@@ -527,8 +458,8 @@ version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9963ff19f40c6102c76756ef0a46004c0d58957d87259fc9208ff8441c12ab96"
 dependencies = [
- "axum 0.8.9",
- "axum-core 0.5.6",
+ "axum",
+ "axum-core",
  "bytes",
  "futures-util",
  "http 1.4.0",
@@ -538,6 +469,27 @@ dependencies = [
  "pin-project-lite",
  "rustversion",
  "serde_core",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-extra"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be44683b41ccb9ab2d23a5230015c9c3c55be97a25e4428366de8873103f7970"
+dependencies = [
+ "axum",
+ "axum-core",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http 1.4.0",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -578,7 +530,7 @@ checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
 dependencies = [
  "getrandom 0.2.17",
  "instant",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -612,26 +564,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
-name = "bincode"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
-dependencies = [
- "bincode_derive",
- "serde",
- "unty",
-]
-
-[[package]]
-name = "bincode_derive"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
-dependencies = [
- "virtue",
-]
-
-[[package]]
 name = "binread"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -660,7 +592,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.8.0",
 ]
 
 [[package]]
@@ -668,6 +600,15 @@ name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bit-vec"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitfield"
@@ -711,6 +652,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -760,6 +710,15 @@ checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
+]
+
+[[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
 ]
 
 [[package]]
@@ -919,21 +878,15 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.61"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
  "shlex",
 ]
-
-[[package]]
-name = "cesu8"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cfg-if"
@@ -1029,7 +982,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "inout",
  "zeroize",
 ]
@@ -1103,12 +1056,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "codicon"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12170080f3533d6f09a19f81596f836854d0fa4867dc32c8172b8474b4e9de61"
-
-[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1155,22 +1102,23 @@ dependencies = [
 
 [[package]]
 name = "console-api"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8030735ecb0d128428b64cd379809817e620a40e5001c54465b99ec5feec2857"
+checksum = "e8599749b6667e2f0c910c1d0dff6901163ff698a52d5a39720f61b5be4b20d3"
 dependencies = [
  "futures-core",
- "prost 0.13.5",
- "prost-types 0.13.5",
- "tonic 0.12.3",
+ "prost",
+ "prost-types",
+ "tonic",
+ "tonic-prost",
  "tracing-core",
 ]
 
 [[package]]
 name = "console-subscriber"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6539aa9c6a4cd31f4b1c040f860a1eac9aa80e7df6b05d506a6e7179936d6a01"
+checksum = "fb4915b7d8dd960457a1b6c380114c2944f728e7c65294ab247ae6b6f1f37592"
 dependencies = [
  "console-api",
  "crossbeam-channel",
@@ -1179,14 +1127,14 @@ dependencies = [
  "hdrhistogram",
  "humantime",
  "hyper-util",
- "prost 0.13.5",
- "prost-types 0.13.5",
+ "prost",
+ "prost-types",
  "serde",
  "serde_json",
  "thread_local",
  "tokio",
  "tokio-stream",
- "tonic 0.12.3",
+ "tonic",
  "tracing",
  "tracing-core",
  "tracing-subscriber",
@@ -1197,6 +1145,12 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "core-foundation"
@@ -1359,13 +1313,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "ctrlc"
 version = "3.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
 dependencies = [
  "dispatch2",
- "nix 0.31.2",
+ "nix 0.31.3",
  "windows-sys 0.61.2",
 ]
 
@@ -1541,7 +1504,9 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
+ "der_derive",
+ "flagset",
  "pem-rfc7468",
  "zeroize",
 ]
@@ -1572,6 +1537,17 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "rusticata-macros",
+]
+
+[[package]]
+name = "der_derive"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1611,9 +1587,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
- "const-oid",
- "crypto-common",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.0",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.1",
 ]
 
 [[package]]
@@ -1752,6 +1739,7 @@ dependencies = [
  "ff",
  "generic-array",
  "group",
+ "hkdf",
  "pem-rfc7468",
  "pkcs8",
  "rand_core 0.6.4",
@@ -1844,9 +1832,9 @@ dependencies = [
 
 [[package]]
 name = "fancy-regex"
-version = "0.16.2"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "998b056554fbe42e03ae0e152895cd1a7e1002aec800fdc6635d20270260c46f"
+checksum = "72cf461f865c862bb7dc573f643dd6a2b6842f7c30b07882b56bd148cc2761b8"
 dependencies = [
  "bit-set",
  "regex-automata",
@@ -1877,13 +1865,12 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "filetime"
-version = "0.2.27"
+version = "0.2.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+checksum = "2d5b2eef6fafbf69f877e55509ce5b11a760690ac9700a2921be067aa6afaef6"
 dependencies = [
  "cfg-if",
  "libc",
- "libredox",
 ]
 
 [[package]]
@@ -1899,6 +1886,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
+name = "flagset"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7ac824320a75a52197e8f2d787f6a38b6718bb6897a35142d749af3c0e8f4fe"
+
+[[package]]
 name = "flate2"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1910,9 +1903,9 @@ dependencies = [
 
 [[package]]
 name = "fluent-uri"
-version = "0.3.2"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1918b65d96df47d3591bed19c5cca17e3fa5d0707318e4b5ef2eae01764df7e5"
+checksum = "bc74ac4d8359ae70623506d512209619e5cf8f347124910440dbc221714b328e"
 dependencies = [
  "borrow-or-share",
  "ref-cast",
@@ -1936,21 +1929,6 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
-
-[[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -2222,9 +2200,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2296,9 +2274,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hdrhistogram"
@@ -2514,6 +2492,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
+name = "hybrid-array"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "hyper"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2547,7 +2534,7 @@ dependencies = [
  "log",
  "rustls",
  "rustls-native-certs",
- "rustls-platform-verifier 0.7.0",
+ "rustls-platform-verifier",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -2584,7 +2571,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2",
  "system-configuration",
  "tokio",
  "tower-layer",
@@ -2670,17 +2657,17 @@ dependencies = [
 
 [[package]]
 name = "ic-bn-lib"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e21032f5e1bd401dcbf460359be3401549d4694dd2971e3642b6d2595f905a9d"
+checksum = "550e056a8c0ca32fa24c9d394961bc312e3bf3eb7865643a568e2c26fdddd80a"
 dependencies = [
  "ahash",
  "anyhow",
  "arc-swap",
  "async-channel 2.5.0",
  "async-trait",
- "axum 0.8.9",
- "axum-extra",
+ "axum",
+ "axum-extra 0.12.6",
  "base64 0.22.1",
  "bytes",
  "candid",
@@ -2712,16 +2699,16 @@ dependencies = [
  "nix 0.30.1",
  "ppp",
  "prometheus",
- "prost 0.14.3",
- "prost-types 0.14.3",
- "rand 0.8.5",
- "rcgen 0.14.7",
+ "prost",
+ "prost-types",
+ "rand 0.8.6",
+ "rcgen 0.14.8",
  "regex",
  "reqwest 0.13.3",
  "rustls",
  "rustls-acme",
  "rustls-pemfile",
- "rustls-platform-verifier 0.6.2",
+ "rustls-platform-verifier",
  "scopeguard",
  "serde",
  "serde_json",
@@ -2729,10 +2716,10 @@ dependencies = [
  "serde_yaml_ng",
  "sev",
  "sha1",
- "sha2 0.10.9",
- "socket2 0.6.3",
- "strum 0.27.2",
- "strum_macros 0.27.2",
+ "sha2 0.11.0",
+ "socket2",
+ "strum 0.28.0",
+ "strum_macros 0.28.0",
  "systemstat",
  "tar",
  "tempfile",
@@ -2741,7 +2728,7 @@ dependencies = [
  "tokio-io-timeout",
  "tokio-rustls",
  "tokio-util",
- "tower 0.5.3",
+ "tower",
  "tower-service",
  "tower_governor",
  "tracing",
@@ -2749,7 +2736,7 @@ dependencies = [
  "uuid",
  "vrl",
  "webpki-root-certs",
- "x509-parser 0.17.0",
+ "x509-parser 0.18.1",
  "zeroize",
  "zstd",
 ]
@@ -2762,7 +2749,7 @@ checksum = "df3448b8f5531dd112ae0c9c9919c7477379c42d6c9d46e1a495add20b405c01"
 dependencies = [
  "anyhow",
  "async-trait",
- "axum 0.8.9",
+ "axum",
  "candid",
  "clap",
  "cloudflare",
@@ -2778,11 +2765,11 @@ dependencies = [
  "instant-acme",
  "parse-size",
  "prometheus",
- "rcgen 0.14.7",
+ "rcgen 0.14.8",
  "reqwest 0.13.3",
  "rustls",
  "serde",
- "socket2 0.6.3",
+ "socket2",
  "strum 0.27.2",
  "thiserror 2.0.18",
  "tokio-util",
@@ -2941,8 +2928,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a94efbb2f7b9cf830124a7412f49ce954dfb14f8133b923a5fee72097a35c85f"
 dependencies = [
  "anyhow",
- "axum 0.8.9",
- "axum-extra",
+ "axum",
+ "axum-extra 0.10.3",
  "axum-server",
  "base64 0.22.1",
  "candid",
@@ -2974,7 +2961,7 @@ checksum = "bb6071ccb7a051e08f6964b674310d00c663d0157c912b30173610e9c32ba0d9"
 dependencies = [
  "anyhow",
  "async-trait",
- "axum 0.8.9",
+ "axum",
  "candid",
  "chacha20poly1305",
  "chrono",
@@ -2986,7 +2973,7 @@ dependencies = [
  "ic-bn-lib",
  "ic-bn-lib-common",
  "ic-custom-domains-canister-api",
- "mockall",
+ "mockall 0.13.1",
  "pem",
  "prometheus",
  "serde",
@@ -3044,7 +3031,7 @@ dependencies = [
  "hkdf",
  "ic_principal",
  "pem",
- "rand 0.8.5",
+ "rand 0.8.6",
  "thiserror 2.0.18",
  "zeroize",
 ]
@@ -3057,8 +3044,8 @@ dependencies = [
  "anyhow",
  "arc-swap",
  "async-trait",
- "axum 0.8.9",
- "axum-extra",
+ "axum",
+ "axum-extra 0.12.6",
  "bytes",
  "candid",
  "clap",
@@ -3089,12 +3076,12 @@ dependencies = [
  "itertools 0.14.0",
  "lazy_static",
  "maxminddb",
- "mockall",
+ "mockall 0.14.0",
  "moka",
- "nix 0.30.1",
+ "nix 0.31.3",
  "pocket-ic",
  "prometheus",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rand_regex",
  "regex",
  "reqwest 0.13.3",
@@ -3102,15 +3089,15 @@ dependencies = [
  "serde",
  "serde_cbor",
  "serde_json",
- "sha2 0.10.9",
- "strum 0.27.2",
+ "sha2 0.11.0",
+ "strum 0.28.0",
  "tempfile",
  "tikv-jemalloc-ctl",
  "tikv-jemallocator",
  "time",
  "tokio",
  "tokio-util",
- "tower 0.5.3",
+ "tower",
  "tower-http",
  "tracing",
  "tracing-core",
@@ -3331,7 +3318,7 @@ dependencies = [
  "ic_bls12_381",
  "lazy_static",
  "pairing",
- "rand 0.8.5",
+ "rand 0.8.6",
  "sha2 0.10.9",
 ]
 
@@ -3357,9 +3344,9 @@ dependencies = [
 
 [[package]]
 name = "ic_principal"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2b6c5941dfd659e77b262342fa58ad49489367ad026255cda8c43682d0c534"
+checksum = "1aea751965eaf92990be8c79c64b4f3174ff22dd3604e6696a06a494afbaba2a"
 dependencies = [
  "crc32fast",
  "data-encoding",
@@ -3502,7 +3489,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -3550,7 +3537,7 @@ dependencies = [
  "hyper",
  "hyper-rustls",
  "hyper-util",
- "rcgen 0.14.7",
+ "rcgen 0.14.8",
  "ring",
  "rustls",
  "rustls-pki-types",
@@ -3572,7 +3559,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
 dependencies = [
- "socket2 0.6.3",
+ "socket2",
  "widestring",
  "windows-registry",
  "windows-result",
@@ -3590,16 +3577,6 @@ name = "ipnetwork"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf370abdafd54d13e54a620e8c3e1145f28e46cc9d704bc6d94414559df41763"
-
-[[package]]
-name = "iri-string"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
-dependencies = [
- "memchr",
- "serde",
-]
 
 [[package]]
 name = "is-terminal"
@@ -3653,22 +3630,6 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jni"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
-dependencies = [
- "cesu8",
- "cfg-if",
- "combine",
- "jni-sys 0.3.1",
- "log",
- "thiserror 1.0.69",
- "walkdir",
- "windows-sys 0.45.0",
-]
-
-[[package]]
-name = "jni"
 version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
@@ -3676,7 +3637,7 @@ dependencies = [
  "cfg-if",
  "combine",
  "jni-macros",
- "jni-sys 0.4.1",
+ "jni-sys",
  "log",
  "simd_cesu8",
  "thiserror 2.0.18",
@@ -3695,15 +3656,6 @@ dependencies = [
  "rustc_version",
  "simd_cesu8",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "jni-sys"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
-dependencies = [
- "jni-sys 0.4.1",
 ]
 
 [[package]]
@@ -3737,9 +3689,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.97"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -3749,27 +3701,28 @@ dependencies = [
 
 [[package]]
 name = "jsonschema"
-version = "0.32.1"
+version = "0.38.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24690c68dfcdde5980d676b0f1820981841016b1f29eecb4c42ad48ab4118681"
+checksum = "89f50532ce4a0ba3ae930212908d8ec50e7806065c059fe9c75da2ece6132294"
 dependencies = [
  "ahash",
- "base64 0.22.1",
  "bytecount",
+ "data-encoding",
  "email_address",
  "fancy-regex",
  "fraction",
+ "getrandom 0.3.4",
  "idna",
  "itoa",
  "num-cmp",
  "num-traits",
- "once_cell",
  "percent-encoding",
  "referencing",
  "regex",
  "regex-syntax",
  "serde",
  "serde_json",
+ "unicode-general-category",
  "uuid-simd",
 ]
 
@@ -3831,6 +3784,9 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "leb128"
@@ -3851,15 +3807,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "libredox"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
- "bitflags",
  "libc",
- "plain",
- "redox_syscall 0.7.4",
 ]
 
 [[package]]
@@ -3915,21 +3874,15 @@ dependencies = [
 
 [[package]]
 name = "matchit"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
-
-[[package]]
-name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "maxminddb"
-version = "0.27.3"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76371bd37ce742f8954daabd0fde7f1594ee43ac2200e20c003ba5c3d65e2192"
+checksum = "faf6467428ad055b71e588bcedcbaf2ff605b3251deb0c52be4a04b674c546dd"
 dependencies = [
  "ipnetwork",
  "log",
@@ -4014,7 +3967,21 @@ dependencies = [
  "cfg-if",
  "downcast",
  "fragile",
- "mockall_derive",
+ "mockall_derive 0.13.1",
+ "predicates",
+ "predicates-tree",
+]
+
+[[package]]
+name = "mockall"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f58d964098a5f9c6b63d0798e5372fd04708193510a7af313c22e9f29b7b620b"
+dependencies = [
+ "cfg-if",
+ "downcast",
+ "fragile",
+ "mockall_derive 0.14.0",
  "predicates",
  "predicates-tree",
 ]
@@ -4032,10 +3999,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "moka"
-version = "0.12.12"
+name = "mockall_derive"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3dec6bd31b08944e08b58fd99373893a6c17054d6f3ea5006cc894f4f4eee2a"
+checksum = "ca41ce716dda6a9be188b385aa78ee5260fc25cd3802cb2a8afdc6afbe6b6dbf"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "moka"
+version = "0.12.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
 dependencies = [
  "async-lock",
  "crossbeam-channel",
@@ -4071,9 +4050,9 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.31.2"
+version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -4156,6 +4135,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.6",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
 name = "num-cmp"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4214,6 +4209,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -4287,58 +4283,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
-name = "openssl"
-version = "0.10.78"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
-dependencies = [
- "bitflags",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "openssl-src"
-version = "300.6.0+3.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8e8cbfd3a4a8c8f089147fd7aaa33cf8c7450c4d09f8f80698a0cf093abeff4"
-dependencies = [
- "cc",
-]
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.114"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
-dependencies = [
- "cc",
- "libc",
- "openssl-src",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "option-ext"
@@ -4366,6 +4314,18 @@ name = "p256"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "p384"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -4406,7 +4366,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.18",
+ "redox_syscall",
  "smallvec",
  "windows-link",
 ]
@@ -4469,18 +4429,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.11"
+version = "1.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+checksum = "cbf0d9e68100b3a7989b4901972f265cd542e560a3a8a724e1e20322f4d06ce9"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.11"
+version = "1.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+checksum = "a990e22f43e84855daf260dded30524ef4a9021cc7541c26540500a50b624389"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4505,6 +4465,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
 name = "pkcs8"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4519,12 +4490,6 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
-
-[[package]]
-name = "plain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plotters"
@@ -4739,35 +4704,12 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.13.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
-dependencies = [
- "bytes",
- "prost-derive 0.13.5",
-]
-
-[[package]]
-name = "prost"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
 dependencies = [
  "bytes",
- "prost-derive 0.14.3",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.13.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
-dependencies = [
- "anyhow",
- "itertools 0.14.0",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
+ "prost-derive",
 ]
 
 [[package]]
@@ -4785,20 +4727,11 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.13.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
-dependencies = [
- "prost 0.13.5",
-]
-
-[[package]]
-name = "prost-types"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
 dependencies = [
- "prost 0.14.3",
+ "prost",
 ]
 
 [[package]]
@@ -4865,7 +4798,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.3",
+ "socket2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4903,7 +4836,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -4931,9 +4864,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -5011,7 +4944,7 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4bfbd599a8c757f89100e3ae559fb1ef9efa1cfd9276136862e3089dec627b31"
 dependencies = [
- "rand 0.8.5",
+ "rand 0.8.6",
  "regex-syntax",
 ]
 
@@ -5060,21 +4993,21 @@ dependencies = [
  "ring",
  "rustls-pki-types",
  "time",
- "yasna",
+ "yasna 0.5.2",
 ]
 
 [[package]]
 name = "rcgen"
-version = "0.14.7"
+version = "0.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10b99e0098aa4082912d4c649628623db6aba77335e4f4569ff5083a6448b32e"
+checksum = "57f6d249aad744e274e682777a50283a225a32705394ee6d5fcc01efa25e4055"
 dependencies = [
  "pem",
  "ring",
  "rustls-pki-types",
  "time",
  "x509-parser 0.18.1",
- "yasna",
+ "yasna 0.6.0",
 ]
 
 [[package]]
@@ -5082,15 +5015,6 @@ name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
 dependencies = [
  "bitflags",
 ]
@@ -5128,13 +5052,14 @@ dependencies = [
 
 [[package]]
 name = "referencing"
-version = "0.32.1"
+version = "0.38.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a3d769362109497b240e66462606bc28af68116436c8669bac17069533b908e"
+checksum = "15a8af0c6bb8eaf8b07cb06fc31ff30ca6fe19fb99afa476c276d8b24f365b0b"
 dependencies = [
  "ahash",
  "fluent-uri",
- "once_cell",
+ "getrandom 0.3.4",
+ "hashbrown 0.16.1",
  "parking_lot",
  "percent-encoding",
  "serde_json",
@@ -5215,7 +5140,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-util",
- "tower 0.5.3",
+ "tower",
  "tower-http",
  "tower-service",
  "url",
@@ -5253,14 +5178,14 @@ dependencies = [
  "quinn",
  "rustls",
  "rustls-pki-types",
- "rustls-platform-verifier 0.7.0",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
  "tokio-util",
- "tower 0.5.3",
+ "tower",
  "tower-http",
  "tower-service",
  "url",
@@ -5298,6 +5223,26 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid 0.9.6",
+ "digest 0.10.7",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -5357,9 +5302,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-acme"
-version = "0.14.1"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b49bf42910782ed684d992550c267c98fbe602320d6bb4a6362292791076eed"
+checksum = "7dcdaa66cd3bf55140f4061b0bb596650d5e8f7f0183cd263fba2a57cf740b96"
 dependencies = [
  "async-io",
  "async-trait",
@@ -5414,34 +5359,13 @@ dependencies = [
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
-dependencies = [
- "core-foundation 0.10.1",
- "core-foundation-sys",
- "jni 0.21.1",
- "log",
- "once_cell",
- "rustls",
- "rustls-native-certs",
- "rustls-platform-verifier-android",
- "rustls-webpki",
- "security-framework",
- "security-framework-sys",
- "webpki-root-certs",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "rustls-platform-verifier"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
  "core-foundation 0.10.1",
  "core-foundation-sys",
- "jni 0.22.4",
+ "jni",
  "log",
  "once_cell",
  "rustls",
@@ -5614,15 +5538,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde-big-array"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11fc7cc2c76d73e0f27ee52abbd64eec84d46f370c88371120433196934e4b7f"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "serde_bytes"
 version = "0.11.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5733,11 +5648,12 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.18.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
+checksum = "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
 dependencies = [
  "base64 0.22.1",
+ "bs58",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -5752,9 +5668,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.18.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
+checksum = "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -5790,38 +5706,36 @@ dependencies = [
 
 [[package]]
 name = "sev"
-version = "6.3.1"
+version = "7.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "420c6c161b5d6883d8195584a802b114af6c884ed56d937d994e30f7f81d54ec"
+checksum = "c2ff74d7e7d1cc172f3a45adec74fbeee928d71df095b85aaaf66eb84e1e31e6"
 dependencies = [
  "base64 0.22.1",
- "bincode",
  "bitfield",
  "bitflags",
  "byteorder",
- "codicon",
  "dirs",
  "hex",
  "iocuddle",
  "lazy_static",
  "libc",
- "openssl",
- "serde",
- "serde-big-array",
- "serde_bytes",
+ "p384",
+ "rsa",
+ "sha2 0.10.9",
  "static_assertions",
  "uuid",
+ "x509-cert",
 ]
 
 [[package]]
 name = "sha1"
-version = "0.10.6"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
- "digest 0.10.7",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -5846,6 +5760,17 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -5917,9 +5842,9 @@ checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "siphasher"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"
@@ -5968,16 +5893,6 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "socket2"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
@@ -5985,6 +5900,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "spinning_top"
@@ -6089,6 +6010,9 @@ name = "strum"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros 0.28.0",
+]
 
 [[package]]
 name = "strum_macros"
@@ -6414,10 +6338,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
-name = "tokio"
-version = "1.52.1"
+name = "tls_codec"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+checksum = "0de2e01245e2bb89d6f05801c564fa27624dbd7b1846859876c7dad82e90bf6b"
+dependencies = [
+ "tls_codec_derive",
+ "zeroize",
+]
+
+[[package]]
+name = "tls_codec_derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d2e76690929402faae40aebdda620a2c0e25dd6d3b9afe48867dfd95991f4bd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "tokio"
+version = "1.52.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -6425,7 +6370,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.3",
+ "socket2",
  "tokio-macros",
  "tracing",
  "windows-sys 0.61.2",
@@ -6492,13 +6437,12 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.12.3"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
+checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
 dependencies = [
- "async-stream",
  "async-trait",
- "axum 0.7.9",
+ "axum",
  "base64 0.22.1",
  "bytes",
  "h2",
@@ -6510,63 +6454,25 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "prost 0.13.5",
- "socket2 0.5.10",
- "tokio",
- "tokio-stream",
- "tower 0.4.13",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tonic"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
-dependencies = [
- "async-trait",
- "axum 0.8.9",
- "base64 0.22.1",
- "bytes",
- "h2",
- "http 1.4.0",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-timeout",
- "hyper-util",
- "percent-encoding",
- "pin-project",
- "socket2 0.6.3",
+ "socket2",
  "sync_wrapper",
  "tokio",
  "tokio-stream",
- "tower 0.5.3",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
 ]
 
 [[package]]
-name = "tower"
-version = "0.4.13"
+name = "tonic-prost"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
 dependencies = [
- "futures-core",
- "futures-util",
- "indexmap 1.9.3",
- "pin-project",
- "pin-project-lite",
- "rand 0.8.5",
- "slab",
- "tokio",
- "tokio-util",
- "tower-layer",
- "tower-service",
- "tracing",
+ "bytes",
+ "prost",
+ "tonic",
 ]
 
 [[package]]
@@ -6590,9 +6496,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
 dependencies = [
  "async-compression",
  "bitflags",
@@ -6602,14 +6508,14 @@ dependencies = [
  "http 1.4.0",
  "http-body",
  "http-body-util",
- "iri-string",
  "pin-project-lite",
  "tokio",
  "tokio-util",
- "tower 0.5.3",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
+ "url",
 ]
 
 [[package]]
@@ -6630,14 +6536,14 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44de9b94d849d3c46e06a883d72d408c2de6403367b39df2b1c9d9e7b6736fe6"
 dependencies = [
- "axum 0.8.9",
+ "axum",
  "forwarded-header-value",
  "governor",
  "http 1.4.0",
  "pin-project",
  "thiserror 2.0.18",
- "tonic 0.14.5",
- "tower 0.5.3",
+ "tonic",
+ "tower",
  "tracing",
 ]
 
@@ -6772,6 +6678,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
+name = "unicode-general-category"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b993bddc193ae5bd0d623b49ec06ac3e9312875fdae725a975c51db1cc1677f"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6801,7 +6713,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "subtle",
 ]
 
@@ -6816,12 +6728,6 @@ name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
-
-[[package]]
-name = "unty"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
 
 [[package]]
 name = "url"
@@ -6870,7 +6776,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b082222b4f6619906941c17eb2297fff4c2fb96cb60164170522942a200bd8"
 dependencies = [
  "outref",
- "uuid",
  "vsimd",
 ]
 
@@ -6881,33 +6786,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
-name = "virtue"
-version = "0.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
-
-[[package]]
 name = "vrl"
-version = "0.26.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ed049ec47d33934e67c8620011584450f035ef392622032076af250de4712c"
+checksum = "a51400e79d9a8efc8089d38bf7f11d07ebca5eb11c5f247c4783ec9409d048d0"
 dependencies = [
  "bytes",
  "cfg-if",
  "chrono",
- "clap",
+ "getrandom 0.3.4",
  "jsonschema",
  "lalrpop",
  "lz4_flex",
@@ -6917,6 +6810,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "serde_yaml_ng",
  "simdutf8",
  "snafu",
  "tracing",
@@ -6975,9 +6869,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -6988,9 +6882,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.70"
+version = "0.4.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
+checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6998,9 +6892,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -7008,9 +6902,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -7021,9 +6915,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
 ]
@@ -7133,9 +7027,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.97"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
+checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -7287,15 +7181,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -7319,21 +7204,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -7371,12 +7241,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -7389,12 +7253,6 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -7404,12 +7262,6 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -7437,12 +7289,6 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -7452,12 +7298,6 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -7473,12 +7313,6 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -7488,12 +7322,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -7624,6 +7452,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04a2ecdf2cc4d33a6a93d71bcfbc00bb1f635cdb8029a2cc0709204a045ec7a3"
 
 [[package]]
+name = "x509-cert"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1301e935010a701ae5f8655edc0ad17c44bad3ac5ce8c39185f75453b720ae94"
+dependencies = [
+ "const-oid 0.9.6",
+ "der",
+ "spki",
+ "tls_codec",
+]
+
+[[package]]
 name = "x509-parser"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7691,6 +7531,16 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
 dependencies = [
+ "time",
+]
+
+[[package]]
+name = "yasna"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5f6765e852b9b4dc8e2a76843e4d64d1cea8e79bcde0b6901aea8e7c7f08282"
+dependencies = [
+ "bit-vec 0.9.1",
  "time",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,18 +16,18 @@ debug = []
 
 [dependencies]
 ahash = "0.8.11"
+bytes = "1.10.0"
+axum-extra = { version = "0.12.6", features = ["middleware"] }
 anyhow = "1.0.93"
 arc-swap = "1.7.1"
 async-trait = "0.1.83"
 axum = { version = "0.8.1", features = ["macros"] }
-axum-extra = "0.10.0"
-bytes = "1.10.0"
 candid = "0.10.10"
 clap = { version = "4.5.20", features = ["derive", "string", "env"] }
 cloudflare = { version = "0.14.0", default-features = false, features = [
     "rustls-tls",
 ] }
-console-subscriber = { version = "0.4.1", optional = true }
+console-subscriber = { version = "0.5.0", optional = true }
 ctrlc = { version = "3.4.5", features = ["termination"] }
 derive-new = "0.7.0"
 fqdn = { version = "0.5.2", features = ["serde"] }
@@ -58,7 +58,7 @@ ic-http-gateway-protocol = { package = "ic-http-gateway-protocol", git = "https:
 isbot = "0.1"
 itertools = "0.14.0"
 lazy_static = "1.5.0"
-maxminddb = "0.27.0"
+maxminddb = "0.28.1"
 moka = { version = "0.12.8", features = ["sync", "future"] }
 prometheus = "0.14.0"
 rand = { version = "0.8.5", features = ["small_rng"] }
@@ -79,8 +79,8 @@ rustls = { version = "0.23.18", default-features = false, features = [
 serde = "1.0.214"
 serde_cbor = "0.11.2"
 serde_json = "1.0.132"
-sha2 = "0.10.8"
-strum = { version = "0.27.1", features = ["derive"] }
+sha2 = "0.11.0"
+strum = { version = "0.28.0", features = ["derive"] }
 tikv-jemallocator = "0.6.0"
 tikv-jemalloc-ctl = { version = "0.6.0", features = ["stats"] }
 time = { version = "0.3.47", features = ["macros", "serde"] }
@@ -109,8 +109,8 @@ hex = "0.4.3"
 httptest = "0.16.1"
 ic-certified-assets = { git = "https://github.com/dfinity/sdk.git", rev = "d65717bd6d0c172247c37dd23395c9fb13b2ba20" }
 ic-http-certification = "3.1.0"
-mockall = "0.13.0"
-nix = { version = "0.30.0", features = ["signal"] }
+mockall = "0.14.0"
+nix = { version = "0.31.0", features = ["signal"] }
 pocket-ic = "=13.0.0"
 rand_regex = "0.17.0"
 serde_cbor = "0.11.2"

--- a/repro-env.lock
+++ b/repro-env.lock
@@ -1,125 +1,101 @@
 [container]
-image = "docker.io/library/archlinux@sha256:c136b06a4f786b84c1cc0d2494fabdf9be8811d15051cd4404deb5c3dc0b2e57"
+image = "docker.io/library/archlinux@sha256:36301eef718527e362e568206b7606a3246c1fc089b24fce20c47cf68065f229"
 
 [[package]]
 name = "abseil-cpp"
-version = "20250814.1-1"
+version = "20260107.1-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/a/abseil-cpp/abseil-cpp-20250814.1-1-x86_64.pkg.tar.zst"
-sha256 = "466313af41985fd11f13cee938f30a7341da195f37d0597fe7a1abe8f3c4fb29"
-signature = "iQIzBAABCgAdFiEE8AuW0VIoAT/8nJ0Dk7EdqkwZfj0FAmjRovEACgkQk7EdqkwZfj2jqA/+LeXv8oPzhCLcpZTurD4gKz3F5flqob4mdwFJm7DJ0B2Z3f6W20ozCAwwlbrVTHNH7O0juuT+ONRhRxdgHQZAs84/V+h7Ec/SJ1LtUATZwbOBJkwp3roiHuzr56bFHU3U0EHO/S+9dhBaddazScI7jaZ9/c9O2G0rgPQZaxDprYjL/QwAlSinbEY0WWj38lTT/Zy9MmMjFxXf6btTVTmTPZ9oUpo9TCQQtGIDfHgfe7jFTp7vXFl09E1jEiULyTcWBNJGLQI8GIStEl6tyFBd00JaCRlTaCvS7V2JcC9SZwJLgSWMBSE8BXJmBBGwZ+dqSZJQ4i/JRuYj7vrfft+qJgRAhxskW1+H0hYpENYEMk0iqZztEInpEWdJcSGtj4+5j0WttBvLfaYOU803MUipjPOYUaV51zpybbZrRMoGjPCPCBY75rS9pPAWrV23ESJ9qWF9TBZcxMIrKzMEpHWBSr1DNT5J7LNSZCYK/tvKQTDYdOZj0ONkPKbVWEKbihEe8ovD5rJyMwdTamJCI2YBeL8v2tMConr9Jgkl+Hrh0bdVgaDr0y1yulVkDffcaZ1d7J4KH3tVFGm5aC7jsnJKY01s6OFbMLppjh5gR86djps3l9AvAlhrP8WGLwE16sOOQHGggWDWUC6kKl+dnMT8tu5aPrzEWR5z0nUo27ZAZzc="
-
-[[package]]
-name = "archlinux-keyring"
-version = "20251027-3"
-system = "archlinux"
-url = "https://archive.archlinux.org/packages/a/archlinux-keyring/archlinux-keyring-20251027-3-any.pkg.tar.zst"
-sha256 = "7130bcbc0c54aa5be6cc1da784836f28036ed182905515c6b0d85f1c6db1e26a"
-signature = "iHUEABYKAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCaQOTlwAKCRBtQr3RFuAGj8OZAQCjXBbOseELs5rSFVgrkdPtfhAVZ6XKUseskfZkZABvmAEAk2nksajjKxsz9pAtvWVs3Yzm4NYLkKFstBGwFRPyQA0="
-
-[[package]]
-name = "audit"
-version = "4.1.2-1"
-system = "archlinux"
-url = "https://archive.archlinux.org/packages/a/audit/audit-4.1.2-1-x86_64.pkg.tar.zst"
-sha256 = "a484b6a37593d7d520075dbdd84e4a2089baa4c49e359465c8828734116743f4"
-signature = "iHUEABYKAB0WIQRizHP4hOUpV7L92IObeih9mi7GCAUCaP1VUQAKCRCbeih9mi7GCJGuAQCE/rrAaJYfWRHXambczdFL2J9Zo6g2hsoIOoyaTN7bzwEA14NfZ1/7OoQIlty/rlaMzBfRfkYlc0E3BMUsDE7U0g4="
-
-[[package]]
-name = "binutils"
-version = "2.45+r29+g2b2e51a31ec7-1"
-system = "archlinux"
-url = "https://archive.archlinux.org/packages/b/binutils/binutils-2.45+r29+g2b2e51a31ec7-1-x86_64.pkg.tar.zst"
-sha256 = "9b4e769969e6b659868466582179adf9fc51dcdd622561e8feb5feb393faab65"
-signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCaJyzVF8UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCuAUAQDxsvXdPvY8+iaMBTGS8VC+fCzquULwmaHYltelv2vb5gD/TZ/2gh5J7JLH0XRu+BlhMYaV5gRaIiuEWUX1H2WkKAY="
+url = "https://archive.archlinux.org/packages/a/abseil-cpp/abseil-cpp-20260107.1-1-x86_64.pkg.tar.zst"
+sha256 = "84f5d6e68585d650f02aaa84e8a0a681483cca0734a67bec1c6ba09ebbd893c9"
+signature = "iQIzBAABCgAdFiEE8AuW0VIoAT/8nJ0Dk7EdqkwZfj0FAmnGwzoACgkQk7EdqkwZfj3UYQ//UIYzZaTzFYj7uqSSSF/kI8VxBi1tYifPhcc6kHVjW90SVBTPG2ess58gjU2BGV/jP7NKlwUuxiwlkFCjHkDrC0GRWyDYxOUuQFDARkH1D/yxBdvaUamnMbnrTTHaBuPoAs6hXcOhV8e5C0LKd1NblLM0dGdwuzDrHRJ1Wp7HSe2ZhK52FmBsWL2mxco7JilZLoTrmKs9loGzdsd8J+QyHurpf/c0Grh4fD+b/XhajbeJaBYdVEgyE5BgEg1MDc83NKfx+uUDO1yaP3NJQPrqyj1GtHhR9ehcxzPciVGbCkwEmEdDun256nr6Q1c2DOxqUb9Y0nxl8gtpB3lpF1nQIW/ReukU5yd7SgL5OK9A27C6BO8WniFcB/kjOD7pwZTo7vAn61WQp+drsJRRleblvxlIdexZIeV6iZdGbQcqpOPARenRiZmBsXlwARoUvPD4nRgxWJhSRJnwS+PnkSRqcDQraf2RblxBRFt1xk4SagbWuh9SJT+LSmBuUYZsOv3umlS16a6HDD1hEJn1CBllaYpvOwLBcEwBN10/R+vVM6tNFCsPCeBMNQ8T8RaNhaeqAogEoqHoxD3Eqm0DZGQD8GN6DuAeIgvMj0tJgUEN4Fkr1JNn+WBeuek/bgw8vcNgpu39Qh+hGwKosLcKDwTCap7XNIMsySbPPrZesWN5WaY="
 
 [[package]]
 name = "cmake"
-version = "4.1.2-1"
+version = "4.3.2-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/c/cmake/cmake-4.1.2-1-x86_64.pkg.tar.zst"
-sha256 = "64c3b3f0c6beb14a6036695c2c3a18e6ffa3c3b46049b357931cfb5d0c862ab7"
-signature = "iQEzBAABCgAdFiEEFRnVq6Zb9vwrc8dWek52CV2KUuQFAmjcPT8ACgkQek52CV2KUuS9pQf/bMHG7mB4V2dwXu3HkV6gub5kd0MRAqkv3KD8+26Qd8DwbGyppi6dOfIjXqsCItpTo/TOAJzxSndPsQNbgNPY9e5ex039bekvGWhRQclDQzGL2rbouQwJlLfWpO6ncvQG3hioqS2Mjqrb/NlZuQFFJd3SlMsaaO2Qkq3wCy70B1dMzdsOW6CkruKG4HrW9G6FBDRMsKnn/AjJDM3b3yokab8DqE3SW3K+GhIXEI3LPg6NEke6kEKJC80O1OcZIjJWUDDRlYPII7LG9pTfGktodOW7zlKWjbJwR1Qr8ssRVB/Q24dVTX6iorz8H0DOpRgGqTcvaErO2YWM/VJgB7/MIQ=="
+url = "https://archive.archlinux.org/packages/c/cmake/cmake-4.3.2-1-x86_64.pkg.tar.zst"
+sha256 = "a450d6b4f0785592f1c8ccfe1508f956465088f6479163e82b90f9568a0d9100"
+signature = "iQEzBAABCgAdFiEEFRnVq6Zb9vwrc8dWek52CV2KUuQFAmnnskcACgkQek52CV2KUuQHSggAlLchXADc4ASLJrPZETCcesbJbzYtpi+4fJ8xoJlIV8gT7XN4Y9q7v6sKrVIMwiIjaFhjfMnRZBaCATdXDToZt1xPVy6jW6J4HLhd/qpU0oh3iOtny0exoW+sA5Y3CtBRpOpfootWf0VkJPFphxkT48GPNgj5wsWjRa9C/gDf/9mCrIxfc8DYMqkB9lHmPcZFOiQZwTrdUNVWisE99JA49uZPCV9vzwW8ZeTkwmOw25dLuntSLzsSQN737fiwYRF0Wzv+Sd7RJGbuSuNkFcLtbX1kfcLGUkytx6xhXz6IS9v5rVD4GDzj3jgFmmR9Mk0f3frkxIERzEBK1ZeRfU6JqA=="
 
 [[package]]
 name = "compiler-rt"
-version = "21.1.4-2"
+version = "22.1.5-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/c/compiler-rt/compiler-rt-21.1.4-2-x86_64.pkg.tar.zst"
-sha256 = "c7b82d73130ef9aed70085ecb069465ac104b56037604c8a295a925992ec53f3"
-signature = "iHUEABYKAB0WIQQhkbiUMbrAqLlt6T0kR0DRfH/Q7AUCaPgdUAAKCRAkR0DRfH/Q7BAWAPsGgfyYX0gNAisaVRPDYUqnzPd404YsQqaeKfcnPDlGWQEA/ANDhTsmlNov+cssUAfc2FuIbX0uvco46Jjq/CAFYgs="
+url = "https://archive.archlinux.org/packages/c/compiler-rt/compiler-rt-22.1.5-1-x86_64.pkg.tar.zst"
+sha256 = "247d72e99e3ebbd46f8e14e162a6d162bdfcedf500af61b5a426aaab668e5320"
+signature = "iHUEABYKAB0WIQTS6V/sAVzx+RGqqww9TFAIu1yNKQUCafy6uwAKCRA9TFAIu1yNKW0eAQCtpYK/Klh3WdzGiDlzLd9IIQ/JoKHpUSJJWgEw24dXvQD9E9ZycrdYnou5D7fiNRW/QdjhnZasOGOQTLpR5OYcTgA="
 
 [[package]]
 name = "cppdap"
-version = "1.58.0-2"
+version = "1.58.0-3"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/c/cppdap/cppdap-1.58.0-2-x86_64.pkg.tar.zst"
-sha256 = "29796195345f80920d6e018d53cd0f92eb7b7d379849d262a0dbcd4b1fa573ef"
-signature = "iQEzBAABCAAdFiEEFRnVq6Zb9vwrc8dWek52CV2KUuQFAmaDH8sACgkQek52CV2KUuRK9Qf8CfghNmb2AN0lgBcvxo38BgOIfBUlC/Zyd2yymxInhogQNgj5xKGDF9ZsLzTXNuGx1s5LDrjLsyLHgJgWIg39sfdAepQtZ1kJPm5MmmIqFMwvVmQ1tPUBOgAQSWs8XL4ssYvYuN23npSh+RhkYC62GhCsJm6CXjSCpksV+F4mHnOik/khw6rPb2hj7kzi+k5x5N2G5+qm9cOcKQLgtkX0lefsAkg5ZjH1qZm3Twa0p/2xMc8cigHtdm5TTTqH9nhKk68eOTAFJvr1T9oo/UxKuQm8pOofjTcKpECFpRpGy+nkxADI08pwvFDN44GE4QAnecpchRleWnnzghh87KExIw=="
+url = "https://archive.archlinux.org/packages/c/cppdap/cppdap-1.58.0-3-x86_64.pkg.tar.zst"
+sha256 = "5c8bd9b3881ba9b2bea98eefa95df21d92b026f0c7537105d943857b22388be3"
+signature = "iQIzBAABCgAdFiEEtZcfLFwQqaCMYAMPeGxj8zDXy5IFAmnGazMACgkQeGxj8zDXy5JhQhAAtaJdE9CFS5GVdCnlKxC6yDubujzmc1LczN3GgtCIzNbIn+hbXnpNsescN+kZ+qeTtecc8cwP8qDBL81KWb1cG5VyYC61hnoI+R4P8yF0NhDRQKEbFOuNft5joN5NWRPrSKEKBkqttBA1tnV15VnXVfkkbzdCwc4xdEWFZMhNuFd9tSDux+TuYaOeshid3u2oer/JKD9o9X/3uwWDuF/U2u77nzQ2yOgerRMdHqjohmQ2pP1DbM051/6z246TLIPdvEKuDiKB5JG+fBVCHGQ6WxMxfHINvoxa77OezVS1dIcjkPOJuHSdHBHxVoMNzvSAx4VFcKMJzofwuaCEHaV3t6+lvO3rbygraqDWA3XlvO7L7Ad3TcVa467wlMUh7PqDaXq+cwaTZAsFXB9bDRoeOL9xWTSeRrZmeJDkOc1o7hZlra3A/6bc9NtsmUHZeOuT8XE3tRBsoNssPTo5FBD+ZeYtqh0d/e/I9A2iqLzlksdHSNS4kcDNA2oen0cnOPnCZyYsPXkf1sfrMKbgHne5HtHQF1I2EOXTBBMXDIDdLV8APabEKw7UtbtTFilyjeAwPzh3yW0EiLFB6n2ybR+a7mDtaK/UvxGo2w0ptiDaYcr7xtPgX/Y6aIvj9Z7jm3xu3vangBYDpqnN5a47rloXv1QClf0YSani45+Qby7b/60="
 
 [[package]]
-name = "device-mapper"
-version = "2.03.36-1"
+name = "curl"
+version = "8.20.0-6"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/d/device-mapper/device-mapper-2.03.36-1-x86_64.pkg.tar.zst"
-sha256 = "528089cec9e9dcbec5690958716a5b13e19d86324c0f81e31cebeac6e2622124"
-signature = "iHUEABYKAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCaP0BCAAKCRBtQr3RFuAGj5/4APwPbos9AmD9f5MOjo5vsGISeMPNdpfOWh9J4uhl458smQD/UmaaoeAANxpw7GFxtG4N3A2pMBK6u0AlH33Cfr8BnwY="
+url = "https://archive.archlinux.org/packages/c/curl/curl-8.20.0-6-x86_64.pkg.tar.zst"
+sha256 = "b55de8ad1a51a4d071dfe5d98a0e46daee8c837cf7d857e11e173ee113efeea1"
+signature = "iHUEABYKAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCafsCEAAKCRBtQr3RFuAGj0TGAQDDsfEGIPdEcAIdgrCnrcHy7nLObvPGF37phJ/TCTR4DAD+Ox4ucCYtOA2bM110KZTUIuHJV7//mhmVdIc/qxGTegQ="
 
 [[package]]
-name = "filesystem"
-version = "2025.10.12-1"
+name = "expat"
+version = "2.8.1-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/f/filesystem/filesystem-2025.10.12-1-any.pkg.tar.zst"
-sha256 = "6b6c3fee7432204840d3b6afc9bc1a68c28f591a47fb220071715c40cca956df"
-signature = "iHUEABYKAB0WIQRizHP4hOUpV7L92IObeih9mi7GCAUCaOvWsQAKCRCbeih9mi7GCDUkAQD0aNjLY4JEQc1r78rnbDnHnGVKf4+NK6YqOHRczT4GFAD8CFITR2hoYIkxcmNjqexDF02XAjdXtuiPwg2Iv8rT3A8="
+url = "https://archive.archlinux.org/packages/e/expat/expat-2.8.1-1-x86_64.pkg.tar.zst"
+sha256 = "6dc98b2806cc8f7cd1e2e02b0ea83c2f209c2823eec1108f726bbf88b37ab563"
+signature = "iHUEABYKAB0WIQRizHP4hOUpV7L92IObeih9mi7GCAUCagD5WQAKCRCbeih9mi7GCBOOAP92U0uk2Bc/gn1WiEmNSnKALCfmhdEaq0qvWOYF4Gf7FQEAyrljq6VtjMvFDcrDZZKpFi1JA1JchE7X4eVwIhGYxg8="
 
 [[package]]
 name = "gc"
-version = "8.2.10-2"
+version = "8.2.12-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/g/gc/gc-8.2.10-2-x86_64.pkg.tar.zst"
-sha256 = "16e9f60c65fba9911c77df1c378c1b68e3d5e4d10f6622564a03a5cc1e9142bc"
-signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCaPkUuF8UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCoZ8AQD2A2qARCOLtSKXvdSun6ipZGlqvb88DRWWh5sYyLGeTQEA2YVNWl+f2BkTw5huPZp76W88D9d+3Eso4jEhX0pCOg8="
+url = "https://archive.archlinux.org/packages/g/gc/gc-8.2.12-1-x86_64.pkg.tar.zst"
+sha256 = "f81f6053b8986150529ad125827f00cc8f7652f827cea34fe3f0e97ce078434e"
+signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCaYTRLF8UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCupJAQDxV7Cgb4mT88rVugSSNl0IZXeGsscXl5AdcpEiySPX8AD/TnTBJQ4PaBHMf2yg6MlvOx3UoY0mM7WygHcEp5Eupg4="
 
 [[package]]
 name = "gcc"
-version = "15.2.1+r22+gc4e96a094636-1"
+version = "16.1.1+r12+g301eb08fa2c5-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/g/gcc/gcc-15.2.1+r22+gc4e96a094636-1-x86_64.pkg.tar.zst"
-sha256 = "fda9f88e73477e7201a7d8a012b949b1d0c53660b4598e2252930190598f7a05"
-signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCaJyzFV8UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCtN8AP9GVil5dJ5FQ7GTYEH3KblDVoXX5Szl5Ihzbh0IJs+9hQEAl1ezL2qACtBZSZKeOqQzBtf/PHrDNdLQfwSTRvx6MwI="
+url = "https://archive.archlinux.org/packages/g/gcc/gcc-16.1.1+r12+g301eb08fa2c5-1-x86_64.pkg.tar.zst"
+sha256 = "80ecc89c7ca567a2c1d460803e1efa434040861f824c34d8fe7000bf27ad82c0"
+signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCafS5tV8UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCuUiAQCgvoBNp3cS3853nVXfsTs+d/es9OS4BeQYBmVGWL6r0AEAlA6Udb4ZVS6Bhrn9tDrQRVWgGw/cqRgWi4boE2D3rAA="
 
 [[package]]
 name = "glib2"
-version = "2.86.1-1"
+version = "2.88.1-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/g/glib2/glib2-2.86.1-1-x86_64.pkg.tar.zst"
-sha256 = "6bbccf6740dab25e8b273f7a994b077fb5f463433d7ff2122de93ba69e35ef84"
-signature = "iHUEABYKAB0WIQSDvIiJNRtd67toQW64rAhgDxCM3wUCaPevuAAKCRC4rAhgDxCM38KzAP4+PmMqEaTO7R+Qjx9qSkU0n624A7uyAoOTGWCQtdyAhgEA0PqSnxJ3Hglf3sKaNJOysGCrpXAeVMSfHB3skqwXMg0="
+url = "https://archive.archlinux.org/packages/g/glib2/glib2-2.88.1-1-x86_64.pkg.tar.zst"
+sha256 = "dc245f5234660abbde431980b24fed9cf5ecbe3cfc829ba0ffb83588c41f665c"
+signature = "iHUEABYKAB0WIQSDvIiJNRtd67toQW64rAhgDxCM3wUCafX4zwAKCRC4rAhgDxCM38M7AP9rwvszygiykkORDIiRTc2MYPigFK6qTmFshE1cW+FIFQD/RoZGEqs+4kol2IscAR0iYzWp+wyKdetso//iwxsIZQU="
 
 [[package]]
-name = "gnupg"
-version = "2.4.8-3"
+name = "gnutls"
+version = "3.8.13-2"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/g/gnupg/gnupg-2.4.8-3-x86_64.pkg.tar.zst"
-sha256 = "5d16c83cf9fd35f9a79cc290f4f586283374e0b8cebd5e17029bf7bad7a471f0"
-signature = "iHUEABYKAB0WIQRizHP4hOUpV7L92IObeih9mi7GCAUCaPnw2AAKCRCbeih9mi7GCBwXAP432DyZDVDqdippTuFdGjhgzo+2+oW1ZbUc/fmNI5K95gEAouSYavqjn829uJublvvLoMyBYdKQ5d9Zgm6P73SypAM="
+url = "https://archive.archlinux.org/packages/g/gnutls/gnutls-3.8.13-2-x86_64.pkg.tar.zst"
+sha256 = "381e8679ec096bba9d25e6bf8de1d186b1f46e892215aa2a63e1582c34a036f1"
+signature = "iQEzBAABCgAdFiEErcih/MFeAdRTEEGelGV6sg8qCSsFAmnyXAQACgkQlGV6sg8qCSuSmQf/XhEm8evSbwYD2cyGzAO1f0FgQDIjwmsO6GIw4K1aiJM0jaIseyly/2a5JMCPvqyiCTpk4Fu1iKGahPhkqV5d5MML18z8l1BA/K2hbLH/DM50W5klnLGHmR8MzL3fbvtmsIofgvmrLcVwXmm66S/Rp7fHnz9JsESngJ5GYtJLg+vwQ4wXs8q8neoYolAUgnfWoziBXm7LMoLhcvkjsdkIO+On7u1Vv/ra+mMCbRf7oTa6EoNNMv4/0GGHIzqMAnm6/eMLurk2sPjIQipfj8lcwbBGNo9bmXAQPSKrXfWtE5Kfi9xl5uo54d2unv87oeInV5MVdUShgAH3W1d9L0zwMg=="
 
 [[package]]
 name = "gtest"
-version = "1.17.0-1"
+version = "1.17.0-2"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/g/gtest/gtest-1.17.0-1-x86_64.pkg.tar.zst"
-sha256 = "e8be39f1917ae843c58128c302e583b0c570df1c8c6106239cec4c84c9b73317"
-signature = "iHUEABYKAB0WIQTrPXZP9dh+CBij4OXwXowSExrrXgUCaCCWOQAKCRDwXowSExrrXn22AP97xO8YH+V5imcJeYLJ3XZIbVh2ylHeuyJfQ5T3htys4AEAnVqyhN9n7oELrWay8yDm9qk3pOi4XH+JI/Sd28N96gQ="
+url = "https://archive.archlinux.org/packages/g/gtest/gtest-1.17.0-2-x86_64.pkg.tar.zst"
+sha256 = "fe0603bf90c88de529881dafa5e348259ed663da4c680c5025efb11edd17e943"
+signature = "iHUEABYKAB0WIQTrPXZP9dh+CBij4OXwXowSExrrXgUCaZD4ggAKCRDwXowSExrrXk/EAP9satDyWb5YsjsAEXAVHbcqbkH4R7pxR9cfrHAccJeaNwD/Rjz/PBZtpq3kKr6/zYZiBkbvn5DztRrSK2iv5lJZSQ4="
 
 [[package]]
 name = "guile"
-version = "3.0.10-1"
+version = "3.0.11-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/g/guile/guile-3.0.10-1-x86_64.pkg.tar.zst"
-sha256 = "bf4d1b474045a88c7ad97b1ce56e8dd5786e5a10de02a8d33dc8f041edc8d01d"
-signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCZnkshF8UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCruHAQDnjJsHGhq4cae34rHS1z+Hr6yzjVQSxvA6SE9XpredlAD/cstobLSMUsHswxf5df94XkoDPJdJs44uXE/iu9gsgQg="
+url = "https://archive.archlinux.org/packages/g/guile/guile-3.0.11-1-x86_64.pkg.tar.zst"
+sha256 = "dbc4c775e0474a5ac8784aab95a77f6fd23ebc930abea34c7a5e0f83dd00873d"
+signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCaS4I218UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCjiKAQCqa5N4msMDL6n3cQiVw8Cs1Jlda8Gtsf2O19E55qxHWQEA/Rl+8nsXY1xsUedEIo1DwVhhaLvCEafsKjFk4d4mMwU="
 
 [[package]]
 name = "hicolor-icon-theme"
@@ -130,20 +106,12 @@ sha256 = "22ec69012b9a55e276b5891f916366f692541dce3793bff3e85a28a10b91990a"
 signature = "iHUEABYKAB0WIQSDvIiJNRtd67toQW64rAhgDxCM3wUCZk/ttQAKCRC4rAhgDxCM39FIAP9Zcpg7ei4MUwFlnla8x7YDFRtQFp2WtiPOhyohRoMxhwEA2Fjer9ZWaLxYDvXfG3TbweF7ZzIQ621pJSfzl/HCnw8="
 
 [[package]]
-name = "iana-etc"
-version = "20251030-1"
+name = "hwdata"
+version = "0.407-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/i/iana-etc/iana-etc-20251030-1-any.pkg.tar.zst"
-sha256 = "a96affd4010a855f60684111422d1710a5dce8b5871561cea7f1469bf983af65"
-signature = "iQEzBAABCgAdFiEE5JnHn1PJalTlcv7hwGCGM3xQdz4FAmkHibAACgkQwGCGM3xQdz7a+Af/XpCfMeH5pChWqXTEDNXNYg4zF0oKaexyIftepXns8ZIDQ2lFa+MRUrDTAgL8/k02a3DROKdxPUI26dAkx4no3Bhlbd5wRY8WSNwTiNs/sSiCQhzKE4Eqm+JN+9dIdi5sjzfKDL4Gx2qeaG7/UkOrTJv1q7HCdv6wcWslrH2Jcso+tZ7Z52OLIrW6R5OYRmzAUDrBwFKJFAJ5hha92LxW5yZFLetUJHFMKL1qV+ePlBqxB984YDR2m2XfSHbWt95wiqUiDwaMAiaOktpIMsfuc4QwTh3ROST1E9rhDtGgawENgY402hcB+wnzU3AOFXwEjA7s1vIXMNXWH5gRrGrkjQ=="
-
-[[package]]
-name = "jansson"
-version = "2.14.1-1"
-system = "archlinux"
-url = "https://archive.archlinux.org/packages/j/jansson/jansson-2.14.1-1-x86_64.pkg.tar.zst"
-sha256 = "18bcb1ca84cf1a59a09d8237d379ceed73acaa1c50ab7a3339800ff665a2f230"
-signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCZ+RdUF8UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCj9MAQDhsiYeCDjvXoHp2TSRinf8gW+FDlRk53V/gtTpqofDhgEAj9NTp35ZhpycEzbbofVyGw95ZAwHVIEHLZ9jhRGHkA4="
+url = "https://archive.archlinux.org/packages/h/hwdata/hwdata-0.407-1-any.pkg.tar.zst"
+sha256 = "ae6c0fa1e3247a3b02cd7e40849245a58cabd8ec0b68ae46280b21e9075a27cf"
+signature = "iQEzBAABCgAdFiEEW34/txt/EDKaHAOrdx32Yn7faB8FAmn64HwACgkQdx32Yn7faB/lcAf6ArEFMvMuharND/eXRk2SNazRjM2u51tMlQtj8WaABPEvbjYEb46Pd5ZuXHAjU8emphGR15mz2eP8auYNUjdFIkQQPQaDs0/mYg6PsI5wQ/DMZr40AKtKV+tVWhJC3PIK/x3z2tzTVhjyR3NtQhJOwx+NFy77K33Dz0tyHkAGOvnHMX9n2C+ZUyVDTEK374G3fnb07C290aa45FxqK2rlLWF72jzg/gZY2FytDGpEDXtuahX0Pr56K6hqXeK8PBgXZOmmlwPffzWpFD4EniwR3B2G2aRaGLrnAhkC2Ma9Klaetit0FisMRDooMLlJrP41iim3SNmjQQ8hdzBdFWE7fA=="
 
 [[package]]
 name = "jsoncpp"
@@ -154,36 +122,36 @@ sha256 = "2aa066e1840850aad3b901dec9e8aaa047afcd1835576378f6ba16285c268fcb"
 signature = "iQEzBAABCAAdFiEEFRnVq6Zb9vwrc8dWek52CV2KUuQFAmblvasACgkQek52CV2KUuSEOwf/fm7VzJjRdFKN6DVeDqFkQjkfaOenZtUCQc3GuSvt9xOZ9ghv6F1Myt3Z5aDnApntNsn+zqjV+OpAPjeiJcrnS8vN+PZ8QLx2udJgO9uZ2e/SG5gkowJvjJFqB2eTL1XeUOhyFzjo2b4dC4VRMxId5oZ/o2jsa1HfRVipSYz3ulfngiJTaUlGHGqSvQc7ykmrs2cnWuCuhY9xIhhLQSo0xvYGaBuCOwCTfGmG+G/IcL+JKQh8kBkTydu92Odpig+dyyhhAZXWHXNuUN/WMxRJZUrsHWLV4eCVV8G1pZknF0o8bu77uS5rTC7hPXSLElvK3eZ+UE2A0EVoha8jn3HVFQ=="
 
 [[package]]
-name = "leancrypto"
-version = "1.6.0-1"
-system = "archlinux"
-url = "https://archive.archlinux.org/packages/l/leancrypto/leancrypto-1.6.0-1-x86_64.pkg.tar.zst"
-sha256 = "2a20a50708410f2c36c7a407e2ab78d05595ff94c85776f8b3b55753c8b0c678"
-signature = "iQEzBAABCgAdFiEErcih/MFeAdRTEEGelGV6sg8qCSsFAmj92CIACgkQlGV6sg8qCSuZ6wgAjY8E1IFA+gCMQILqEOwEWAeCUm1cHWXo3SQOz5R2qYGIhFDk62nigrlM+YIs0QYgri6CvxcCgffIh7ujtUsJTclOyyGs+AvXlh23WOrCF/5NLLjsnutQjIn2kbr45qI/qP+KRMPDn1w8Ospp0Mu7UpNa8Eh78qWdl4TGC9LnUUPlNvTq9p7RWf7/VIKzxD7Xepb4bTWkST6bexT6+z2mYfVaWMmfk+spKMF5EHgzdLVqTTHA1na1MnD86lWd1ZaC16eGvfcTqvqK+fYL2SCa2x93aA7ZwxS0bGUU54LmetHDtnvJA1IW4ePiR+7jP5KMCTUS8Mdw8eu9CfDMJVkEYA=="
-
-[[package]]
-name = "libcap"
-version = "2.77-1"
-system = "archlinux"
-url = "https://archive.archlinux.org/packages/l/libcap/libcap-2.77-1-x86_64.pkg.tar.zst"
-sha256 = "16a575cf5266f6187d0a11930f8cfa9ba38df92a842f430c9e965dba689063bd"
-signature = "iHUEABYKAB0WIQRizHP4hOUpV7L92IObeih9mi7GCAUCaP/c7AAKCRCbeih9mi7GCO70AQDHNcUnROkchgSjgRMO6O56243jue7qbsUm/zAX3lLgRAEAqo9CSqCJ04H1M6nZ/CM+mUmV8JOfnwqk1b37dr2QPAM="
-
-[[package]]
 name = "libedit"
-version = "20250104_3.1-1"
+version = "20251016_3.1-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/l/libedit/libedit-20250104_3.1-1-x86_64.pkg.tar.zst"
-sha256 = "9b4167ade67f899d5f4d1e0d3e8e8f18b5edfdd076f5aeffd100cb3093117987"
-signature = "iQEzBAABCAAdFiEEW34/txt/EDKaHAOrdx32Yn7faB8FAme8RWMACgkQdx32Yn7faB9bnQf+N2KYErONnv0FLvqScucx7dhD+DNMqRFEEruhqsnAtP9KZzRePYMys6Uhn4TlIysatDnz6qy2UMeXuLOKDAYXMz4M37lfRT6YsBzbNj93FQlVrfelM/ap6U3vGBnHUVv8zqPoI6SgF+qqRuDJtoE3DR6TiiHgYm2oHRR/0NwF9S3hxqVkc+Ebmz7VTTlXW0x/g2uOKRqPyJR17GCuVrRWW/B0eIYrNIVVTE9jcMVKC5Uil+OAYd1bPoTQRgolw/Vp13QnHyUC4u8OwM3yl1b3CWjdRkwz7ImS+K5aF6z9/bUGzPwM1WmPkiz4TNeYHqxnKAQ9GnSLZOJBv1rMl3mI+g=="
+url = "https://archive.archlinux.org/packages/l/libedit/libedit-20251016_3.1-1-x86_64.pkg.tar.zst"
+sha256 = "62fd156cc247c3feb8a750efdfbf5842d9a7c07327890339d4342095d6c86f51"
+signature = "iQIzBAABCgAdFiEEtZcfLFwQqaCMYAMPeGxj8zDXy5IFAmmnYnMACgkQeGxj8zDXy5IRKw/+M9+I0lNV6GAHsqFT85ZxcO1HhZux3sdo1/PZsT81Tana8kud9jHGjDfS7zOItz6a0pJ7Q/7CL5BKUd7T6TKLjhFeuiZeBfREiiHqXoXnFopZZzEiXGLu0qDjS1Q8jPfs3BydLIa7niUx6uCjDBegULZkJgyEg+zeUc60tzywrb8/Ii6/MKazq7dmMVU6F+ZQH4Nv/jovsnT6RWS0YexKF0qMZzDRaUCZs7pHkllQJCWPa2O3OdUEhTopKxqWn5UeeMmdeIyyqy7cBhGKmQbbK7wxhQkIpK3Q2By7fLldeXOsrqD64xHXL7dupuXqI+6U/uO8KsNhbJRY2JRI2nUsqDwM8qxoR9OTpjJuBbFX6PzpgluB9c0WD/ISO60o/bcd4iXdkfCb66Tk+Oav6dr5tRVj7ifFzrmmV4Av6UMwtajKiebckOc4WXmgAd4Rd8uMAecFS+Mz7ZIKwaJkFRHGa7L57FpLAh0ox58cILYdqXJdUcwT4vTQvKEXO3ZIvcKmQBc8PhD/iSjEln5KcQy/2B3+e2n3gsVbggykMYHhFY6ae1x2b5Knt17NqCLTj/ITbgAdsrBFikkRCUKHMKthz8YcSYL/tUkrSd0AmxVMteSZUO19bqj0ZTwrU2eI2zqPon4j2rhAEEpohfpfvPDoOvronFeObj0S+nF4IGbmzp8="
 
 [[package]]
 name = "libelf"
-version = "0.194-1"
+version = "0.195-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/l/libelf/libelf-0.194-1-x86_64.pkg.tar.zst"
-sha256 = "e8a0c340301c947e44e77bd1bda1e08ae429050f69597bb6f1bd4db56412f2ff"
-signature = "iHUEABYKAB0WIQRizHP4hOUpV7L92IObeih9mi7GCAUCaPxx3QAKCRCbeih9mi7GCGr6AQDctp6urzhWqHnF9mkjJG9yIeRt0w7cGCNTA+PmY7wTQAD9EFVikFYLqWg7rdzhAHag22KOsA+wXKZvJLd48JH9rQA="
+url = "https://archive.archlinux.org/packages/l/libelf/libelf-0.195-1-x86_64.pkg.tar.zst"
+sha256 = "e7faf9dc2d9dab8975a4a95ce0804c45b3fe69c1551ccb4c05c52003cb2e75c1"
+signature = "iQJLBAABCAA1FiEEwQA0ZnZjToDJQPuenAL/QZ/svhYFAmnjfU0XHGZveGJvcm9uQGFyY2hsaW51eC5vcmcACgkQnAL/QZ/svhbxqg/8DGBgcos38yvljfVizgfic9tpeMU2aFipOy0szxl0drQsC1SNO9LoYimjK0zzyQCPtqrkAFjoCgStV9gq6xn8zry2NfvqYuDXYcshlbZ+ey5zNzjtMwsPyXtONSeexP4KI2EzKy9LhUQeF2SMs/W4inS2r1dxlLnfBvZhJghdO3e28Wz08zw+KbizhIr1b/dtD9W8+kSL3flKvFj+4WDWdf+4vWPJIqUy2VEl8gkvrZpRPMimrog+9PvMA778PqCTCoX6EenIhno9rhx8MFgFWHIP2xW3PKPgmhjOCtH6s1zxCN5zYS1i8UCfXmGj1Rp4KAUstphXFOKuLjmMHxllftlvI0HvMhdEC0N/8fHM/wa0XqxBs/xn0ysqBSoRp2fI/A3z5D4KOZCIPYFeL02wzgolK6bl65vZK80/HCToyyNxv4rH9r4Ka5+Hr1nEd3CDwKmjDMISJ7JTBzv//qpQwuqLP08I2ZbqaP6XCN6i5e0CSNMpG6/OTynn1zQ0NDTpBTGByVQtowko0VqmHdgkly4GPKqCV7IrP6R+tJmpbnFVwkRgs3up9xlDnphp1oSM4jLSUNPMlQqMyyCNzz0lGpBMmshhfgVFN9iePfe6ZFUh64OinzikJxjEyWvHkfbz15gB5j986DwYbhkA0Td8HEOWU1sLfdYB3SfI+FcOJJM="
+
+[[package]]
+name = "libgit2"
+version = "1:1.9.3-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/l/libgit2/libgit2-1:1.9.3-1-x86_64.pkg.tar.zst"
+sha256 = "676caaf7c963aedc46db0a3475064344d9eea74fe0d8429c6c6aa438b5d00a7e"
+signature = "iHUEABYKAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCafl5IgAKCRBtQr3RFuAGj5YOAP460nYsYISWcglMsp+ZuvB1buTRmP3N2GpNDO88QKnhLQD/WONQLtk1BqMrG09NepuDz4/3AVnri64jDURi+t6i7Q0="
+
+[[package]]
+name = "libgpg-error"
+version = "1.61-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/l/libgpg-error/libgpg-error-1.61-1-x86_64.pkg.tar.zst"
+sha256 = "7d5a5b39f588b275558f5e13bd792bff84cf89abb6d48e3e494d6c30e8ea9ca4"
+signature = "iQEyBAABCgAdFiEErcih/MFeAdRTEEGelGV6sg8qCSsFAmn8smkACgkQlGV6sg8qCSvbxgf4ofr+pdCIe+566ohHSxoUw5m8MIv2QSUbXbX/1ExhMJkipVhdS976rl0u5SQEsXuYLx7+XpsKvOgwG2bBE5V5gMuiwAzqfwijefuroyqqMrMfgMv1C4oKS0GcWc9R3kQtDM/xAap4OR75KqkeWt+t3vBV2z/HdBdOZeJXPprPFjYeye5c466JcoJCcxDO3Nl9qZiIsK4NY1rDRn0y8K69v/1dOcfIZu3dvAHczIMub2rTOt7MVSKFBA+AvTRnFI7VC/N+Z5LmZVunoCNaLnuIIc9yANfedS+UkFdvGc2giAcveb/n92dwzDHv3p79YYFgdnvydsGKqn7gabB7NVp6"
 
 [[package]]
 name = "libisl"
@@ -195,91 +163,91 @@ signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCZtWJeV8UgAAAAAAuAChpc3N
 
 [[package]]
 name = "libmpc"
-version = "1.3.1-2"
+version = "1.4.1-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/l/libmpc/libmpc-1.3.1-2-x86_64.pkg.tar.zst"
-sha256 = "10554706eb15ed2186fbd55fd5db8fa5919788ac9a75d26c0b9ef5bdfca9d470"
-signature = "iQEzBAABCAAdFiEEFRnVq6Zb9vwrc8dWek52CV2KUuQFAmaHCZwACgkQek52CV2KUuRjbAf/TmL9cCMXYTGsNmR2om6kT7XjczfZoFR9AM0FSTUNy5AuNZNUUCfm6ie6F4rFwHc3nETOSojScOZauZlcNiLrVriHYYFSZ8EhKiCJCo68a7KTbceBNoBuT6AEIpGMpIMti/cvWhu8VXl5JIRo8LNPBzDih05aCDUJ2nayKPYNHalDayu87sDXzJYXuzC8KD7XmUa7Kirn0ZpA4VZXc8CUjYYvn0wvRwLKQP4WMpszxmblQWjMVbQxh7dwC+gPtqIANVjoGKMRfr6QpT03XXIEaTBKbMsxeYFvwn+y2JN30t6oFI6LJADZ22VwimEzu06u+x9c+3+pr4k7Py43OCOGmg=="
-
-[[package]]
-name = "libnghttp2"
-version = "1.68.0-1"
-system = "archlinux"
-url = "https://archive.archlinux.org/packages/l/libnghttp2/libnghttp2-1.68.0-1-x86_64.pkg.tar.zst"
-sha256 = "5069aca35ac522e8a7de7ddb2b4d6c62e4d6d05b7e19288b7de2c1e3d9d69d96"
-signature = "iHUEABYKAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCaP3nogAKCRBtQr3RFuAGj/P4AQDOZluKnoOJ2vpWxsppZpAwBS43FfQ36kOxcGlECoIB7wEA3AXN6q4a/ImR6trAUW+ubxkYB6wsMZEdFFTkLuCluAU="
+url = "https://archive.archlinux.org/packages/l/libmpc/libmpc-1.4.1-1-x86_64.pkg.tar.zst"
+sha256 = "880bdba957ebe5136449c7b61821e92628d7bdd43f370e5a0818d229372d3851"
+signature = "iQEzBAABCgAdFiEEFRnVq6Zb9vwrc8dWek52CV2KUuQFAmnhAlsACgkQek52CV2KUuSBcgf9E61NpAV+F+wHPlOgZOT9yurZAhQwUNd4SRQkNEFrbyMJ1C3Bu9vUayr05Q+MxeQ8/J0W5aACrWSOEAtvYlu9vfmzbn7/S9rHtH9fmvmj46hZemo48cVTq9YTQA1Doe5e9j3DTOWdEsWv7XCMSIXGI2RdIXYB+TH1DLNi7B95EwDySH7SpznjH+SGv9ttVMsmAChRbGR3fIVi6hz6OgSGErFJJmTI5jwt06U6L7Yhl/4ybvYXuh1DGhdFpNhJBGLcYmQhBhv3OGa2dwj051fEjneL2PK80u4nmc+3dP7cOW3pY8jBDpOVfRvnAwiY/NuJMK1YK3iFd3YbYQnuu1D2cQ=="
 
 [[package]]
 name = "libuv"
-version = "1.51.0-1"
+version = "1.52.1-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/l/libuv/libuv-1.51.0-1-x86_64.pkg.tar.zst"
-sha256 = "4a4e992621b881a221becb6b9669bb4092ffebec8d87bd90f235866356cc5c35"
-signature = "iHUEABYKAB0WIQRUwf0nM2HqUUojd5Pylr3lA2jGzgUCaAuLRwAKCRDylr3lA2jGzrT/AP43Gr5SSjnTzsFRn9PXhiwSxSD9n3wnk+MY0BWz1QKiYwD/XYWd0OVkTq6LSIbIBsmp5msI8fCiYMyVKNBHimfBNAU="
+url = "https://archive.archlinux.org/packages/l/libuv/libuv-1.52.1-1-x86_64.pkg.tar.zst"
+sha256 = "a77eec1bc392f68df6b199d4eb912e0720a40eed214f1ce09b8cbaf00a382dcc"
+signature = "iHUEABYKAB0WIQRUwf0nM2HqUUojd5Pylr3lA2jGzgUCaas73QAKCRDylr3lA2jGzqkwAP9YcLuN7XGiltwvEeN6sQ2ed2mNjfG+ge6SztfkkJOyIQEA9ritERF2MBL0aqZcIdx4A979gvzas4cXbnoN79ca3Qk="
 
 [[package]]
 name = "lld"
-version = "21.1.4-1"
+version = "22.1.5-3"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/l/lld/lld-21.1.4-1-x86_64.pkg.tar.zst"
-sha256 = "6140b090753c5ec85b8f794f48f72916759151b59434de47966a8f32acfa6471"
-signature = "iHUEABYKAB0WIQQhkbiUMbrAqLlt6T0kR0DRfH/Q7AUCaPfyUAAKCRAkR0DRfH/Q7G2zAQCXGvSjHxhBEqe11w9if9e3SoPUNG/FmolyRKvOUOsstAD+JYokvBsmp7EhKl+vYKzX68hIW0uhJ4iZPM4HdzH1TQg="
+url = "https://archive.archlinux.org/packages/l/lld/lld-22.1.5-3-x86_64.pkg.tar.zst"
+sha256 = "63ee376649e81e82896557965aea3b580cfc586bb0aff9ea7e1323df60b79b62"
+signature = "iHUEABYKAB0WIQTS6V/sAVzx+RGqqww9TFAIu1yNKQUCaf8l5wAKCRA9TFAIu1yNKZIZAP9x47L46/b1+pD/kAX3GSy4S6AKKFeOMzPkmCNiuIv6cQD9GUHaZjFuVBcQOYu6LcoQpD9ZxRXz+yvYN7mYxwDwvw8="
+
+[[package]]
+name = "llhttp"
+version = "9.3.1-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/l/llhttp/llhttp-9.3.1-1-x86_64.pkg.tar.zst"
+sha256 = "e93332a577aacebdef11d0626df9a4f45dd6468187309693ccaa8de1547dc71c"
+signature = "iQIzBAABCgAdFiEEsNZSlUdmBrcfDG+CqF6BHrTKLggFAmmQzoAACgkQqF6BHrTKLgjUNw/+KlDsMf3ITF8QKgoEMWg57td+bZVbLijaRgOWlbJozcO76Ri8mOhCOv+mIpT/H44upsBeCHkooYi1YmV48m7vLbtBPcqKpr5d1+ccfh3BTzPZXZacw5jUASifAD84M2w4g2GrvrfUn4lFvy8WAYWUmYLEKdMIXVR9abV0M+B8yrNxgeyPzbHHlleJ9tGHHVuTV99GbRsA5HktkrknfoLKZnzMt+jk1uqhqLAPZaSJ41oFwhRyEkCXqOUb2kEqlSJo6Y94n/ipy50pk04RjiB5D75VTm/lJHPBFOIH/bA20K/G15EBH7ql7D9M/tFWaBWaErlTSKf/hT+x8NIf913dcnCxzDBwinMUnrsiJJyp4gSa+dRKgu6BOuF5z35neZVLYHNtyhQmWGzMc0J6w0mhLFqglhEFen+G9NMTfhu9agvxHAZKgA3hnZEsBs09F6XvgZN5jA23pNUKL+lw0hBd6zgPM5yILHVXsBPgGuwr7NjvfBKx10z/uHRz+Jtvm0r5KSTlq4pwz1sWNoSwKQN/2Hb8YdEw1DLoxYXSpDcDtPhUGqZz4wExfFoC+Qo2M1hp7zRTRrRkwf9S8Lnx7IxEX9Qv0miqoJTEkB0TnIsLlg2sT9AISOMHbB6eMyPLscS/PYB3QzJ4uv5RMQx1zJ7GuY7XahJGYY0moYFfcrWFoSw="
 
 [[package]]
 name = "llvm-libs"
-version = "21.1.4-1"
+version = "22.1.5-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/l/llvm-libs/llvm-libs-21.1.4-1-x86_64.pkg.tar.zst"
-sha256 = "6b213d7594e0e34d1a97f84821bb7bf5666d20fbec859ec9eac26faa49df8c36"
-signature = "iHUEABYKAB0WIQQhkbiUMbrAqLlt6T0kR0DRfH/Q7AUCaPfBzwAKCRAkR0DRfH/Q7NlkAP98hx8a6pGHF3O1Ir4btvKNQ+yWNe2+AbfvEbovxzj0xgEAi998cU+T89zkMsnBsQlTDHsCiRGZSZjzw50CA9+7/Ac="
+url = "https://archive.archlinux.org/packages/l/llvm-libs/llvm-libs-22.1.5-1-x86_64.pkg.tar.zst"
+sha256 = "4694118dbf5704a482c82bd0ea292f891068ef36935f897bea73743187bc3482"
+signature = "iHUEABYKAB0WIQTS6V/sAVzx+RGqqww9TFAIu1yNKQUCafy4/AAKCRA9TFAIu1yNKdU1AP9hn3ew7dYYkgFxQ6Q6rgETUJuASDqZmiBdG4kQMamFXAEA5dNjMQIMAAzyugJHR0bMzNjJeJ4kz3jN4mG43qcttww="
 
 [[package]]
 name = "lua"
-version = "5.4.8-2"
+version = "5.5.0-2"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/l/lua/lua-5.4.8-2-x86_64.pkg.tar.zst"
-sha256 = "ae687129437b412be66e64cfddaff3093354a92412a78955ba6d3ece43c08bef"
-signature = "iQIzBAABCgAdFiEEj8FaBklQqZ3RvRTdOeS4d+YuuRUFAmhMs+IACgkQOeS4d+YuuRWSGRAAsULD+7/dbGYWpRaWKqjnj15nIyHkGTyJsVFM0nFdXQYtzP+WBhrvGNH5xj1sHGEWboH88w12RhCqOguOaLRnn6uONaxbZsdMykybiByCxtcU4GyQRdcaOfR35daerONPf2laJ5NlS3w34rmjjJyetquqTqo+z3pLUAEoqjLp56SxgimNU+GtC/x5G81GArnvWJhwbsFe8VcWCHV1B/oblRFfSBKsfw/RU3u0PoBVbbnudHk0Rcdigm/NnXfgVaUtOfcTdfbOpA61gqTW/1BXatf6LJKdRb2Wey/kaCDTfPQTO/TEPnH7hrqbpC1SrL2KG2OYD8jTmW7z1dwUnclBkVMZt3MPR/CL/JGZlzERo1Fmde/HSBMk6TUkwYdU3rHzOyMgJ1PFxU6qgj0spM4FaO+dB/Zo4FpRZS8bQ1Gob1WaQfzEXsP9t+YmHi6fmE2aylH/0OUVjALLMMA6ZnA9XxnooChssJiCAU2/M1ZVbjd4BcbmM1NLWHzjonafyWfjRrKiyzG0haF9gqLDZjOOZ8fDhuPHaEY6yxgfHpE4VZtIdhcY2a+uVshC8ZhnaoaKAL1x6JtkbNLTY7n/PgiCxUx0gH7sLtWIqdKXyCkKzOREzq6J1no+XBOmBk4gpy4/V2pOTUgTJt+wZd90SLzEkXpzVxvJHy14DWjj4L6pEvo="
+url = "https://archive.archlinux.org/packages/l/lua/lua-5.5.0-2-x86_64.pkg.tar.zst"
+sha256 = "969a87f28839b2e6a0040fff088d51673f497e6ea3515eb94aabd6f4a1696337"
+signature = "iQIzBAABCgAdFiEEsNZSlUdmBrcfDG+CqF6BHrTKLggFAmmFrHIACgkQqF6BHrTKLgi5FBAAySVaKuatglE+f3uywWRDlUpyWEfGuvj8z8kdJeucizRkg4AYuHPNBhXTh/8vfNIRiniK8C0DGyE0oFfqK1LoRlrXNbeXFDJM2uAVJ9iQGQQYg3AGFhmh7hjW+KI1rrmaJfB2zQC+Z9uSBToObJM/MLO+27lk3D0AiVnm1z0E/v/X5WxEkaFXMJThCCvFkZbS79zqIRJTFJZ30Rc0Z9MAKZmVeILyBZVkMkNk2VUWCwfl7N1W0GrClv/FRBIteJ2ey+yLoktVgz8i6mifOXL5f3lVmJdb7wWIRD3rRSx1GrR6bj70kyCr1+gcxOqnJPCpXvV59M7raToowO5MD4enjHcMLDDQNQLcqh7lW+UtcjV0dP93zootQYKO9EYHOOBluglsPS2p+q8bjn+YpcGU3pjlnBsu4kTUoD1k0OKKNeIth/Uvnh+UFaTc4pIWW8DqllYTRH0ZSKXZ6OYsqO5eu6ucPXgiorazLamyFGoOnbRj16BrRfLRFDoWz2jGaaOobuEFnMUEw1k1/5Holny06wrGCeA1nLmLfJzoz9Ex+nS2bRrpG0EV0x6htZ2YpA7AUxPEVvGyrLgnFU08JJloI3qzG90/OQ4LZB0AZOpZ3ED6HE7PUJe1bYCukSTQBz23XI3oYAG+i9NfrtPQbYeCtIgjJq5OjOumZIn3QDl8334="
 
 [[package]]
 name = "make"
-version = "4.4.1-2"
+version = "4.4.1-3"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/m/make/make-4.4.1-2-x86_64.pkg.tar.zst"
-sha256 = "7c1bc0d882f7c8d1bcb305eb7efaabc19ed6afa5a9a443575fa0d5ed57985535"
-signature = "iHUEABYKAB0WIQSZH24/B2XPYpWIhYYTmwnaW/DTOAUCZBT0lQAKCRATmwnaW/DTOKwJAP9/kfT3rO0NhbD8wuI6ajzjyKtrl4SfuU0yu/PKByXQOgD/aYSvsyXylJhCadU2smO4LbP2Vj9fnIvEwPvbXbesVQ0="
+url = "https://archive.archlinux.org/packages/m/make/make-4.4.1-3-x86_64.pkg.tar.zst"
+sha256 = "b03efac9175b986a5f29302336fb1271874464644de3191e6a40079eb8cc5276"
+signature = "iQIzBAABCgAdFiEELjbYYgIhSC/EXLfyqRdkdZMmtEAFAmnaRRkACgkQqRdkdZMmtEDRLA/7BjiS9bh2OQqIhpLnFJSSPNtxSHbFHBoKPsIkXrEj7zSBZ/CX2ze1PlDMs6su0PQ4BYMtsq31c+UnUxO8Ux20a8VWwywpZcLzLgOsLLqAuDmsBr8VavsrIzNIo78S/ua2qnQ0nYNp/N/YXH+dHBcPTvuypqt6gRWWmm9UrG2co4GI3qIqBLR2ZKimrrIA6zqNcllmxJXPycRF006ovr3tikcBy6mh7AONXncyYPFqk+u3/+W49VEtY2XEK+Nu4+fSdU5+Z2STFu61yPXZbBz7b3Mt7TTVTlGmyBbPXCeyy6LaN6xnbzZDuySOdGg9jLKxs5OgYiDhh4rODRZmk6HhYFkl/uQjWU+zdKAuHARHLmzlwdVZUDm3NP0vWNvEeqxtDLPGmp8S6aOJPvwA17cyMx69jGtBtab7dcJem5EmO0GkGsTmu/tU/7XVu6dzK3TmentSKAH+dBJNg23R37diIddGuLZQjxeMMsjp9F9cD7kSWQTbuVKPBsjv95jfhlNPYirCGL/l2iMz9XO7W2f6HQlXingZVAynSnPeGkW2crEMyIdlOmFZZvi/fArhQWtWyFa08MjbcTPxEuVJKFLEbYA6Es86hnxkD8Cy4G/pUY0gwgUA9i88kHEEVmC5VCutO/y51ogFJvV6zpEIkSjVrYwJ2lx7vIlN9IdRspA1Xe0="
 
 [[package]]
 name = "musl"
-version = "1.2.5-6"
+version = "1.2.6-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/m/musl/musl-1.2.5-6-x86_64.pkg.tar.zst"
-sha256 = "b858891e1c97517cab07a7c060affc47bef7819266e0157554d59f3ecad79fef"
-signature = "iQJLBAABCgA1FiEEiee5MxxK59f699MFwTIpOVS75K0FAmg/nssXHHNwdXB5a2luQGFyY2hsaW51eC5vcmcACgkQwTIpOVS75K0KiQ/+N+8Vg90QUuC+EsFzt4kFOkD74IZjPDSyfsNbIgP1y8curfRtZJDR+hcWzYQEbHB6jjVBZeAgVlEaYQQsSWCXthcXslEfNyCP3FWp5hNC6VFibfZhZbg45T4P/4lCd1UuOdY02UmX8yo8rmmltCYPk/AGvoi89nAwRRhj8UU30pQfufouha2jJ178Lgv8eT6qqUjS5KCkaeheg3yUPb1W6br4Lm55owk3GtVxe2hQ2hMmJU3Dzavy80PBZb0bD5JvPQJ0R13IET5+Qn/a7XkJL1oxPmCM+TLcdobnCYNjXXNL1egYKoeaqYvMa95VPnXysjlIVcijBB2xpHaMd5x47y73c6yfBmrp3zYqEZcV4ZmpUG8bCq3XL8IUq29wDkI7W02vNyUYsbyBox37a0eG5orLR2K2Oj6bH2xJl2PcJC9HMoLvoCopQlU3+xUAEjbYQVpoMdryuJUQfmYjDOCZOG6ilYoM0burw9naf0yE/17wKIVZegAOtYcKIN731NGgKCWgfJ25/kqSWFjAPQLGFrtUbJuJ5UX3vCmUz8uG0KLGXdoNPssI2W1zEFDjANWGxXKk2s1ysAMCtnDqOTfmmxqlyYTIdjtT5fBbgQyjtXYi3+ktqnsgulS/Fq/ST99+5/z/HRqAJY06pjrmDgR/wNC4kzWEF5YSCe12KWU/zpk="
+url = "https://archive.archlinux.org/packages/m/musl/musl-1.2.6-1-x86_64.pkg.tar.zst"
+sha256 = "193b040c7174637ebcb7449914017e4b300089884a659d00bce59888744dc184"
+signature = "iQJLBAABCgA1FiEEiee5MxxK59f699MFwTIpOVS75K0FAmm/In4XHHNwdXB5a2luQGFyY2hsaW51eC5vcmcACgkQwTIpOVS75K11JBAAtrp8Ovvj6VJOhuR/QKfUDDCpWbcvh+wyqSwXIgRGBR3+m5+HcHkaTUGxtodWpCjiEJeM303SGTgPVsSKlUpNzK/emqhRpKX6pETNvFCjGYZGplvBhdh/LNRf/OMzU2Ld16woc4RUYKciV1LDohB1XVMHpG//QkTHcLOJT4G57NJoS9t0JumxPdZUwEbVrYG56wEMIIVABfY2zb2iFCrjkr1N8GlTCnI8HXpsq0E4yMkhIZ/a1dkFEDmWgFX8g+7JaVVbMFGDaJMGBIM/9bI7Ydc9JtXFbC6aRizF86ZfZdlK3xj0/WAFaqDoj1/O3aToaTqYic/qgPeOqo/nBOyyMxPU9dpz3RBOD9poSiLhjvhERyMSGwuGeAt8D2EGsrUjhJvydF84WfF0ZhlIZIWh1pW+Rf/CPzMeeM3eipLv58HTj5v70JSJuinTM0oIHWoIhsyZPz39dW0UJ+Qqi455f8h8Nj3a/UZfwElNqwLFkV4Qjt9qSRy8twaBNlQuh04PpRhSktRiXNKqc4Ldvcuo/9rhxdByORyfaelYL7OvyX5DyZqmlr1MmtREu4mHU2wN0znRfGinGdVNcqFtFScaABM2tnG8ZE1fOngHg6+P7cFzYYNN8PRaNUHGmSEmbHOoC3k236GmWbCTbDfcZcLauORmJg5GxxoW64PO53CdBRs="
 
 [[package]]
-name = "pacman-mirrorlist"
-version = "20251021-1"
+name = "nettle"
+version = "4.0-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/p/pacman-mirrorlist/pacman-mirrorlist-20251021-1-any.pkg.tar.zst"
-sha256 = "2c0bc24705f4c6f1325291e366eb367853f47763bc37b4ecf00bf6eca3a02e3c"
-signature = "iQEzBAABCgAdFiEEW34/txt/EDKaHAOrdx32Yn7faB8FAmj3GfAACgkQdx32Yn7faB/efwf9FQzLBm8//mGHsiJ3LYCuyjXdluD4/yIZGhgB3K4Ba3mVVVParj6S2zb9BRmazl6yjy7eUDJYzv5u8yjjBLEgmi/G3/zbEI4nMH/GHglOOaz1mx1E8AX+HA68rAsuw5uGaZTSr2yjMfB7jLSgnaBN1tIrK6vtJ2XQmCJRviA5fgYd4eaBxNbv1Z6EK0Nzw8V54TPR2qxlDL+g3pPhBy/in88n64CZSccb8wqLVm8A9CMhSGxD65Ykf/wdHa5IVXxvNgVku5Tz5s977JK2cHE0GVQq3Z70N8mZ0nJK0M5MQ7w34Knfhm0h6h/I8fmEwCXHUt51GB+QSW7olajzbSRE2g=="
+url = "https://archive.archlinux.org/packages/n/nettle/nettle-4.0-1-x86_64.pkg.tar.zst"
+sha256 = "679138a8405ca383aba7836d54fdc282db9394b7dc23c097b8965f70119adf13"
+signature = "iQEzBAABCgAdFiEErcih/MFeAdRTEEGelGV6sg8qCSsFAmnyWiAACgkQlGV6sg8qCStpDAgAo5ldL6CUnrLyJdgSJpTvyVbXyHpEHzBKgB6dFclj0rkgOG+RkT8yfXtnnSOM2KDLAayjnlc2YhcvgS6KHQU4Mk44CDzZIR9ino3PkpktB+F5IHiLPPrvZmfUs9kMM2OQqsFhSwEDV8AmRbub7rRL/sUZ+gCAWqcI7c/0wNd21nbgzrTdZvQD8oX6Ce9e3r9yvbyzxwea8jDwt+jTX4BdTr3XuCHv1W/oaqSMY9xw6tedxkwoNG2FJWxxb3zOvF5ujPnGSlKikGGYkkqXip/ikeHwRSd7LRu64rSwvdS6Q89qSaXvn88A8GhaDM8GlprfYy08JwuQyMlMHGHuR0s0CA=="
 
 [[package]]
-name = "pcre2"
-version = "10.47-1"
+name = "pacman"
+version = "7.1.0.r9.g54d9411-2"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/p/pcre2/pcre2-10.47-1-x86_64.pkg.tar.zst"
-sha256 = "54e0d8c998d2748f47fead1926b04357719bdd00fa1cea84901c3af501aab002"
-signature = "iHUEABYKAB0WIQRizHP4hOUpV7L92IObeih9mi7GCAUCaPjQFgAKCRCbeih9mi7GCGYRAQCETj0JBs1qGDMjVf5jrCg1ViOyEZBSdoLN+mjjP4YcAgEAyd0DoOT6R3O5ewVaoXwazx5YCEbSqDqYkKCKTgrlcQg="
+url = "https://archive.archlinux.org/packages/p/pacman/pacman-7.1.0.r9.g54d9411-2-x86_64.pkg.tar.zst"
+sha256 = "2092ec7a0391416e4a1757c455bc071d7b58a124cedc83f582cb7d37d52f211b"
+signature = "iHUEABYKAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCafsCRAAKCRBtQr3RFuAGjyafAQCx4yIjOB4jkD7O3w4d1/J4FpASbwGRJY3HKSHs/yyzMAEA1wtPIrTB4JigNv/GHqUGbkcNfuTenATlAa8bDXuEsAk="
 
 [[package]]
 name = "protobuf"
-version = "32.1-1"
+version = "34.1-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/p/protobuf/protobuf-32.1-1-x86_64.pkg.tar.zst"
-sha256 = "c8a2a11f54e301b9475ba1f7fdf8e3eaf1d17dafa5e4d8baf79237be3d4c8b19"
-signature = "iQIzBAABCgAdFiEE8AuW0VIoAT/8nJ0Dk7EdqkwZfj0FAmjQZyoACgkQk7EdqkwZfj0xwg//fHJsDqUWVF0vQ8/Ora1tjALp8+xUpYOl/EitnpXUzuZG7VafQp5ZagjPPwJ9pctiV+elQBQovWy0LxMECQbMBOah+DR55Ju0Lk7xR2PAJ99VvKozYtZZ0kKgQgIpMQ0xKw3n9jy/klkQBdTdDUbGxOJlF7zMxpHO+mKduiaM+Ri9yvhVfxYmC7R7EuAf+Rwx2TbRQhHsdufDdMpAxPj4B0ZcrsnmW0sIpuzaNHdJEisZaIjDyJMWH4c5wp5z6eLTy1VoGjBWeMgvAWocqxyxsgho8S8yh4a9hLpN2+vEwIHMZOjTmWTVHlS83ft8sKQx3jJdh7cJnPRy91W7uf3PbfsvCb172Ih6cTN3wtwbXyr7SfPY36YJ8THMJrgiwHLh9fJI7UI3NBrn7nIS7kCIZXIiYkfo3M9s23iMiVvkr/xwWkvEaUTEKFE2NSD07J7aTeNJy4bo3fU0Hv5J7Jj5q1BzlH3zaqdJMifP0F9h1zD+ZPXQpIn8FSvBxJ5xfAAfYdvC2PELrUmAbOJw2bSCzBGmbSVd9e7AA+K76Ky2yHCpMC/H7rs3b4ZLw9OktzIQwsx2SXKfT+8gEFoMC4Uet378w/N34iUqYIAcnTx/qHBbadudbyf6iZe2vyqzm0oB+dxB86KHsVostQtgOyXlPfrUYa0WGGl7xWAJU/Ic/3g="
+url = "https://archive.archlinux.org/packages/p/protobuf/protobuf-34.1-1-x86_64.pkg.tar.zst"
+sha256 = "f1781a1490e7eb5da64f248c8eea62d753ceba7dd7fb6aee6591c09ef9278019"
+signature = "iQIzBAABCgAdFiEELjbYYgIhSC/EXLfyqRdkdZMmtEAFAmnG07gACgkQqRdkdZMmtEB39BAAxQphXHOxzQUxP1gsfg34Oc+VlOu939WszvTX3RoENQ7Dzi3wFclxBT7YRywgecBzwaKkWEu4hUnp9e+/xG+np5sLHRDRqMKpfIKiIrAtFiSmdKSTrEApjlRAdLJNlNZ8/mOER4k+4LA4eH5hVcvRtOfmv4k7wrkLtrZWgfX1OAiMW7b0Rjle6iZX+ungjbnztREmhRTZaF5VP9NLbj9SWansCusgyPBn/cpxfAPUN22n3htm0YspeFG/2fsFO6/Rz+FXjvbJp0pPjcmqS0Tgq+lkfflZpPNQP0U/iBLTBZGErI8bVNMTF/y6xv2pVRwTC5jCJM1MunJ9gdYXZyG4Z5IivBDU2H11irDgCaSx3EEQ66KnYkmk/+7KdmlpYe6u8Yvk8bxCU+gnvbmT01UJ3FBbOCakqymDyLQdnszJa0JdEMyq94elLeyjxOUUvhY4S4buGO1/D1v7xDSz1p7DFgisIO7X+wR/zlsl/q4/7ltXeCSuLBd/+JoXuQLbNJFXxAOLOjFM0KZV3bL7idyWxIQpobXTWDX7Ue3ONEsWaAbQDfeUmHvT3PjBjJwNxIIGRMYGHD/SdQLez/uG8bV3OD9S6qUO4guJSdnsBToDqkxadfTVoA4KctB7GijXjTT9tS28ewfmQXj0bOqrMiWmCzIU+VIAm6J9rd7Ipp3dMB4="
 
 [[package]]
 name = "rhash"
@@ -291,16 +259,24 @@ signature = "iHUEABYKAB0WIQTrPXZP9dh+CBij4OXwXowSExrrXgUCaPVaqgAKCRDwXowSExrrXvp
 
 [[package]]
 name = "rust"
-version = "1:1.91.0-1"
+version = "1:1.95.0-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/r/rust/rust-1:1.91.0-1-x86_64.pkg.tar.zst"
-sha256 = "d90182651fffda25f6658ec436b9e91f4549ccb08d4eb640f7b2e9c5781752ac"
-signature = "iHUEABYKAB0WIQSDvIiJNRtd67toQW64rAhgDxCM3wUCaQTMDgAKCRC4rAhgDxCM3/JnAP9upNTWy4ImmNylOyAhtWoLF8QwdfriYFkMuB+UJcQBNQD/TK/TsoQzh8QNNVx1I4tevcpYaLn2tlHWgTXbfwtzIgQ="
+url = "https://archive.archlinux.org/packages/r/rust/rust-1:1.95.0-1-x86_64.pkg.tar.zst"
+sha256 = "7fb944fe7316c4b56946e97629c1c274c7dd477301f72ff38665e516a961cf61"
+signature = "iHUEABYKAB0WIQSDvIiJNRtd67toQW64rAhgDxCM3wUCaeD+JwAKCRC4rAhgDxCM3+a+AQDYqAJgf84M0ML7M7irZpz+lqnDUPOWdv1f2Ncndw5ilQD/Y5IQ3hhescVkc3Qq957lfwEtFF4JHwVgHDUYSb7NXgM="
 
 [[package]]
 name = "rust-musl"
-version = "1:1.91.0-1"
+version = "1:1.95.0-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/r/rust-musl/rust-musl-1:1.91.0-1-x86_64.pkg.tar.zst"
-sha256 = "b2f9aa4481492c6c5bc57445cb43b65b1b87575df9bb2fb4a1dd37bdcdcdb705"
-signature = "iHUEABYKAB0WIQSDvIiJNRtd67toQW64rAhgDxCM3wUCaQTMEQAKCRC4rAhgDxCM38adAP0SEOKJUNPxaurFEdme04Sd30bts6H62uHUXzS/9FjvqQEA8FC6Zv9wXMUDBvh8cmM79ym9vVzFGx4NXqHISNfpXAw="
+url = "https://archive.archlinux.org/packages/r/rust-musl/rust-musl-1:1.95.0-1-x86_64.pkg.tar.zst"
+sha256 = "362af945af3da46608036f094f73124694d816001810872d728a34fe8af5f683"
+signature = "iHUEABYKAB0WIQSDvIiJNRtd67toQW64rAhgDxCM3wUCaeD+KQAKCRC4rAhgDxCM39dFAP4jpCK0BwjQlfA9DIICUNe81RSMq3dC1LwoGny1v6pYggD8CmDX4Y2TizyqFq53J6i+lTe1jhW6qjtDTxw/MSpO9wQ="
+
+[[package]]
+name = "sqlite"
+version = "3.53.1-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/s/sqlite/sqlite-3.53.1-1-x86_64.pkg.tar.zst"
+sha256 = "22a1cbbfb507506959c29e8f352c378add53cea35963465bd1a783bd7a3f7262"
+signature = "iQEzBAABCgAdFiEErcih/MFeAdRTEEGelGV6sg8qCSsFAmn6BEwACgkQlGV6sg8qCSv7Xwf9FEkCzpAHj2A1CoKqx+JgPcv0bwQDHo3ZLVvz3CPoKwnY6NkZv4mdBqZ6PLYr8i3Rd/hBFmgWEx9yNibhDoZyVZb8Gv1JyCZnmD+61gI8dITd086AJbmlF7219TpT648BRdHbtpNDEI8jj4oR3YqiDvhss69b+kzFRJrlooGvW6Rg1HMvG5IC2bzJez/nVy+4XghBFObBWLG0wcSwtw4vqdF+tZ5hK6m3yJhcEDNYQUqVMeLi8PhFV5rfGjCzHGoCX70gxx6IHOCLCPdn9Yxxh/bo/YnbBc4PJqTZzY89iWhX/ZCTkjqWPRexygintYR09FWPwofYwRf3SJzU2MVUbw=="

--- a/src/routing/mod.rs
+++ b/src/routing/mod.rs
@@ -15,7 +15,7 @@ use axum::{
     response::{IntoResponse, Redirect},
     routing::{get, post},
 };
-use axum_extra::{either::Either, extract::Host, middleware::option_layer};
+use axum_extra::{either::Either, middleware::option_layer};
 use bytes::Bytes;
 use candid::Principal;
 use fqdn::FQDN;
@@ -24,7 +24,7 @@ use http_body_util::Full;
 use ic_bn_lib::{
     http::{
         cache::{CacheBuilder, KeyExtractorUriRange},
-        extract_host,
+        extract_authority, extract_host,
         middleware::waf::WafLayer,
         shed::{
             sharded::ShardedLittleLoadShedderLayer,
@@ -60,6 +60,7 @@ use crate::{
     cli::Cli,
     metrics::{self},
     routing::{
+        error_cause::ClientError,
         ic::subnets_info::SubnetsInfo,
         middleware::{
             canister_match, cors, geoip, headers,
@@ -580,9 +581,13 @@ pub async fn setup_router(
         .nest("/api/v3", router_api_v3)
         .nest("/api/v4", router_api_v4)
         .fallback(
-            |Host(host): Host, Extension(ctx): Extension<Arc<RequestCtx>>, request: Request| async move {
+            |Extension(ctx): Extension<Arc<RequestCtx>>, request: Request| async move {
+                let Some(host) = extract_authority(&request) else {
+                    return Ok(ErrorCause::Client(ClientError::NoAuthority).into_response());
+                };
+
                 // Check if the request's host matches API hostname
-                if api_hostname.zip(extract_host(&host)).map(|(a, b)| a == b) == Some(true) {
+                if api_hostname.zip(extract_host(host)).map(|(a, b)| a == b) == Some(true) {
                     return router_api.oneshot(request).await;
                 }
 
@@ -590,7 +595,10 @@ pub async fn setup_router(
                 let canister_id = request.extensions().get::<CanisterId>();
 
                 // If the custom domains are enabled and the request came to the base domain
-                if let Some(v) = custom_domains_router && ctx.is_base_domain() && path.starts_with("/custom-domains") {
+                if let Some(v) = custom_domains_router
+                    && ctx.is_base_domain()
+                    && path.starts_with("/custom-domains")
+                {
                     return v.oneshot(request).await;
                 }
 


### PR DESCRIPTION
* Mainly updates `ic-bn-lib` to close some vulns (remove openssl dep)
* Update `repro-env` reproducible environment (inner Arch packages)
* Update other crates
* Remove deprecations (`Host` extractor)