### PR TITLE
Clarify string type in namespace

### DIFF
--- a/src/routing/ic/route_provider/health.rs
+++ b/src/routing/ic/route_provider/health.rs
@@ -184,11 +184,11 @@ impl HealthCheckActor {
         let success = res.healthy.yesno();
         self.metrics
             .checks
-            .with_label_values(&[&self.node.name, success])
+            .with_label_values(&[self.node.name.as_str(), success])
             .inc();
         self.metrics
             .check_duration
-            .with_label_values(&[&self.node.name, success])
+            .with_label_values(&[self.node.name.as_str(), success])
             .observe(start.elapsed().as_secs_f64());
         self.tx.send((self.node.clone(), res)).await.ok();
     }

--- a/src/routing/ic/routing_table_manager.rs
+++ b/src/routing/ic/routing_table_manager.rs
@@ -367,11 +367,11 @@ impl RoutingTableManager {
             let subnet_id_str = subnet_id.to_string();
             self.metrics
                 .data_fetches_duration
-                .with_label_values(&[&subnet_id_str, res.is_ok().yesno()])
+                .with_label_values(&[subnet_id_str.as_str(), res.is_ok().yesno()])
                 .observe(duration.as_secs_f64());
             self.metrics
                 .data_fetches
-                .with_label_values(&[&subnet_id_str, res.is_ok().yesno()])
+                .with_label_values(&[subnet_id_str.as_str(), res.is_ok().yesno()])
                 .inc();
 
             match res {


### PR DESCRIPTION
This helps older (1.93) rust versions infer the correct types and works around the following error:

> expected &[&String], found &[&str; 2]