### PR TITLE
chore: Use `AgentExt` trait in routing table manager

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,6 +152,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "array-init"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d62b7694a562cdf5a74227903507c56ab2cc8bdd1f781ed5cb4cf9c9f810bfc"
+
+[[package]]
 name = "arrayvec"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -264,9 +270,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.42"
+version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
+checksum = "3976abdc8fe7d1133d43d304afd42abdf5bc3e1319d263d223bde07b5efc4be8"
 dependencies = [
  "compression-codecs",
  "compression-core",
@@ -282,7 +288,7 @@ checksum = "096146020b08dbc4587685b0730a7ba905625af13c65f8028035cdfd69573c91"
 dependencies = [
  "anyhow",
  "futures",
- "http 1.4.2",
+ "http 1.5.0",
  "httparse",
  "log",
 ]
@@ -311,7 +317,7 @@ version = "3.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
 dependencies = [
- "event-listener 5.4.1",
+ "event-listener 5.4.2",
  "event-listener-strategy",
  "pin-project-lite",
 ]
@@ -363,7 +369,7 @@ dependencies = [
  "async-net",
  "futures",
  "futures-rustls",
- "http 1.4.2",
+ "http 1.5.0",
  "lazy_static",
  "log",
  "rustls-pki-types",
@@ -419,7 +425,7 @@ dependencies = [
  "bytes",
  "form_urlencoded",
  "futures-util",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body",
  "http-body-util",
  "hyper",
@@ -450,7 +456,7 @@ checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body",
  "http-body-util",
  "mime",
@@ -472,7 +478,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body",
  "http-body-util",
  "mime",
@@ -544,26 +550,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
-name = "binread"
-version = "2.2.0"
+name = "binrw"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16598dfc8e6578e9b597d9910ba2e73618385dc9f4b1d43dd92c349d6be6418f"
+checksum = "6ad120d555272286c1017d25165ab8bd74806f13fc85b258484ec7e4ce75458f"
 dependencies = [
- "binread_derive",
- "lazy_static",
- "rustversion",
+ "array-init",
+ "binrw_derive",
+ "bytemuck",
 ]
 
 [[package]]
-name = "binread_derive"
-version = "2.1.0"
+name = "binrw_derive"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d9672209df1714ee804b1f4d4f68c8eb2a90b1f7a07acf472f88ce198ef1fed"
+checksum = "6df92e0e9baae4dc82c7bad7715ca40c0a5c71539057bf2ea04a5c29c980410b"
 dependencies = [
  "either",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -592,22 +598,22 @@ dependencies = [
 
 [[package]]
 name = "bitfield"
-version = "0.19.4"
+version = "0.19.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21ba6517c6b0f2bf08be60e187ab64b038438f22dd755614d8fe4d4098c46419"
+checksum = "b45721c9db4c7a20899d05efb7ad9235f50b256e980db30ffb229abf732934c3"
 dependencies = [
  "bitfield-macros",
 ]
 
 [[package]]
 name = "bitfield-macros"
-version = "0.19.4"
+version = "0.19.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f48d6ace212fdf1b45fd6b566bb40808415344642b76c3224c07c8df9da81e97"
+checksum = "c0cb6f3d4773a2107b94cbeccaa5b5f0b35a88389b5d522d13d659f64317b22d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -725,6 +731,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
+name = "bytemuck"
+version = "1.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -817,12 +829,12 @@ checksum = "ade8366b8bd5ba243f0a58f036cc0ca8a2f069cff1a2351ef1cac6b083e16fc0"
 
 [[package]]
 name = "candid"
-version = "0.10.32"
+version = "0.10.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b649560badafa98cdf260958393f317c013b5aa819dba26f21cc3e26cae41dae"
+checksum = "cdec808f2220b263bbc88557a2a44fb6b2db5875c99731ad00aae575ad59215c"
 dependencies = [
  "anyhow",
- "binread",
+ "binrw",
  "byteorder",
  "candid_derive",
  "hex",
@@ -840,9 +852,9 @@ dependencies = [
 
 [[package]]
 name = "candid_derive"
-version = "0.10.32"
+version = "0.10.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f94f9df97dd04077b5a30e82dfb5a5f2eae1a6e8c9d6a98fd24351c8a333464"
+checksum = "2ee4839d8e442990b2853556e57ee9f6f4527371bbbfd7b4dcdd4f3c7d910964"
 dependencies = [
  "lazy_static",
  "proc-macro2",
@@ -858,9 +870,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c89588d05638b5b4594a3348a2d6c20277e43a7f5c5202b05cc56888475a47b8"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1598,13 +1610,13 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1683,9 +1695,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "elliptic-curve"
@@ -1768,11 +1780,10 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "event-listener"
-version = "5.4.1"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
- "concurrent-queue",
  "parking",
  "pin-project-lite",
 ]
@@ -1783,7 +1794,7 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
- "event-listener 5.4.1",
+ "event-listener 5.4.2",
  "pin-project-lite",
 ]
 
@@ -2166,7 +2177,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.4.2",
+ "http 1.5.0",
  "indexmap 2.14.0",
  "slab",
  "tokio",
@@ -2304,7 +2315,7 @@ dependencies = [
  "futures-util",
  "h2",
  "hickory-proto",
- "http 1.4.2",
+ "http 1.5.0",
  "idna",
  "ipnet",
  "jni",
@@ -2419,9 +2430,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
 dependencies = [
  "bytes",
  "itoa",
@@ -2434,7 +2445,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
 dependencies = [
  "bytes",
- "http 1.4.2",
+ "http 1.5.0",
 ]
 
 [[package]]
@@ -2445,7 +2456,7 @@ checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body",
  "pin-project-lite",
 ]
@@ -2473,7 +2484,7 @@ dependencies = [
  "crossbeam-channel",
  "form_urlencoded",
  "futures",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body-util",
  "hyper",
  "hyper-util",
@@ -2512,7 +2523,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "h2",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body",
  "httparse",
  "httpdate",
@@ -2529,7 +2540,7 @@ version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http 1.4.2",
+ "http 1.5.0",
  "hyper",
  "hyper-util",
  "log",
@@ -2565,7 +2576,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body",
  "hyper",
  "ipnet",
@@ -2625,7 +2636,7 @@ dependencies = [
  "elliptic-curve",
  "futures-util",
  "hex",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body",
  "http-body-util",
  "ic-certification 3.2.0",
@@ -2684,7 +2695,7 @@ dependencies = [
  "hex",
  "hickory-proto",
  "hickory-resolver",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body",
  "http-body-util",
  "humantime",
@@ -2944,7 +2955,7 @@ dependencies = [
  "futures",
  "hex",
  "hostname",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body",
  "http-body-util",
  "httptest",
@@ -3015,7 +3026,7 @@ checksum = "689c75307307b577220b7bade846123d62ef0a8fe536540267571c8e94825cf5"
 dependencies = [
  "base64 0.22.1",
  "candid",
- "http 1.4.2",
+ "http 1.5.0",
  "ic-certification 3.2.0",
  "ic-representation-independent-hash 3.2.0",
  "serde",
@@ -3032,7 +3043,7 @@ dependencies = [
  "bytes",
  "candid",
  "futures",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body",
  "http-body-util",
  "ic-agent",
@@ -3118,7 +3129,7 @@ dependencies = [
  "candid",
  "flate2",
  "hex",
- "http 1.4.2",
+ "http 1.5.0",
  "ic-cbor 3.2.0",
  "ic-certificate-verification 3.2.0",
  "ic-certification 3.2.0",
@@ -3407,7 +3418,7 @@ dependencies = [
  "aws-lc-rs",
  "base64 0.22.1",
  "bytes",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body",
  "http-body-util",
  "httpdate",
@@ -3960,7 +3971,7 @@ dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
  "equivalent",
- "event-listener 5.4.1",
+ "event-listener 5.4.2",
  "futures-util",
  "parking_lot",
  "portable-atomic",
@@ -5070,7 +5081,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body",
  "http-body-util",
  "hyper",
@@ -5116,7 +5127,7 @@ dependencies = [
  "futures-util",
  "h2",
  "hickory-resolver",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body",
  "http-body-util",
  "hyper",
@@ -5237,9 +5248,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.42"
+version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
  "aws-lc-rs",
  "brotli",
@@ -5268,7 +5279,7 @@ dependencies = [
  "chrono",
  "futures",
  "futures-rustls",
- "http 1.4.2",
+ "http 1.5.0",
  "log",
  "pem",
  "rcgen 0.13.2",
@@ -5405,9 +5416,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+checksum = "687274d293b6cdc6e73e0fee520bf2049650090d7164f87672d212a3c530cf4a"
 dependencies = [
  "dyn-clone",
  "ref-cast",
@@ -5612,7 +5623,7 @@ dependencies = [
  "indexmap 1.9.3",
  "indexmap 2.14.0",
  "schemars 0.9.0",
- "schemars 1.2.1",
+ "schemars 1.2.2",
  "serde_core",
  "serde_json",
  "serde_with_macros",
@@ -6343,13 +6354,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.1"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6328af13490e73a9b4694030fafd93f8c8c6a9dede33e821c3fc63eddf8042ba"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -6402,7 +6413,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "h2",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body",
  "http-body-util",
  "hyper",
@@ -6461,7 +6472,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body",
  "http-body-util",
  "pin-project-lite",
@@ -6483,7 +6494,7 @@ dependencies = [
  "bitflags",
  "bytes",
  "futures-core",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body",
  "percent-encoding",
  "pin-project-lite",
@@ -6515,7 +6526,7 @@ dependencies = [
  "axum",
  "forwarded-header-value",
  "governor",
- "http 1.4.2",
+ "http 1.5.0",
  "pin-project",
  "thiserror 2.0.19",
  "tonic",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2657,9 +2657,9 @@ dependencies = [
 
 [[package]]
 name = "ic-bn-lib"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ea8fa20bc6bac82a9491e26a43b70b9e0f276da534957c6cf0d589cf1a689ac"
+checksum = "b83872540bf299cf6dd63b09e04f603acb34a4e67e03c12db14022596982f6bd"
 dependencies = [
  "ahash",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ http = "1.3.1"
 http-body = "1.0.1"
 http-body-util = "0.1.2"
 humantime = "2.2.0"
-ic-bn-lib = { version = "0.5.0", features = [
+ic-bn-lib = { version = "0.5.1", features = [
     "cert-providers",
     "lb",
     "clients-hyper",

--- a/repro-env.lock
+++ b/repro-env.lock
@@ -1,5 +1,5 @@
 [container]
-image = "docker.io/library/archlinux@sha256:592e11bd99ab579f933a0cb77a8f66e2f3ae57f5eafacf13aea44a6e98ef21ae"
+image = "docker.io/library/archlinux@sha256:3406a568f45d68f0bef35dc80b3eacec8bda59b0292b2e50d5932ba1667f20cf"
 
 [[package]]
 name = "abseil-cpp"
@@ -10,20 +10,28 @@ sha256 = "6266ca9133e80c3f1643480d67d2a113b0b427b79ea8611b06cca9b4ddfa1694"
 signature = "iQIzBAABCgAdFiEEj8FaBklQqZ3RvRTdOeS4d+YuuRUFAmop/QAACgkQOeS4d+YuuRVmqQ/+M2ISHEcTN7hPHS80X+Y2e2AdvzmZNaOgWJ/OS3vC0R4w9s0gTzo0a4qsKETrIDF6VrmjbqdRmHjcA3VcmWzDF//y64wcnYTEoPs4Y6lRWhTEblf1g68HeJJw7nnM/V4cprUxuI6jfBrnFl/y/xiI0iXsknfDTVQFfUQP/BMU7wxoKAIl4oDRQDEtG8Sm5/M4Bl6/oF+zCPkE9LPxRPsmtbXgZfP4d7RO/VjSyGDuuSJ+fjpePvjN2JjKveHBWRdh2wegVNs5hgH2zdCPJZUkQU9c6PtI7Rzrm6LrdqJge30BFqyBWDswtfMFBAFbHc8Eh48Twk+uKrCzjc7YFZb9tK81t7VvV4sFNcqeLHqgG1bBkLRLr6tKRILVZYsjEmTH/IlDBJQ6NTzXQCiYmO1HT5Gw/9mnCOXrntYmgL6CElNMj2uAlb0ZJqLQSP80Batc2tJDGOhuE9cyK2PiiKj4/nNAKFOkYe2mjx7v2Ibpo8fJkfLwDkn6rCIskZGF+qyEAcee+2DQCA/gtZSSyvlYsvmmJv9WeOIcuxOPj85n07zk8D7Zc4f+cNFz8Dda1VBnH5UgSX80ewGHmgVINMJF/csLIMb72QgTT8NUg6Yro7ptBtrkd1OoHGgnVfisaCuFLcXXOUm6CRqwtexnaKD+Vr0uY5m1rU4MJrfPfPKmpNw="
 
 [[package]]
-name = "ca-certificates-mozilla"
-version = "3.126-1"
+name = "archlinux-keyring"
+version = "20260727-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/c/ca-certificates-mozilla/ca-certificates-mozilla-3.126-1-x86_64.pkg.tar.zst"
-sha256 = "a734f218ff0c21f97edbd3304cd9f35aa083aa59dbae977856facc798daab415"
-signature = "iHUEABYKAB0WIQSDvIiJNRtd67toQW64rAhgDxCM3wUCalsT0wAKCRC4rAhgDxCM32WfAQD8n/vtCqXLrAZQoC+Bf/NWOn49opBaAD6H1ClZiWDsggEA+Vpc+7tsBHDYGPJw9XNVYJ/03F+JoHRmMdy/hS69iQc="
+url = "https://archive.archlinux.org/packages/a/archlinux-keyring/archlinux-keyring-20260727-1-any.pkg.tar.zst"
+sha256 = "694c4236ff403b5be549436d2df2910092cb6d778bb027fd232be9dddf4ea090"
+signature = "iHUEABYKAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCamesSgAKCRBtQr3RFuAGj1k0AQC7cYzJpnLYf75Y5XuDSnLyaQuOzWClUKmgK1J8I4WqOgD9HELQUtsFV1378DEWFtDfE4gRVDCV0ei9SaUBf6Lkbg4="
+
+[[package]]
+name = "binutils"
+version = "2.47-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/b/binutils/binutils-2.47-1-x86_64.pkg.tar.zst"
+sha256 = "b1d7ad4d4b0f451282d5ff2c9c1605fbae485fcdd6d5683d59c3c6a5bcf92496"
+signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCamibO18UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCrU8AP0eLn1304FUWUE0boO6NKN85rvD4IoPj0WIR5TVFgBvHwD/Vkn+yNt5PkMcBJwL/ydEqwe64c/gpU7pQxxoHXFVMQE="
 
 [[package]]
 name = "cmake"
-version = "4.4.0-2"
+version = "4.4.1-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/c/cmake/cmake-4.4.0-2-x86_64.pkg.tar.zst"
-sha256 = "4c3fbb45566fb10a4616bf19a1a1a90ba4eaad358c27aeca70178d5f8f68889d"
-signature = "iQEzBAABCgAdFiEEFRnVq6Zb9vwrc8dWek52CV2KUuQFAmpfm98ACgkQek52CV2KUuTKRAf/XP+62viT5qX2Lyrlt7lJEnsR+vvWMAG68dDtMIA0/LB889ZZrx/rrfFRA0MPEmYqKXqcsRERzqwX6YPCS4iaAxSPxoffxLT1WHtFWreNpiePfZW0yftslS0nClU5dLLrfyeY83JKvqqUMHBR3K9OBYxKc7TRWpPaPRHPzQuYtmB3hByibjhjalLJHgOmd7V8HCgec3NScJ9Jt8amgQPhB4nweqayrZbXRxo6P6aU1v3O3Enri5pR/UqYScxb8PoHEzr0q37bWrCG7ZIS58OACDISNCrwMhQmu2pJJFeT0sAA4lxdE16spNwrgEVxSiu6uvyyofJYipeqBw5onp3Hag=="
+url = "https://archive.archlinux.org/packages/c/cmake/cmake-4.4.1-1-x86_64.pkg.tar.zst"
+sha256 = "ae8c5419a5d862ac7f868cdcd10cd06ed8fe7dcee778e4e00353e27dda033a94"
+signature = "iQEzBAABCgAdFiEEFRnVq6Zb9vwrc8dWek52CV2KUuQFAmpo/DkACgkQek52CV2KUuTyZgf/Rpkt4J0AWfKESZDJ1hGae++OzAZkuOHL3C0e8kRFrTEnS9zlPPAx7k5xYzPi9Gg7jtd16MQAjd4OoMuOfyqJlFbOfnZLsfdFcvtML6n9rajX9fr6ng+83Pd2/uv3M7pes3u3f0/HWknU4tiyY6eO/AWn3Kdhj5e2WhRrhvKJGBZiGQB6hJoUNRBQwJjxuRZN5ZlqzdnQDO0whPBhV1+wyfLDI8AfQckUNCxnvFgdvR74H11k6OxRXu3JSX6y8A5+XV9Zvg1IPcTizii5VSMimiw6iP/ESbxH9kAKboQnM/KqG0X4LiPsJj9IEnyCMqdkzFwbSw8sNYgkoqFAw0BJvQ=="
 
 [[package]]
 name = "compiler-rt"
@@ -42,14 +50,6 @@ sha256 = "5c8bd9b3881ba9b2bea98eefa95df21d92b026f0c7537105d943857b22388be3"
 signature = "iQIzBAABCgAdFiEEtZcfLFwQqaCMYAMPeGxj8zDXy5IFAmnGazMACgkQeGxj8zDXy5JhQhAAtaJdE9CFS5GVdCnlKxC6yDubujzmc1LczN3GgtCIzNbIn+hbXnpNsescN+kZ+qeTtecc8cwP8qDBL81KWb1cG5VyYC61hnoI+R4P8yF0NhDRQKEbFOuNft5joN5NWRPrSKEKBkqttBA1tnV15VnXVfkkbzdCwc4xdEWFZMhNuFd9tSDux+TuYaOeshid3u2oer/JKD9o9X/3uwWDuF/U2u77nzQ2yOgerRMdHqjohmQ2pP1DbM051/6z246TLIPdvEKuDiKB5JG+fBVCHGQ6WxMxfHINvoxa77OezVS1dIcjkPOJuHSdHBHxVoMNzvSAx4VFcKMJzofwuaCEHaV3t6+lvO3rbygraqDWA3XlvO7L7Ad3TcVa467wlMUh7PqDaXq+cwaTZAsFXB9bDRoeOL9xWTSeRrZmeJDkOc1o7hZlra3A/6bc9NtsmUHZeOuT8XE3tRBsoNssPTo5FBD+ZeYtqh0d/e/I9A2iqLzlksdHSNS4kcDNA2oen0cnOPnCZyYsPXkf1sfrMKbgHne5HtHQF1I2EOXTBBMXDIDdLV8APabEKw7UtbtTFilyjeAwPzh3yW0EiLFB6n2ybR+a7mDtaK/UvxGo2w0ptiDaYcr7xtPgX/Y6aIvj9Z7jm3xu3vangBYDpqnN5a47rloXv1QClf0YSani45+Qby7b/60="
 
 [[package]]
-name = "cryptsetup"
-version = "2.8.7-1"
-system = "archlinux"
-url = "https://archive.archlinux.org/packages/c/cryptsetup/cryptsetup-2.8.7-1-x86_64.pkg.tar.zst"
-sha256 = "3e77b353731dd4432a7b451fca4b6880b89405c5914324b82a294f3c5fd75393"
-signature = "iHUEABYKAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCamBS9AAKCRBtQr3RFuAGjwT4AQDHzLKDCNqqtcFbbhj+fC/FM4NAU7pJKBz7pvHEHdMxAwEAshQwT+J9FBhD9hytgZxEJ5yh7T+2KmyzKFkFLI1qCQg="
-
-[[package]]
 name = "gc"
 version = "8.2.12-1"
 system = "archlinux"
@@ -59,11 +59,27 @@ signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCaYTRLF8UgAAAAAAuAChpc3N
 
 [[package]]
 name = "gcc"
-version = "16.1.1+r346+g4e03491b401d-4"
+version = "16.1.1+r595+g171d15ac6959-1"
 system = "archlinux"
-url = "https://archive.archlinux.org/packages/g/gcc/gcc-16.1.1+r346+g4e03491b401d-4-x86_64.pkg.tar.zst"
-sha256 = "346a52cc965b67f362d5b6701ec339eb43df8e68f8167a491a30847d15545a48"
-signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCalVDgl8UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCphDAPoCr4b+frRqXkq4A7C9iTGXNO+5xVaYL8vXOug+qKHFUwEA1hdn9wdZnzEa3P/1B9g0S0h2vgKb9uisFBaanJdVfAo="
+url = "https://archive.archlinux.org/packages/g/gcc/gcc-16.1.1+r595+g171d15ac6959-1-x86_64.pkg.tar.zst"
+sha256 = "d44729e212926d42dda48d2e8f1ec9f3133fec1089209f4914fad170b19d9c3e"
+signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCamic8l8UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCix/AQCNZ9i/Wif0K5gNx3KPgZVW/L7NhOp5XWY49PizaHDB0QEA2BuKVPB9nmdl3ywbK7nYSk7qKCDx2MSROoIOI+YN1Q8="
+
+[[package]]
+name = "gcc-libs"
+version = "16.1.1+r595+g171d15ac6959-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-16.1.1+r595+g171d15ac6959-1-x86_64.pkg.tar.zst"
+sha256 = "a3088c9ab302a5dcaaff385c62c47e50cb096d618a171c1d32adbb96978cac36"
+signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCamic818UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCks3AP9W1c2HgSAH9XjcstNUZS5xQB/zl3b/1+SKA8s1GeB+7QD+MM078SL9PoVMlqzFKUosiR3DwoB05Sgb7ilXr/b3mwY="
+
+[[package]]
+name = "glibc"
+version = "2.44+r5+g7cba77790f32-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/g/glibc/glibc-2.44+r5+g7cba77790f32-1-x86_64.pkg.tar.zst"
+sha256 = "e9a1ae5e9a7176dcf10b339a13961ceb65bd35042acd134ac7ea84e938b745ed"
+signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCamibLl8UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCgpqAQDZjoDJpsmM2PQ+VDGz+EY605za8cqdla160iuk9BPnggD9FKRsDQ+8Y2ZCV3zA4HstAZM5n9YRmlGtWL42XkN5cgc="
 
 [[package]]
 name = "gtest"
@@ -98,12 +114,52 @@ sha256 = "2aa066e1840850aad3b901dec9e8aaa047afcd1835576378f6ba16285c268fcb"
 signature = "iQEzBAABCAAdFiEEFRnVq6Zb9vwrc8dWek52CV2KUuQFAmblvasACgkQek52CV2KUuSEOwf/fm7VzJjRdFKN6DVeDqFkQjkfaOenZtUCQc3GuSvt9xOZ9ghv6F1Myt3Z5aDnApntNsn+zqjV+OpAPjeiJcrnS8vN+PZ8QLx2udJgO9uZ2e/SG5gkowJvjJFqB2eTL1XeUOhyFzjo2b4dC4VRMxId5oZ/o2jsa1HfRVipSYz3ulfngiJTaUlGHGqSvQc7ykmrs2cnWuCuhY9xIhhLQSo0xvYGaBuCOwCTfGmG+G/IcL+JKQh8kBkTydu92Odpig+dyyhhAZXWHXNuUN/WMxRJZUrsHWLV4eCVV8G1pZknF0o8bu77uS5rTC7hPXSLElvK3eZ+UE2A0EVoha8jn3HVFQ=="
 
 [[package]]
+name = "libarchive"
+version = "3.8.9-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/l/libarchive/libarchive-3.8.9-1-x86_64.pkg.tar.zst"
+sha256 = "07b7aaec008cc4892cb2da0c599a16438d2e70869a01b90c4e20bf153f58c3b3"
+signature = "iHUEABYKAB0WIQRizHP4hOUpV7L92IObeih9mi7GCAUCami8mgAKCRCbeih9mi7GCAXHAQCzQhczpfAOlP6aAujffljEpqafLYOJ1/zQvxNcnDzl9AEAo0Cy0ekVCjLM1b/Kx6rS1rkYpJmFLRSiabObIBmF8AY="
+
+[[package]]
+name = "libasan"
+version = "16.1.1+r595+g171d15ac6959-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/l/libasan/libasan-16.1.1+r595+g171d15ac6959-1-x86_64.pkg.tar.zst"
+sha256 = "7c41fc21b41606f7c37efaf0837e5566e5b9056e6978f741d124ebbf6311e164"
+signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCamic9F8UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCi0uAQDq31JetHZwUo4l0l3fADivtPLbnMshHKAA8cjcbLNw5gEAlOD/5vLRVktrlnYbSEr1WCq2h2Hg4h+RJYLfgwHRqAI="
+
+[[package]]
+name = "libatomic"
+version = "16.1.1+r595+g171d15ac6959-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/l/libatomic/libatomic-16.1.1+r595+g171d15ac6959-1-x86_64.pkg.tar.zst"
+sha256 = "150a3310b362db672c4444e95080c677c1ca433fa03b1c4f80ac007af8decdc0"
+signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCamic9V8UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCoZFAP9ScZmAsrSRe8pYsM3PPIXVOHFkqPQoTHh+kv+8+k4mKgD+KWpfBiWssUHx2G0cNnEZSCDsGaA0bP6pW0NwQQb9Eg4="
+
+[[package]]
 name = "libedit"
 version = "20260512_3.1-1"
 system = "archlinux"
 url = "https://archive.archlinux.org/packages/l/libedit/libedit-20260512_3.1-1-x86_64.pkg.tar.zst"
 sha256 = "70cb736e4fdee330cd0dfab45875f6ea378ae819958dd15748c300b8d7285b42"
 signature = "iQIzBAABCgAdFiEE4kC1fixGMLp2ji8m/BtUfI2BcsgFAmoI97oACgkQ/BtUfI2BcsikyQ/7B/S1MQ9uI6NeSwoCUxSh8LvJjSc0ixgimM4BsDqxYM0HGTPGXEGMqdjvCFE3duhNfmGphGqSmTGQcxiJjgKKGmzj4xW1b4M3lWoyiv98jx7kR1aRtVthXGWbVFmJKuCuUQd9iWT+h3gh5QHVKib122FAWuWnWgXrXPyfYFMaY7I5nUMr8URDEYVZje5Cjx81AcavUg+6nAQyeH4hDxgsVhvyhqBNzfodN6v/1oV50jaayMs4QvU/CXQL2lnXB1NjMcTJMdYDJ0mXaLHEqYwUj6evQEXlkqlakG32OJ9uQBojYLpATpCheWxqDmjsoRwIay/EGmyYJVvzzqx21bmP5VtAKz63LIQTHqNAZS06hjF65+NYnjFGcwGdWE6FD1DAXWKM/K0KP+tjFg9i7DqwSK578Q6GdLCPty3Jjn7PlaOs9Qt1ysWOOVym3RRAI8isAb+33uCodqhgh5+i52sHhxZDJC9tLju+ESVKWceOschHx9GBz/K6jLa+/xodsEdv/G2J8U1WgIrty2tVWwsy0OaWghLEgx/6yNO09+/D9CYNOukBebOnLiiCQFtkjI6Aj+YiT9LKbf204trvzgWqc0huMrkh80ZcvEt3Rc9MQciuQCyFIy6FF/Pva02PXi0D42S1trgkmnMmLHLP0RGkqKPxdKrofibe5D0Uucyaaus="
+
+[[package]]
+name = "libgcc"
+version = "16.1.1+r595+g171d15ac6959-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/l/libgcc/libgcc-16.1.1+r595+g171d15ac6959-1-x86_64.pkg.tar.zst"
+sha256 = "dc8e53852e71b2196ffd05f2b96d1b30bf7bad5c103c3368c4b20debdccb4b90"
+signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCamic9V8UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCii+AP43grBo3MVWJ4A3DwJbpTdwl6oEDz75z0gxg5WhTslD9gEA2tms0a7rr5MpOQfbZqYJ7G48KhjTgLb6wlgE/yhB0gE="
+
+[[package]]
+name = "libgfortran"
+version = "16.1.1+r595+g171d15ac6959-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/l/libgfortran/libgfortran-16.1.1+r595+g171d15ac6959-1-x86_64.pkg.tar.zst"
+sha256 = "3167014e245690cb957eeab42f8e2a68708e3f054b37114b43c86fecc84c033a"
+signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCamic9V8UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCk6tAQDhWI/YUcP4HjWq7rRhcjs9gqtl+98g1PocDZ14gJCJjQD9ExHn+FlZjSK+C4FM+1dl9ULjAJsC12MgSD2WoX/+qAQ="
 
 [[package]]
 name = "libgit2"
@@ -114,6 +170,22 @@ sha256 = "ecad55ff6d0ee582faded4c2056c061fde9537627df77481d93b22f1a9b12e49"
 signature = "iQIzBAABCgAdFiEEsNZSlUdmBrcfDG+CqF6BHrTKLggFAmpbfqAACgkQqF6BHrTKLgi77Q/8Dewk7j6wNQR6SQCrGxRh1EyFyQQkXNcteXGBrQEaonTDEed2d5XBaOUltb51vlANY+QqDlrFGQsaIYaR1qSlsV181MoWJGHdL+HhHthsWoTYUh9wjEypCfp0Mo2yvS9ycNnWU9xZgfHtmQ4nyK5HVs4WQTuOProJH1fOuFFq5hPtYdpemgQuA4NBZvJckAlv3WowdAJvVtMr7565QAZRyVWlYIVczqmfKn4cKg8k5s5zUHQjTLzTqthjawydPM8JgAkxNo12E1N6VYayXiv3r4kE2rcf/9KNvtBeOJy9zuKJJ5HB8I34l0GodXMnPOwYJ+2hvZe4o7+G/JAPWVyxeluNrTBfFJvJ+fPs6NNpR0TY0NjussJa3piNcdrRXz9G0lYI0kkD0+v/e/e+beRU8bNpLkPZ7seQ+TtNBfvpJajIIoNSxDnxRGdFyZg/K2WW+NcZfwhLeLp9eVmy+570j/ZrviysZiOIw/I4BlIqSNCWax9JBY/lZiBkTg10oHaza6zV1rMSJB5XRsIfFnWiJGRzAC7dd1klVenmn0YHr0WeeUjOjfibdp2eZQMtlKhzvTFtZ4YcBuOakuluCc2n+JNfQeOV5Wu6l2sHfCSsgtSV8CZNOrnjYawjlfI0beUKKFzOtPOF7VXhlKdRAC+c1jyO/J4Xaju8YfANSukz6GU="
 
 [[package]]
+name = "libgomp"
+version = "16.1.1+r595+g171d15ac6959-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/l/libgomp/libgomp-16.1.1+r595+g171d15ac6959-1-x86_64.pkg.tar.zst"
+sha256 = "92c9acb2cd1cd1aab8bc991c12ec6785c546d9be621900ee7323cc099daec8ac"
+signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCamic9l8UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCp6KAP9n9gVfAJV2DVGwC5lJ0qgE3a3WYvSuZ0HRVe9dUutGaQD9EXrFrkWEXt2TyLY8Mc5YXjW8/9SqOKpSnAqJcdDdKwA="
+
+[[package]]
+name = "libhwasan"
+version = "16.1.1+r595+g171d15ac6959-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/l/libhwasan/libhwasan-16.1.1+r595+g171d15ac6959-1-x86_64.pkg.tar.zst"
+sha256 = "3e3180c93989abdeeb4e4845da024ce98a1fdd48ce8639b21f5f30986985e8ac"
+signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCamic9l8UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCluOAPoCr1Er+VgniX9vI6UCXPPucIVg/b879P6/FfKNNZ9rdgEAjkp0CjRmNefHUxVmLqDd0B305tuIaFt7gctdTkOX3g0="
+
+[[package]]
 name = "libisl"
 version = "0.28-1"
 system = "archlinux"
@@ -122,12 +194,84 @@ sha256 = "e72fd1165d674f440ff9882b514c999423098a5852ea41fa692db65f391c98c1"
 signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCakq0ul8UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCgMCAQCuIvVOR12g+pI+G/EumoSVkYRBDCOsNAzAuLbJxyXcpgEAvEHsrU/aKFdekdJJd9dP8MP7vGSvSxsELAtS99pJZAI="
 
 [[package]]
+name = "liblsan"
+version = "16.1.1+r595+g171d15ac6959-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/l/liblsan/liblsan-16.1.1+r595+g171d15ac6959-1-x86_64.pkg.tar.zst"
+sha256 = "bc63bf5584c9228f932bf922cb44c9f576df2dcac94942f1a984200991018f25"
+signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCamic9l8UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCk97AQDFsmIzn+nweAKo5xV0AJQwR5+pNPe4ltoal5RsChu26QD+NOy5FOq0yCL6vSkZDf0vi7JHAOZIDGv+G2qGqBYFfQ4="
+
+[[package]]
 name = "libmpc"
 version = "1.4.1-1"
 system = "archlinux"
 url = "https://archive.archlinux.org/packages/l/libmpc/libmpc-1.4.1-1-x86_64.pkg.tar.zst"
 sha256 = "880bdba957ebe5136449c7b61821e92628d7bdd43f370e5a0818d229372d3851"
 signature = "iQEzBAABCgAdFiEEFRnVq6Zb9vwrc8dWek52CV2KUuQFAmnhAlsACgkQek52CV2KUuSBcgf9E61NpAV+F+wHPlOgZOT9yurZAhQwUNd4SRQkNEFrbyMJ1C3Bu9vUayr05Q+MxeQ8/J0W5aACrWSOEAtvYlu9vfmzbn7/S9rHtH9fmvmj46hZemo48cVTq9YTQA1Doe5e9j3DTOWdEsWv7XCMSIXGI2RdIXYB+TH1DLNi7B95EwDySH7SpznjH+SGv9ttVMsmAChRbGR3fIVi6hz6OgSGErFJJmTI5jwt06U6L7Yhl/4ybvYXuh1DGhdFpNhJBGLcYmQhBhv3OGa2dwj051fEjneL2PK80u4nmc+3dP7cOW3pY8jBDpOVfRvnAwiY/NuJMK1YK3iFd3YbYQnuu1D2cQ=="
+
+[[package]]
+name = "libnghttp3"
+version = "1.18.0-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/l/libnghttp3/libnghttp3-1.18.0-1-x86_64.pkg.tar.zst"
+sha256 = "4a474a6c8c2970bead13cbdf4ab47662039d43dcc48aa811ee58becd778cf890"
+signature = "iHUEABYKAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCamYDDAAKCRBtQr3RFuAGj7VnAQD2WpePvpZNdgpFc7vO1vXSGMN9lr3qaA7vbypIaJpJXAD9Ebg7wopx2Ajigt9aq+5888h/5i8/2nN+Fk8fG0XwTQ8="
+
+[[package]]
+name = "libngtcp2"
+version = "1.25.0-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/l/libngtcp2/libngtcp2-1.25.0-1-x86_64.pkg.tar.zst"
+sha256 = "e4a728d9f647f3c52a3aedd67c589be5f43e7dd31ebde6867ad535ba29ec9511"
+signature = "iHUEABYKAB0WIQQEKYl95fO9rFN6MGltQr3RFuAGjwUCamYCwgAKCRBtQr3RFuAGj87bAP0VpC6Qn3iGVMDNzoR/wMBxMf+kdx8Sw0hatkEJjVXb9QEA4DGbIJM06qwjzzdKrWrjAKfIOlGvnxdPWr5LgMBx0wg="
+
+[[package]]
+name = "libobjc"
+version = "16.1.1+r595+g171d15ac6959-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/l/libobjc/libobjc-16.1.1+r595+g171d15ac6959-1-x86_64.pkg.tar.zst"
+sha256 = "c523051bbd453f2d194a74cb3ce4285b4801addd388b77fe21cd3aca4430b5e9"
+signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCamic9l8UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCp7XAPoCbvPBM5AchKWl3+W1SAxb44CoUvVROYhWJH8F6M1N9QEAiRI92DhxIYvGGns9ypzNHzmo97C9HjgbF4wu7nWOPQo="
+
+[[package]]
+name = "libquadmath"
+version = "16.1.1+r595+g171d15ac6959-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/l/libquadmath/libquadmath-16.1.1+r595+g171d15ac6959-1-x86_64.pkg.tar.zst"
+sha256 = "1c413092fddca442bf4b600b6c03562424e328f1b73bcdc2b9ca7f798c26d5e3"
+signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCamic9l8UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCtNyAP0XXxbI0d2HubuU8SWf4Cb1J3mqYuavzPinSmG9NVs5WQEA4p3UMIBRpfzKS22fKlNCH6fyi4UEeFQjVG6puL2Wqw4="
+
+[[package]]
+name = "libstdc++"
+version = "16.1.1+r595+g171d15ac6959-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/l/libstdc++/libstdc++-16.1.1+r595+g171d15ac6959-1-x86_64.pkg.tar.zst"
+sha256 = "14d6eea64e005e54e7fdecdd461cd770aa24c13cca5142f6753b9eaf7efb5631"
+signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCamic918UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCh0CAP9A6J2Cx+4Z6M8rvjLBatTLxLtVDUuIef//l1k99wbXzAD+NE4tLFflMjQlmr16LpFMNjGMGKng2rRBU/qsENnYUgI="
+
+[[package]]
+name = "libsysprof-capture"
+version = "50.0-4"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/l/libsysprof-capture/libsysprof-capture-50.0-4-x86_64.pkg.tar.zst"
+sha256 = "4f547dfd1827d92b3f0db5d2a6aac8fb2ed1fae3606eadfdae14a62ce76ee1a8"
+signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCami2f18UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCiXxAQDShJ93r1w2tjl2aNWlCXw0BT0w8AJUbyfNjtqjjO0XZwD+MPm7MIvjivb1GxftWuabmsxPe55K6+1YTNRxcV12FgI="
+
+[[package]]
+name = "libtsan"
+version = "16.1.1+r595+g171d15ac6959-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/l/libtsan/libtsan-16.1.1+r595+g171d15ac6959-1-x86_64.pkg.tar.zst"
+sha256 = "7dc2e4dc22789cf180ab617a3947558c79c550d43a2975f8295ae4c7d8e74419"
+signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCamic918UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCtySAP9nvifzvnoxbX8r1Tem7hl+l0WoGHRYk5BEgQltVWUjhQD6AkKyBkDP56iu7K+/Zmv7W7pgDn4lbl//nz9uWOX8nA8="
+
+[[package]]
+name = "libubsan"
+version = "16.1.1+r595+g171d15ac6959-1"
+system = "archlinux"
+url = "https://archive.archlinux.org/packages/l/libubsan/libubsan-16.1.1+r595+g171d15ac6959-1-x86_64.pkg.tar.zst"
+sha256 = "e30a1eadd6e37fbf5c8dec8a823de2c25d0057bb90567459bd4a820c83814517"
+signature = "iNUEABYKAH0WIQQFx3danouXdAf+COadTFqhVCbaCgUCamic918UgAAAAAAuAChpc3N1ZXItZnByQG5vdGF0aW9ucy5vcGVucGdwLmZpZnRoaG9yc2VtYW4ubmV0MDVDNzc3NUE5RThCOTc3NDA3RkUwOEU2OUQ0QzVBQTE1NDI2REEwQQAKCRCdTFqhVCbaCretAP9bD0imydff04/mr5QJPEoJsOGz++yMsqP3QE/9+uuhzwD/Sfq85R0mYPW/YxoIAIpnLV+cb2fId0J4sSUjuVgg+A4="
 
 [[package]]
 name = "libuv"

--- a/src/policy/domain_canister.rs
+++ b/src/policy/domain_canister.rs
@@ -3,8 +3,9 @@ use std::sync::Arc;
 use ahash::AHashSet;
 use candid::Principal;
 use fqdn::{FQDN, Fqdn};
+use ic_bn_lib::ic_agent::agent::SubnetType;
 
-use crate::routing::ic::routing_table_manager::{LooksUpSubnetType, SubnetType};
+use crate::routing::ic::routing_table_manager::LooksUpSubnetType;
 
 /// Things needed to verify domain-canister match
 #[derive(derive_new::new)]
@@ -34,7 +35,7 @@ impl DomainCanisterMatcher {
             Some(SubnetType::System) => &self.domains_system,
             Some(SubnetType::CloudEngine) => &self.domains_engine,
             Some(
-                SubnetType::Application | SubnetType::VerifiedApplication | SubnetType::Unknown,
+                SubnetType::Application | SubnetType::VerifiedApplication | SubnetType::Unknown(_),
             )
             | None => &self.domains_app,
         };

--- a/src/routing/ic/route_provider/health.rs
+++ b/src/routing/ic/route_provider/health.rs
@@ -5,6 +5,7 @@ use std::{
 };
 
 use ahash::AHashMap;
+use arc_swap::ArcSwapOption;
 use async_trait::async_trait;
 use bytes::Bytes;
 use derive_new::new;
@@ -243,6 +244,7 @@ pub struct HealthCheckManager {
     check_interval: Duration,
     tx: mpsc::Sender<(Arc<Node>, HealthCheckResult)>,
     rx: mpsc::Receiver<(Arc<Node>, HealthCheckResult)>,
+    node_list: Arc<ArcSwapOption<NodeList>>,
     node_list_rx: watch::Receiver<NodeList>,
     healthy_nodes_tx: watch::Sender<Vec<HealthyNode>>,
     idle_interval: Interval,
@@ -263,10 +265,12 @@ impl Debug for HealthCheckManager {
 }
 
 impl HealthCheckManager {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         checker: Arc<dyn ChecksHealth>,
         check_interval: Duration,
         idle_period: Duration,
+        node_list: Arc<ArcSwapOption<NodeList>>,
         node_list_rx: watch::Receiver<NodeList>,
         healthy_nodes_tx: watch::Sender<Vec<HealthyNode>>,
         ewma_alpha: f64,
@@ -282,6 +286,7 @@ impl HealthCheckManager {
             check_interval,
             rx,
             tx,
+            node_list,
             node_list_rx,
             healthy_nodes_tx,
             idle_interval,
@@ -316,6 +321,7 @@ impl HealthCheckManager {
     /// Starts & stops actors to match the new list of nodes
     #[allow(clippy::cast_possible_wrap)]
     async fn update_node_list(&mut self, node_list: NodeList) {
+        self.node_list.store(Some(Arc::new(node_list.clone())));
         self.metrics.nodes.set(node_list.len() as i64);
 
         let start = Instant::now();
@@ -528,11 +534,13 @@ mod test {
         let checker = Arc::new(TestHealthChecker::default());
         let (node_list_tx, node_list_rx) = watch::channel(NodeList::new(vec![]));
         let (healthy_nodes_tx, mut healthy_nodes_rx) = watch::channel(vec![]);
+        let node_list = Arc::new(ArcSwapOption::empty());
 
         let manager = HealthCheckManager::new(
             checker,
             Duration::from_millis(50),
             Duration::from_secs(10),
+            node_list,
             node_list_rx,
             healthy_nodes_tx,
             0.5,

--- a/src/routing/ic/route_provider/provider.rs
+++ b/src/routing/ic/route_provider/provider.rs
@@ -6,16 +6,14 @@ use std::{
 
 use anyhow::anyhow;
 use arc_swap::ArcSwapOption;
-use derive_new::new;
 use fqdn::FQDN;
 use ic_bn_lib::ic_agent::{
     AgentError,
     agent::route_provider::{RouteProvider, RoutesStats},
 };
 use prometheus::{IntCounterVec, Registry, register_int_counter_vec_with_registry};
-use tokio::{select, sync::watch};
+use tokio::sync::watch;
 use tokio_util::{sync::CancellationToken, task::TaskTracker};
-use tracing::{info, warn};
 use url::Url;
 
 use crate::routing::ic::route_provider::{
@@ -41,49 +39,6 @@ impl Metrics {
             )
             .unwrap(),
         }
-    }
-}
-
-/// Handles incoming updates of the node list on behalf of [`DynamicRouteProvider`]
-#[derive(new)]
-#[allow(clippy::struct_field_names)]
-pub struct RouteProviderManager {
-    node_list: Arc<ArcSwapOption<NodeList>>,
-    node_list_rx: watch::Receiver<NodeList>,
-}
-
-impl Display for RouteProviderManager {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "RouteProviderManager")
-    }
-}
-
-impl Debug for RouteProviderManager {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{self}")
-    }
-}
-
-impl RouteProviderManager {
-    async fn run(mut self, token: CancellationToken) {
-        warn!("{self}: Started");
-
-        loop {
-            select! {
-                // Process updates to the node list
-                Ok(()) = self.node_list_rx.changed() => {
-                    let node_list = self.node_list_rx.borrow_and_update().clone();
-                    info!("{self}: Got a new list of nodes ({}), storing", node_list.len());
-                    self.node_list.store(Some(Arc::new(node_list.clone())));
-                }
-
-                () = token.cancelled() => {
-                    break;
-                }
-            }
-        }
-
-        warn!("{self}: Shutting down");
     }
 }
 
@@ -163,16 +118,13 @@ impl DynamicRouteProvider {
         );
         tracker.spawn(fetcher_manager.run(node_fetch_interval, token.child_token()));
 
-        // Start route provider manager
-        let route_provider_manager = RouteProviderManager::new(node_list, node_list_rx.clone());
-        tracker.spawn(route_provider_manager.run(token.child_token()));
-
         // Start health checking
         let (healthy_nodes_tx, healthy_nodes_rx) = watch::channel(vec![]);
         let health_check_manager = HealthCheckManager::new(
             health_checker,
             health_check_interval,
             idle_period,
+            node_list,
             node_list_rx,
             healthy_nodes_tx,
             ewma_alpha,

--- a/src/routing/ic/routing_table_manager.rs
+++ b/src/routing/ic/routing_table_manager.rs
@@ -6,27 +6,26 @@ use std::{
     time::{Duration, Instant},
 };
 
-use ahash::{AHashMap, AHashSet};
+use ahash::AHashMap;
 use anyhow::{Context, Error, anyhow};
 use arc_swap::ArcSwapOption;
 use async_trait::async_trait;
 use candid::Principal;
-use futures::future::join_all;
+pub use ic_bn_lib::ic_agent::agent::SubnetType;
 use ic_bn_lib::{
     BoolYesNo,
     health::Healthy,
-    ic_agent::{Agent, agent::SubnetType as AgentSubnetType, hash_tree::SubtreeLookupResult},
+    ic::{AgentExt, CanisterRange, SubnetData},
+    ic_agent::Agent,
     tasks::Run,
 };
 use prometheus::{
-    HistogramVec, IntCounterVec, IntGauge, Registry, register_histogram_vec_with_registry,
-    register_int_counter_vec_with_registry, register_int_gauge_with_registry,
+    IntCounterVec, IntGauge, Registry, register_int_counter_vec_with_registry,
+    register_int_gauge_with_registry,
 };
 use tokio::time::interval;
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
-
-use crate::metrics::HTTP_DURATION_BUCKETS;
 
 /// Retry interval used when no snapshot has been fetched yet and we are in the
 /// aggressive boot-strap loop.
@@ -36,24 +35,11 @@ const AGGRESSIVE_RETRY_INTERVAL: Duration = Duration::from_secs(1);
 /// the whole fetch a success.
 const SUCCESS_FRACTION: f64 = 2.0 / 3.0;
 
-/// The type of an IC subnet as reported in the NNS state tree.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum SubnetType {
-    Application,
-    System,
-    VerifiedApplication,
-    CloudEngine,
-    Unknown,
-}
-
 #[derive(Clone)]
 pub struct Metrics {
     subnets: IntGauge,
     ranges: IntGauge,
-    id_fetches: IntCounterVec,
     data_fetches: IntCounterVec,
-    id_fetches_duration: HistogramVec,
-    data_fetches_duration: HistogramVec,
 }
 
 impl Metrics {
@@ -73,36 +59,10 @@ impl Metrics {
             )
             .unwrap(),
 
-            id_fetches: register_int_counter_vec_with_registry!(
-                format!("routing_table_manager_id_fetches"),
-                format!("Counts number of subnet-id fetches and their outcome"),
-                &["success"],
-                registry
-            )
-            .unwrap(),
-
             data_fetches: register_int_counter_vec_with_registry!(
                 format!("routing_table_manager_data_fetches"),
                 format!("Counts number of per-subnet data fetches"),
                 &["subnet_id", "success"],
-                registry
-            )
-            .unwrap(),
-
-            id_fetches_duration: register_histogram_vec_with_registry!(
-                format!("routing_table_manager_id_fetches_duration"),
-                format!("Records the duration of subnet_ids fetching in seconds"),
-                &["success"],
-                HTTP_DURATION_BUCKETS.to_vec(),
-                registry
-            )
-            .unwrap(),
-
-            data_fetches_duration: register_histogram_vec_with_registry!(
-                format!("routing_table_manager_data_fetches_duration"),
-                format!("Records the duration of per-subnet data fetching in seconds"),
-                &["subnet_id", "success"],
-                HTTP_DURATION_BUCKETS.to_vec(),
                 registry
             )
             .unwrap(),
@@ -115,106 +75,9 @@ pub trait LooksUpSubnetType: Send + Sync {
     fn lookup_subnet_type(&self, canister_id: &Principal) -> Option<SubnetType>;
 }
 
-#[async_trait]
-trait FetchesSubnetInfo: Send + Sync {
-    async fn fetch_subnet_ids(
-        &self,
-        root_subnet_id: Principal,
-    ) -> Result<AHashSet<Principal>, Error>;
-
-    async fn fetch_subnet_data(&self, subnet_id: &Principal) -> Result<SubnetData, Error>;
-}
-
-#[async_trait]
-impl FetchesSubnetInfo for Agent {
-    /// Returns the list of all subnet IDs as reported by the NNS state tree.
-    async fn fetch_subnet_ids(
-        &self,
-        root_subnet_id: Principal,
-    ) -> Result<AHashSet<Principal>, Error> {
-        let cert = self
-            .read_subnet_state_raw(vec![vec!["subnet".into()]], root_subnet_id)
-            .await
-            .context("failed to read /subnet from NNS")?;
-
-        let SubtreeLookupResult::Found(subnet_tree) =
-            cert.tree.lookup_subtree([b"subnet".as_ref()])
-        else {
-            return Err(anyhow!("/subnet subtree not found in NNS state tree"));
-        };
-
-        // list_paths() returns one entry per leaf, so the same subnet ID appears
-        // multiple times (once per sub-key: "type", "public_key", "node/...",
-        // etc.).  The AHashSet deduplicates them.
-        let subnet_ids = subnet_tree
-            .list_paths()
-            .iter()
-            .filter(|p| !p.is_empty())
-            .map(|p| {
-                Principal::try_from_slice(p[0].as_bytes())
-                    .context("malformed subnet ID in NNS tree")
-            })
-            .collect::<Result<_, _>>()?;
-
-        Ok(subnet_ids)
-    }
-
-    async fn fetch_subnet_data(&self, subnet_id: &Principal) -> Result<SubnetData, Error> {
-        let subnet = self
-            .fetch_subnet_by_id(subnet_id)
-            .await
-            .context("failed to fetch subnet info")?;
-
-        let ranges = subnet
-            .iter_canister_ranges()
-            .map(|r| CanisterRange {
-                start: *r.start(),
-                end: *r.end(),
-            })
-            .collect();
-
-        let subnet_type = SubnetType::from(subnet.subnet_type());
-        if subnet_type == SubnetType::Unknown {
-            return Err(anyhow!("unknown subnet type: {:?}", subnet.subnet_type()));
-        }
-
-        Ok(SubnetData {
-            ranges,
-            subnet_type,
-        })
-    }
-}
-
-impl From<Option<&AgentSubnetType>> for SubnetType {
-    fn from(t: Option<&AgentSubnetType>) -> Self {
-        match t {
-            Some(AgentSubnetType::Application) => Self::Application,
-            Some(AgentSubnetType::System) => Self::System,
-            Some(AgentSubnetType::VerifiedApplication) => Self::VerifiedApplication,
-            Some(AgentSubnetType::CloudEngine) => Self::CloudEngine,
-            Some(AgentSubnetType::Unknown(_)) | None => Self::Unknown,
-        }
-    }
-}
-
-/// Represents a single canister range of a subnet.
-/// start & end are inclusive.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct CanisterRange {
-    start: Principal,
-    end: Principal,
-}
-
-/// Subnet's canister ranges & its type
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct SubnetData {
-    ranges: Vec<CanisterRange>,
-    subnet_type: SubnetType,
-}
-
 /// A single NNS routing entry: a contiguous canister ID range assigned to a
 /// specific subnet, with the subnet's type embedded to avoid a secondary lookup.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 struct RoutingEntry {
     range: CanisterRange,
     subnet_type: SubnetType,
@@ -237,7 +100,7 @@ impl SubnetsRoutingTable {
             for range in data.ranges {
                 ranges.push(RoutingEntry {
                     range,
-                    subnet_type: data.subnet_type,
+                    subnet_type: data.subnet_type.clone(),
                 });
             }
         }
@@ -265,7 +128,7 @@ impl LooksUpSubnetType for SubnetsRoutingTable {
 
         let r = &self.ranges[idx];
         if id <= r.range.end.as_slice() {
-            Some(r.subnet_type)
+            Some(r.subnet_type.clone())
         } else {
             None
         }
@@ -279,7 +142,7 @@ impl LooksUpSubnetType for SubnetsRoutingTable {
 /// 2. Concurrently call `fetch_subnet_by_id` for each subnet, fetching both
 ///    its type and canister ranges directly from the subnet.
 pub struct RoutingTableManager {
-    subnet_info_fetcher: Arc<dyn FetchesSubnetInfo>,
+    subnet_info_fetcher: Arc<dyn AgentExt + Send + Sync + 'static>,
     root_subnet_id: Principal,
     snapshot: Mutex<AHashMap<Principal, SubnetData>>,
     /// `None` until the first successful fetch
@@ -325,7 +188,7 @@ impl RoutingTableManager {
     }
 
     fn new_with_fetcher(
-        fetcher: Arc<dyn FetchesSubnetInfo>,
+        fetcher: Arc<dyn AgentExt + Send + Sync + 'static>,
         root_subnet_id: Principal,
         interval: Duration,
         registry: &Registry,
@@ -346,30 +209,28 @@ impl RoutingTableManager {
     }
 
     /// Update the local snapshot with the fresh per-subnet data
-    async fn refresh_snapshot(&self, subnet_ids: &AHashSet<Principal>) {
+    #[allow(clippy::cast_possible_wrap)]
+    async fn refresh_snapshot(&self) -> Result<usize, Error> {
         // Fetch the per-subnet data concurrently
         let start = Instant::now();
-        let futures = subnet_ids.iter().map(|subnet_id| async move {
-            let start = Instant::now();
-            let res = self.subnet_info_fetcher.fetch_subnet_data(subnet_id).await;
-            (subnet_id, res, start.elapsed())
-        });
-        let results = join_all(futures).await;
+        let results = self
+            .subnet_info_fetcher
+            .fetch_all_subnets_data(self.root_subnet_id, Some(80))
+            .await
+            .context("unable to fetch subnets data")?;
         let dur = start.elapsed();
+        let subnets_count = results.len();
+        self.metrics.subnets.set(subnets_count as i64);
 
         let mut snapshot = self.snapshot.lock().unwrap();
         // Remove any subnets that are already gone from the list
-        snapshot.retain(|x, _| subnet_ids.contains(x));
+        snapshot.retain(|x, _| results.contains_key(x));
 
         // Insert/update the new data that was fetched.
         // If there was an error - the older data will stay in the snapshot.
         let mut ok = 0;
-        for (subnet_id, res, duration) in results {
+        for (subnet_id, res) in results {
             let subnet_id_str = subnet_id.to_string();
-            self.metrics
-                .data_fetches_duration
-                .with_label_values(&[subnet_id_str.as_str(), res.is_ok().yesno()])
-                .observe(duration.as_secs_f64());
             self.metrics
                 .data_fetches
                 .with_label_values(&[subnet_id_str.as_str(), res.is_ok().yesno()])
@@ -378,7 +239,7 @@ impl RoutingTableManager {
             match res {
                 Ok(data) => {
                     ok += 1;
-                    snapshot.insert(*subnet_id, data);
+                    snapshot.insert(subnet_id, data);
                 }
                 Err(e) => {
                     warn!("{self}: {subnet_id}: error fetching data: {e:#}");
@@ -387,45 +248,21 @@ impl RoutingTableManager {
         }
 
         info!(
-            "{self}: Successfully loaded data for {ok}/{} subnets in {}s",
-            subnet_ids.len(),
+            "{self}: Successfully loaded data for {ok}/{subnets_count} subnets in {}s",
             dur.as_secs_f64()
         );
+
+        Ok(subnets_count)
     }
 
     /// Tries to update the routing table by refreshing the per-subnet data
     #[allow(clippy::cast_precision_loss)]
     #[allow(clippy::cast_possible_wrap)]
     async fn update_routing_table(&self) -> Result<(), Error> {
-        // Get the list of all subnet's IDs
-        let start = Instant::now();
-        let res = self
-            .subnet_info_fetcher
-            .fetch_subnet_ids(self.root_subnet_id)
-            .await;
-        self.metrics
-            .id_fetches
-            .with_label_values(&[res.is_ok().yesno()])
-            .inc();
-        self.metrics
-            .id_fetches_duration
-            .with_label_values(&[res.is_ok().yesno()])
-            .observe(start.elapsed().as_secs_f64());
-
-        let subnet_ids = res.context("unable to fetch subnet IDs")?;
-        self.metrics.subnets.set(subnet_ids.len() as i64);
-
-        info!(
-            "{self}: Got a list of {} subnets in {}s",
-            subnet_ids.len(),
-            start.elapsed().as_secs_f64()
-        );
-
-        if subnet_ids.is_empty() {
-            return Err(anyhow!("no subnet ids were fetched"));
-        }
-
-        self.refresh_snapshot(&subnet_ids).await;
+        let subnets_count = self
+            .refresh_snapshot()
+            .await
+            .context("unablt to refresh snapshot")?;
         let snapshot = self.snapshot.lock().unwrap();
 
         // Check if we already have enough valid subnet data.
@@ -433,7 +270,7 @@ impl RoutingTableManager {
         // That is, if we have *some* info for at least SUCCESS_FRACTION subnets,
         // then we're good to publish a new routing table.
         // Some info is better than no info in this case, since it anyway changes very rarely.
-        let fraction = (snapshot.len() as f64) / (subnet_ids.len() as f64);
+        let fraction = (snapshot.len() as f64) / (subnets_count as f64);
         if fraction < SUCCESS_FRACTION {
             return Err(anyhow!(
                 "Less than {SUCCESS_FRACTION} of the subnets were successfully fetched: {fraction}"
@@ -514,7 +351,8 @@ impl Run for RoutingTableManager {
 mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
 
-    use ic_bn_lib::{MAINNET_ROOT_SUBNET_ID, principal};
+    use ahash::AHashSet;
+    use ic_bn_lib::{MAINNET_ROOT_SUBNET_ID, ic_agent::AgentError, principal};
 
     use super::*;
 
@@ -563,45 +401,67 @@ mod tests {
     struct TestSubnetInfoFetcher(AtomicUsize);
 
     #[async_trait]
-    impl FetchesSubnetInfo for TestSubnetInfoFetcher {
+    impl AgentExt for TestSubnetInfoFetcher {
+        // Not used by `RoutingTableManager`, which calls `fetch_all_subnets_data` directly.
         async fn fetch_subnet_ids(
             &self,
             _root_subnet_id: Principal,
-        ) -> Result<AHashSet<Principal>, Error> {
+        ) -> Result<AHashSet<Principal>, AgentError> {
+            unimplemented!()
+        }
+
+        // Not used by `RoutingTableManager`, which calls `fetch_all_subnets_data` directly.
+        async fn fetch_subnet_data(
+            &self,
+            _subnet_id: &Principal,
+        ) -> Result<SubnetData, AgentError> {
+            unimplemented!()
+        }
+
+        async fn fetch_all_subnets_data(
+            &self,
+            _root_subnet_id: Principal,
+            _concurrency: Option<usize>,
+        ) -> Result<AHashMap<Principal, Result<SubnetData, AgentError>>, AgentError> {
             let v = self.0.fetch_add(1, Ordering::SeqCst);
 
-            if v == 0 {
-                Err(anyhow!("foo"))
+            let subnet_ids = if v == 0 {
+                return Err(AgentError::MessageError("foo".into()));
             } else if v == 1 {
-                Ok(AHashSet::from_iter([
+                AHashSet::from_iter([
                     principal!("uqzsh-gqaaa-aaaaq-qaada-cai"),
                     principal!("gjxif-ryaaa-aaaad-ae4ka-cai"),
                     principal!("aaaaa-aa"),
                     principal!("lusdn-iiaaa-aaaam-qivpa-cai"),
-                ]))
+                ])
             } else if v == 2 {
-                Ok(AHashSet::from_iter([
+                AHashSet::from_iter([
                     principal!("uqzsh-gqaaa-aaaaq-qaada-cai"),
                     principal!("gjxif-ryaaa-aaaad-ae4ka-cai"),
                     principal!("6hsbt-vqaaa-aaaaf-aaafq-cai"),
                     principal!("lusdn-iiaaa-aaaam-qivpa-cai"),
-                ]))
+                ])
             } else if v == 3 {
-                Ok(AHashSet::from_iter([
+                AHashSet::from_iter([
                     principal!("uqzsh-gqaaa-aaaaq-qaada-cai"),
                     principal!("gjxif-ryaaa-aaaad-ae4ka-cai"),
                     principal!("lusdn-iiaaa-aaaam-qivpa-cai"),
-                ]))
+                ])
             } else {
-                Err(anyhow!("foo"))
-            }
-        }
+                return Err(AgentError::MessageError("foo".into()));
+            };
 
-        async fn fetch_subnet_data(&self, subnet_id: &Principal) -> Result<SubnetData, Error> {
-            create_data()
-                .get(subnet_id)
-                .cloned()
-                .ok_or_else(|| anyhow!("foo"))
+            let data = create_data();
+            Ok(subnet_ids
+                .into_iter()
+                .map(|id| {
+                    let res = data
+                        .get(&id)
+                        .cloned()
+                        .ok_or_else(|| AgentError::MessageError("foo".into()));
+                    (id, res)
+                })
+                .collect())
         }
     }
 

--- a/src/routing/ic/routing_table_manager.rs
+++ b/src/routing/ic/routing_table_manager.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use ahash::AHashMap;
-use anyhow::{Context, Error, anyhow};
+use anyhow::{Context, Error, anyhow, bail};
 use arc_swap::ArcSwapOption;
 use async_trait::async_trait;
 use candid::Principal;
@@ -136,11 +136,6 @@ impl LooksUpSubnetType for SubnetsRoutingTable {
 }
 
 /// Fetches the full routing table and subnet types.
-///
-/// Round trips performed per update cycle:
-/// 1. Read NNS `/subnet` to discover all subnet IDs.
-/// 2. Concurrently call `fetch_subnet_by_id` for each subnet, fetching both
-///    its type and canister ranges directly from the subnet.
 pub struct RoutingTableManager {
     subnet_info_fetcher: Arc<dyn AgentExt + Send + Sync + 'static>,
     root_subnet_id: Principal,
@@ -263,6 +258,11 @@ impl RoutingTableManager {
             .refresh_snapshot()
             .await
             .context("unablt to refresh snapshot")?;
+
+        if subnets_count == 0 {
+            bail!("No subnets were fetched");
+        }
+
         let snapshot = self.snapshot.lock().unwrap();
 
         // Check if we already have enough valid subnet data.

--- a/src/routing/ic/routing_table_manager.rs
+++ b/src/routing/ic/routing_table_manager.rs
@@ -398,10 +398,10 @@ mod tests {
     }
 
     #[derive(Default)]
-    struct TestSubnetInfoFetcher(AtomicUsize);
+    struct TestAgent(AtomicUsize);
 
     #[async_trait]
-    impl AgentExt for TestSubnetInfoFetcher {
+    impl AgentExt for TestAgent {
         // Not used by `RoutingTableManager`, which calls `fetch_all_subnets_data` directly.
         async fn fetch_subnet_ids(
             &self,
@@ -528,7 +528,7 @@ mod tests {
     #[tokio::test]
     #[allow(clippy::await_holding_lock)] // clippy is stupid
     async fn test_routing_table_manager() {
-        let fetcher = TestSubnetInfoFetcher::default();
+        let fetcher = TestAgent::default();
         let manager = RoutingTableManager::new_with_fetcher(
             Arc::new(fetcher),
             MAINNET_ROOT_SUBNET_ID,


### PR DESCRIPTION
Drop redundant code, remove `FetchesSubnetInfo` trait, use implementation from `ic-bn-lib`. This also drops a few metrics since they're using data that is now behind API boundaries, but they're not very useful.