### PR TITLE
fix: MUSL build 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,8 +25,8 @@ jobs:
 
       - name: Install repro-env
         run: |
-          wget 'https://github.com/kpcyrd/repro-env/releases/download/v0.4.3/repro-env'
-          echo '2a00b21ac5e990e0c6a0ccbf3b91e34a073660d1f4553b5f3cda2b09cc4d4d8a  repro-env' | sha256sum -c -
+          wget 'https://github.com/kpcyrd/repro-env/releases/download/v0.4.4/repro-env'
+          echo 'eaae57fbb51f6f802cb1c5ea4c07588feb18f8f533d7175b3cde599a974bb0d3  repro-env' | sha256sum -c -
           sudo install -m755 repro-env -t /usr/bin
 
       - name: Install deps

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get -y install protobuf-compiler podman
 
       - name: Build
-        run: repro-env build --env LDFLAGS="-fno-link-libatomic" -- cargo build --features sev-snp --release --target x86_64-unknown-linux-musl
+        run: repro-env build --env CFLAGS="-fno-link-libatomic" -- cargo build --features sev-snp --release --target x86_64-unknown-linux-musl
 
       - name: Generate SHA checksum
         run: shasum target/x86_64-unknown-linux-musl/release/ic-gateway > ic-gateway.shasum
@@ -42,7 +42,7 @@ jobs:
         run: rm -rf target
 
       - name: Build again
-        run: repro-env build --env LDFLAGS="-fno-link-libatomic" -- cargo build --features sev-snp --release --target x86_64-unknown-linux-musl
+        run: repro-env build --env CFLAGS="-fno-link-libatomic" -- cargo build --features sev-snp --release --target x86_64-unknown-linux-musl
 
       - name: Check SHA checksum
         run: shasum -c ic-gateway.shasum

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get -y install protobuf-compiler podman
 
       - name: Build
-        run: repro-env build -- cargo build --features sev-snp --release --target x86_64-unknown-linux-musl
+        run: repro-env build --env LDFLAGS="-fno-link-libatomic" -- cargo build --features sev-snp --release --target x86_64-unknown-linux-musl
 
       - name: Generate SHA checksum
         run: shasum target/x86_64-unknown-linux-musl/release/ic-gateway > ic-gateway.shasum
@@ -42,7 +42,7 @@ jobs:
         run: rm -rf target
 
       - name: Build again
-        run: repro-env build -- cargo build --features sev-snp --release --target x86_64-unknown-linux-musl
+        run: repro-env build --env LDFLAGS="-fno-link-libatomic" -- cargo build --features sev-snp --release --target x86_64-unknown-linux-musl
 
       - name: Check SHA checksum
         run: shasum -c ic-gateway.shasum

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,12 @@ jobs:
 
       - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6
 
+      - name: Install repro-env
+        run: |
+          wget 'https://github.com/kpcyrd/repro-env/releases/download/v0.4.4/repro-env'
+          echo 'eaae57fbb51f6f802cb1c5ea4c07588feb18f8f533d7175b3cde599a974bb0d3  repro-env' | sha256sum -c -
+          sudo install -m755 repro-env -t /usr/bin
+
       - name: Install deps
         run: sudo apt-get update && sudo apt-get -y install protobuf-compiler && cargo install cargo-all-features
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,3 +32,6 @@ jobs:
       - name: Run all unit and integration tests
         run: |
           ./run-tests.sh
+
+      - name: Build using repro-env
+        run: repro-env build --env CFLAGS="-fno-link-libatomic" -- cargo build --features sev-snp --target x86_64-unknown-linux-musl


### PR DESCRIPTION
Arch upstream broke GCC in MUSL, it's fixed in master but unreleased, so for now use CFLAGS to work it around.
Also run `repro-env` in tests.

https://gitlab.archlinux.org/archlinux/packaging/packages/gcc/-/work_items/39