### PR TITLE
chore: bump dependencies to use reqwest 0.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,6 +158,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "ascii-canvas"
 version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -384,6 +390,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
 dependencies = [
  "aws-lc-sys",
+ "untrusted 0.7.1",
  "zeroize",
 ]
 
@@ -837,9 +844,9 @@ checksum = "ade8366b8bd5ba243f0a58f036cc0ca8a2f069cff1a2351ef1cac6b083e16fc0"
 
 [[package]]
 name = "candid"
-version = "0.10.27"
+version = "0.10.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ba5b4833b63bf7b785fecdd2cc918ed90d988fd974825d5c48e7b407c39ef38"
+checksum = "f39b6abc5caef7fdedbeaadb2136c27337c1625765bcf3f2ad07112fe838d492"
 dependencies = [
  "anyhow",
  "binread",
@@ -860,9 +867,9 @@ dependencies = [
 
 [[package]]
 name = "candid_derive"
-version = "0.10.27"
+version = "0.10.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b60664b6324832dfb4863f3b19eb4d58819cd38fba6d3941b101213cea0d9ec"
+checksum = "fca85cd61b91271bd44fee6c4a8fff316791aea6aca59fb2752e6fef8617f854"
 dependencies = [
  "lazy_static",
  "proc-macro2",
@@ -1029,13 +1036,12 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cloudflare"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1678b3295890df5895480a7c080430e73df2b7101f1763f62a3b32dd532f1d37"
+version = "0.14.1"
+source = "git+https://github.com/dfinity/cloudflare-rs?rev=7d10dca3b339e8a29cb663341dbc802fe51bf322#7d10dca3b339e8a29cb663341dbc802fe51bf322"
 dependencies = [
  "chrono",
  "http 1.4.0",
- "reqwest 0.12.28",
+ "reqwest 0.13.3",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -2319,12 +2325,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 
 [[package]]
+name = "hickory-net"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2295ed2f9c31e471e1428a8f88a3f0e1f4b27c15049592138d1eebe9c35b183"
+dependencies = [
+ "async-trait",
+ "aws-lc-rs",
+ "bitflags",
+ "bytes",
+ "cfg-if",
+ "data-encoding",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "h2",
+ "hickory-proto 0.26.1",
+ "http 1.4.0",
+ "idna",
+ "ipnet",
+ "jni",
+ "lru-cache",
+ "parking_lot",
+ "rand 0.10.1",
+ "rustls",
+ "rustls-pki-types",
+ "thiserror 2.0.18",
+ "time",
+ "tinyvec",
+ "tokio",
+ "tokio-rustls",
+ "tracing",
+ "url",
+ "webpki-roots 1.0.7",
+]
+
+[[package]]
 name = "hickory-proto"
 version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
 dependencies = [
  "async-trait",
+ "aws-lc-rs",
  "bitflags",
  "bytes",
  "cfg-if",
@@ -2353,6 +2396,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "hickory-proto"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643"
+dependencies = [
+ "aws-lc-rs",
+ "bitflags",
+ "data-encoding",
+ "idna",
+ "ipnet",
+ "jni",
+ "once_cell",
+ "prefix-trie",
+ "rand 0.10.1",
+ "ring",
+ "rustls-pki-types",
+ "thiserror 2.0.18",
+ "time",
+ "tinyvec",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "hickory-resolver"
 version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2360,7 +2427,7 @@ checksum = "dc62a9a99b0bfb44d2ab95a7208ac952d31060efc16241c87eaf36406fecf87a"
 dependencies = [
  "cfg-if",
  "futures-util",
- "hickory-proto",
+ "hickory-proto 0.25.2",
  "ipconfig",
  "moka",
  "once_cell",
@@ -2374,6 +2441,35 @@ dependencies = [
  "tokio-rustls",
  "tracing",
  "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "hickory-net",
+ "hickory-proto 0.26.1",
+ "ipconfig",
+ "ipnet",
+ "jni",
+ "moka",
+ "ndk-context",
+ "once_cell",
+ "parking_lot",
+ "rand 0.10.1",
+ "resolv-conf",
+ "rustls",
+ "smallvec",
+ "system-configuration",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-rustls",
+ "tracing",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -2606,9 +2702,9 @@ dependencies = [
 
 [[package]]
 name = "ic-agent"
-version = "0.47.2"
+version = "0.47.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fefe511d29d927aa5a2090c2e26e0b72cd0633ab7007927e19aeceb05c2a42b1"
+checksum = "85dbab284eac1806b77833cff143d66ae97aae74d34b0e60fb4ab4edf3d6fa12"
 dependencies = [
  "arc-swap",
  "async-channel 2.5.0",
@@ -2629,7 +2725,7 @@ dependencies = [
  "http-body-util",
  "ic-certification 3.2.0",
  "ic-ed25519",
- "ic-transport-types 0.47.2",
+ "ic-transport-types 0.47.3",
  "ic-verify-bls-signature",
  "ic_principal",
  "k256",
@@ -2640,7 +2736,6 @@ dependencies = [
  "rand 0.10.1",
  "rangemap",
  "reqwest 0.13.3",
- "ring",
  "sec1",
  "serde",
  "serde_bytes",
@@ -2657,13 +2752,13 @@ dependencies = [
 
 [[package]]
 name = "ic-bn-lib"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "550e056a8c0ca32fa24c9d394961bc312e3bf3eb7865643a568e2c26fdddd80a"
+version = "0.0.0-git"
+source = "git+https://github.com/dfinity/ic-bn-lib?rev=43c60f0810c8c110ad69f1ea67337538a365faea#43c60f0810c8c110ad69f1ea67337538a365faea"
 dependencies = [
  "ahash",
  "anyhow",
  "arc-swap",
+ "arrayvec 0.7.6",
  "async-channel 2.5.0",
  "async-trait",
  "axum",
@@ -2681,8 +2776,8 @@ dependencies = [
  "futures-util",
  "governor",
  "hex",
- "hickory-proto",
- "hickory-resolver",
+ "hickory-proto 0.26.1",
+ "hickory-resolver 0.26.1",
  "http 1.4.0",
  "http-body",
  "http-body-util",
@@ -2732,6 +2827,7 @@ dependencies = [
  "tower-service",
  "tower_governor",
  "tracing",
+ "tracing-subscriber",
  "url",
  "uuid",
  "vrl",
@@ -2743,9 +2839,8 @@ dependencies = [
 
 [[package]]
 name = "ic-bn-lib-common"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df3448b8f5531dd112ae0c9c9919c7477379c42d6c9d46e1a495add20b405c01"
+version = "0.2.1"
+source = "git+https://github.com/dfinity/ic-bn-lib?rev=43c60f0810c8c110ad69f1ea67337538a365faea#43c60f0810c8c110ad69f1ea67337538a365faea"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2755,8 +2850,8 @@ dependencies = [
  "cloudflare",
  "derive-new",
  "fqdn",
- "hickory-proto",
- "hickory-resolver",
+ "hickory-proto 0.26.1",
+ "hickory-resolver 0.26.1",
  "http 1.4.0",
  "humantime",
  "hyper",
@@ -2770,7 +2865,7 @@ dependencies = [
  "rustls",
  "serde",
  "socket2",
- "strum 0.27.2",
+ "strum 0.28.0",
  "thiserror 2.0.18",
  "tokio-util",
  "tower-service",
@@ -2923,9 +3018,8 @@ dependencies = [
 
 [[package]]
 name = "ic-custom-domains-backend"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a94efbb2f7b9cf830124a7412f49ce954dfb14f8133b923a5fee72097a35c85f"
+version = "0.0.0-git"
+source = "git+https://github.com/dfinity/custom-domains?rev=152876decb8ceb308df3f488ca1e58fd0a7c8768#152876decb8ceb308df3f488ca1e58fd0a7c8768"
 dependencies = [
  "anyhow",
  "axum",
@@ -2955,9 +3049,8 @@ dependencies = [
 
 [[package]]
 name = "ic-custom-domains-base"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb6071ccb7a051e08f6964b674310d00c663d0157c912b30173610e9c32ba0d9"
+version = "0.0.0-git"
+source = "git+https://github.com/dfinity/custom-domains?rev=152876decb8ceb308df3f488ca1e58fd0a7c8768#152876decb8ceb308df3f488ca1e58fd0a7c8768"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2968,7 +3061,7 @@ dependencies = [
  "clap",
  "derive-new",
  "fqdn",
- "hickory-resolver",
+ "hickory-resolver 0.26.1",
  "humantime",
  "ic-bn-lib",
  "ic-bn-lib-common",
@@ -2987,9 +3080,8 @@ dependencies = [
 
 [[package]]
 name = "ic-custom-domains-canister-api"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9df00102fef39217284d2bad9e3c4ab88eed77d8a938d18f71b82004070e70ae"
+version = "0.0.0-git"
+source = "git+https://github.com/dfinity/custom-domains?rev=152876decb8ceb308df3f488ca1e58fd0a7c8768#152876decb8ceb308df3f488ca1e58fd0a7c8768"
 dependencies = [
  "candid",
  "derive-new",
@@ -3000,9 +3092,8 @@ dependencies = [
 
 [[package]]
 name = "ic-custom-domains-canister-client"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab4b0006685d359e2fbd9662d84a424fb2e00e888d841438039c61f929f866dd"
+version = "0.0.0-git"
+source = "git+https://github.com/dfinity/custom-domains?rev=152876decb8ceb308df3f488ca1e58fd0a7c8768#152876decb8ceb308df3f488ca1e58fd0a7c8768"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -3057,7 +3148,7 @@ dependencies = [
  "fqdn",
  "futures",
  "hex",
- "hickory-resolver",
+ "hickory-resolver 0.25.2",
  "hostname",
  "http 1.4.0",
  "http-body",
@@ -3071,7 +3162,7 @@ dependencies = [
  "ic-custom-domains-base",
  "ic-http-certification 3.2.0",
  "ic-http-gateway-protocol",
- "ic-transport-types 0.47.2",
+ "ic-transport-types 0.47.3",
  "isbot",
  "itertools 0.14.0",
  "lazy_static",
@@ -3270,9 +3361,9 @@ dependencies = [
 
 [[package]]
 name = "ic-transport-types"
-version = "0.47.2"
+version = "0.47.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a46a13c1e36d4ac5db68a84e68f2e9edf7773bea131e915e251709b00f5910d9"
+checksum = "a2116182b3ec5a831d579db0a205b6cf9c2ca96616493bef99480532d0b3c2f5"
 dependencies = [
  "candid",
  "hex",
@@ -3528,6 +3619,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f05ad37c421b962354c358d347d4a6130151df9407978372d3ad7f0c8f71a64"
 dependencies = [
  "async-trait",
+ "aws-lc-rs",
  "base64 0.22.1",
  "bytes",
  "http 1.4.0",
@@ -3538,7 +3630,6 @@ dependencies = [
  "hyper-rustls",
  "hyper-util",
  "rcgen 0.14.8",
- "ring",
  "rustls",
  "rustls-pki-types",
  "serde",
@@ -3571,6 +3662,9 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "ipnetwork"
@@ -3822,6 +3916,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3847,6 +3947,15 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru-cache"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
+dependencies = [
+ "linked-hash-map",
+]
 
 [[package]]
 name = "lru-slab"
@@ -4029,6 +4138,12 @@ dependencies = [
  "tagptr",
  "uuid",
 ]
+
+[[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "new_debug_unreachable"
@@ -4649,12 +4764,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "prefix-trie"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cf6e3177f0684016a5c209b00882e15f8bdd3f3bb48f0491df10cd102d0c6e7"
+dependencies = [
+ "either",
+ "ipnet",
+ "num-traits",
+]
+
+[[package]]
 name = "pretty"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d22152487193190344590e4f30e219cf3fe140d9e7a3fdb683d82aa2c5f4156"
 dependencies = [
- "arrayvec",
+ "arrayvec 0.5.2",
  "typed-arena",
  "unicode-width",
 ]
@@ -4719,7 +4845,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -4989,8 +5115,8 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
 dependencies = [
+ "aws-lc-rs",
  "pem",
- "ring",
  "rustls-pki-types",
  "time",
  "yasna 0.5.2",
@@ -5002,8 +5128,8 @@ version = "0.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57f6d249aad744e274e682777a50283a225a32705394ee6d5fcc01efa25e4055"
 dependencies = [
+ "aws-lc-rs",
  "pem",
- "ring",
  "rustls-pki-types",
  "time",
  "x509-parser 0.18.1",
@@ -5163,7 +5289,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "hickory-resolver",
+ "hickory-resolver 0.25.2",
  "http 1.4.0",
  "http-body",
  "http-body-util",
@@ -5172,6 +5298,7 @@ dependencies = [
  "hyper-util",
  "js-sys",
  "log",
+ "mime_guess",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -5221,7 +5348,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.17",
  "libc",
- "untrusted",
+ "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
 
@@ -5309,6 +5436,7 @@ dependencies = [
  "async-io",
  "async-trait",
  "async-web-client",
+ "aws-lc-rs",
  "base64 0.22.1",
  "blocking",
  "chrono",
@@ -5318,7 +5446,6 @@ dependencies = [
  "log",
  "pem",
  "rcgen 0.13.2",
- "ring",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -5393,7 +5520,7 @@ dependencies = [
  "aws-lc-rs",
  "ring",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -6725,6 +6852,12 @@ checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
@@ -7504,12 +7637,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
 dependencies = [
  "asn1-rs 0.7.1",
+ "aws-lc-rs",
  "data-encoding",
  "der-parser 10.0.0",
  "lazy_static",
  "nom 7.1.3",
  "oid-registry 0.8.1",
- "ring",
  "rusticata-macros",
  "thiserror 2.0.18",
  "time",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ async-trait = "0.1.83"
 axum = { version = "0.8.1", features = ["macros"] }
 candid = "0.10.10"
 clap = { version = "4.5.20", features = ["derive", "string", "env"] }
-cloudflare = { version = "0.14.0", default-features = false, features = [
+cloudflare = { git = "https://github.com/dfinity/cloudflare-rs", rev = "7d10dca3b339e8a29cb663341dbc802fe51bf322", default-features = false, features = [
     "rustls-tls",
 ] }
 console-subscriber = { version = "0.5.0", optional = true }
@@ -33,9 +33,9 @@ derive-new = "0.7.0"
 fqdn = { version = "0.5.2", features = ["serde"] }
 futures = "0.3.31"
 hickory-resolver = { version = "0.25.1", features = [
-    "tls-ring",
-    "https-ring",
-    "dnssec-ring",
+    "tls-aws-lc-rs",
+    "https-aws-lc-rs",
+    "dnssec-aws-lc-rs",
     "webpki-roots",
 ] }
 hostname = "0.4.0"
@@ -43,17 +43,17 @@ http = "1.3.1"
 http-body = "1.0.1"
 http-body-util = "0.1.2"
 humantime = "2.2.0"
-ic-bn-lib = { version = "0.1.18", features = [
+ic-bn-lib = { git = "https://github.com/dfinity/ic-bn-lib", rev = "43c60f0810c8c110ad69f1ea67337538a365faea", features = [
     "acme",
     "vector",
     "cert-providers",
     "clients-hyper",
 ] }
-ic-bn-lib-common = "0.1"
-ic-custom-domains-backend = "0.1"
-ic-custom-domains-base = "0.1"
+ic-bn-lib-common = { git = "https://github.com/dfinity/ic-bn-lib", rev = "43c60f0810c8c110ad69f1ea67337538a365faea" }
+ic-custom-domains-backend = { git = "https://github.com/dfinity/custom-domains", rev = "152876decb8ceb308df3f488ca1e58fd0a7c8768" }
+ic-custom-domains-base = { git = "https://github.com/dfinity/custom-domains", rev = "152876decb8ceb308df3f488ca1e58fd0a7c8768" }
 ic-http-certification = { version = "3.1.0", optional = true }
-ic-transport-types = "0.47"
+ic-transport-types = "0.47.3"
 ic-http-gateway-protocol = { package = "ic-http-gateway-protocol", git = "https://github.com/dfinity/ic-http-gateway-protocol", tag = "v0.5.1" }
 isbot = "0.1"
 itertools = "0.14.0"
@@ -72,7 +72,7 @@ reqwest = { version = "0.13.2", default-features = false, features = [
     "stream",
 ] }
 rustls = { version = "0.23.18", default-features = false, features = [
-    "ring",
+    "aws-lc-rs",
     "std",
     "brotli",
 ] }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.91.0"
+channel = "1.95.0"
 targets = ["x86_64-unknown-linux-musl"]
 profile = "default"

--- a/src/core.rs
+++ b/src/core.rs
@@ -86,7 +86,7 @@ pub async fn main(
     );
 
     // Install crypto-provider
-    rustls::crypto::ring::default_provider()
+    rustls::crypto::aws_lc_rs::default_provider()
         .install_default()
         .map_err(|_| anyhow!("unable to install Rustls crypto provider"))?;
 

--- a/src/core.rs
+++ b/src/core.rs
@@ -102,7 +102,7 @@ pub async fn main(
 
     // DNS resolver
     let dns_options: DnsOptions = (&cli.dns).into();
-    let dns_resolver = bnhttp::dns::Resolver::new(dns_options.clone());
+    let dns_resolver = bnhttp::dns::Resolver::new(dns_options.clone())?;
 
     // HTTP client
     let mut http_client_opts: ClientOptions = (&cli.http_client).into();


### PR DESCRIPTION
This PR bumps dependencies so that only reqwest 0.13 is used in the dependency tree. The motivation for this change is that reqwest 0.12 and reqwest 0.13 cannot be used in the dependency tree at the same time without a ton of boilerplate code.

Moreover, we switch to aws-lc-rs completely in prod build:
```
$ cargo tree -i ring --all-features --edges normal,build
warning: nothing to print.
```