### PR TITLE
feat(NODE-1976): Add MCP redirect & metrics

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,8 @@ env:
   CARGO_TERM_COLOR: never
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
+  GIT_SHA: ${{ github.sha }}
+  RELEASE_TAG: ${{ github.ref }}
 
 permissions:
   contents: write
@@ -35,6 +37,13 @@ jobs:
       # Improves reproducibility
       - name: Set SOURCE_DATE_EPOCH
         run: echo "SOURCE_DATE_EPOCH=$(git log -1 --format=%ct)" >> "$GITHUB_ENV"
+
+      - name: Set Cargo.toml version
+        shell: bash
+        run: |
+          mv Cargo.toml Cargo.toml.orig
+          sed "s/0\\.0\\.0-git/${RELEASE_TAG##*\/v}/" Cargo.toml.orig > Cargo.toml
+          rm -f Cargo.toml.orig
 
       - name: Build
         run: repro-env build --env SOURCE_DATE_EPOCH -- cargo build --features sev-snp,smtp,mcp --release --target x86_64-unknown-linux-musl --bin ic-gateway

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -337,7 +337,7 @@ checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -497,7 +497,7 @@ checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
 dependencies = [
  "getrandom 0.2.17",
  "instant",
- "rand 0.8.7",
+ "rand 0.8.8",
 ]
 
 [[package]]
@@ -630,7 +630,7 @@ checksum = "c0cb6f3d4773a2107b94cbeccaa5b5f0b35a88389b5d522d13d659f64317b22d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -683,9 +683,9 @@ dependencies = [
 
 [[package]]
 name = "blocking"
-version = "1.6.2"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+checksum = "a70e4329df6cb94385eed412ec92375c3cdd8a6e502493d1229b6414e4036dfa"
 dependencies = [
  "async-channel 2.5.0",
  "async-task",
@@ -915,9 +915,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.4.3"
+version = "1.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "509591b7bcd67f4ef775afad7662703b4935daaa6ec0e5605cfb1090b32a2b6d"
+checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1055,7 +1055,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1235,9 +1235,9 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+checksum = "8498c871161e1742aaa9d52551b2d6ebdd4c3d45a3be423e3728f33b955be550"
 dependencies = [
  "cfg-if",
 ]
@@ -1749,7 +1749,7 @@ checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1828,9 +1828,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
+checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
 
 [[package]]
 name = "elliptic-curve"
@@ -2150,7 +2150,7 @@ checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -2297,9 +2297,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.16"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
+checksum = "ef8e5e5a340588f4452631496976cf8636d4a7ecf600239fdc27615d2530bc16"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2865,7 +2865,7 @@ dependencies = [
  "prometheus",
  "prost",
  "prost-types",
- "rand 0.8.7",
+ "rand 0.8.8",
  "rcgen 0.14.9",
  "regex",
  "reqwest 0.13.4",
@@ -3076,7 +3076,7 @@ dependencies = [
  "hkdf",
  "ic_principal",
  "pem 3.0.6",
- "rand 0.8.7",
+ "rand 0.8.8",
  "thiserror 2.0.20",
  "zeroize",
 ]
@@ -3121,7 +3121,7 @@ dependencies = [
  "nix",
  "pocket-ic",
  "prometheus",
- "rand 0.8.7",
+ "rand 0.8.8",
  "rand_regex",
  "regex",
  "reqwest 0.13.4",
@@ -3358,7 +3358,7 @@ dependencies = [
  "ic_bls12_381",
  "lazy_static",
  "pairing",
- "rand 0.8.7",
+ "rand 0.8.8",
  "sha2 0.10.9",
 ]
 
@@ -3467,9 +3467,9 @@ checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
 
 [[package]]
 name = "icu_provider"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92a7ed671a6aad807a8651a2e1782a6598fda9ce5185dd8158549e95a91c6428"
+checksum = "d27bbb9d3abbefac45d55f647c9de1d44aafcd1186eb91879afef17c396c3e73"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -4044,9 +4044,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.33"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
 name = "logos"
@@ -4145,9 +4145,9 @@ dependencies = [
 
 [[package]]
 name = "mail-parser"
-version = "0.11.6"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4084ec5c2f90b341d0c70990e92a23b128f75ca14fc1dd5edd8fd5c9b417da4d"
+checksum = "0b3a9080c1fb8190e232df37a10aa1b3d6b08be084e537069913f025e0ce86c5"
 dependencies = [
  "encoding_rs",
  "hashify",
@@ -4397,7 +4397,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand 0.8.7",
+ "rand 0.8.8",
  "smallvec",
  "zeroize",
 ]
@@ -4488,7 +4488,7 @@ dependencies = [
  "chrono",
  "getrandom 0.2.17",
  "http 1.5.0",
- "rand 0.8.7",
+ "rand 0.8.8",
  "serde",
  "serde_json",
  "serde_path_to_error",
@@ -5258,9 +5258,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
+checksum = "e058c7de0b26af77780c769414d6257830bb240f3c38477dbc2c16e5f54d6d4c"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -5347,7 +5347,7 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4bfbd599a8c757f89100e3ae559fb1ef9efa1cfd9276136862e3089dec627b31"
 dependencies = [
- "rand 0.8.7",
+ "rand 0.8.8",
  "regex-syntax",
 ]
 
@@ -5461,7 +5461,7 @@ checksum = "92ecd8964f8453721699a1ed72037b0db49ce2f5a5138486ee89bed6f67cdf3a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -5861,9 +5861,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.14"
+version = "0.103.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0527518605e68109d875e248ea259b6758801cf165e4b2c2733ae3b51f12535a"
+checksum = "f3c3cf1d8b1e7d4927e2d154c3fcb02979afb9939629c62cd9048d4f07b60ac2"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -5960,7 +5960,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals 0.30.0",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -6063,7 +6063,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -6085,7 +6085,7 @@ checksum = "f852137cce035d6a4df67ccce505ff6b3e9fd3a10e3e52b24dc71e650bb1a9bd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -6120,7 +6120,7 @@ checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -6606,9 +6606,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6774,7 +6774,7 @@ checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -6948,7 +6948,7 @@ checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -7533,9 +7533,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.256.0"
+version = "0.258.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec1492381bfd5ea51c2a99a919b676662559925cb8d7490547ec2e14c1ad3eb1"
+checksum = "e974fe6821a8cf64575d51ea2194e2c8f77e7b66e9afe7419ce8a97f9ee0d251"
 dependencies = [
  "leb128fmt",
  "wasmparser",
@@ -7569,9 +7569,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.256.0"
+version = "0.258.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60bd825ffedc6cba8a642924ba7ae424afbc47811cffbcb7b92031ec24e59b4c"
+checksum = "d9a61719f93a87b16d325921e251800c4833f8fab50fa21c7de73aed50086313"
 dependencies = [
  "bitflags 2.13.1",
  "indexmap 2.14.0",
@@ -7580,9 +7580,9 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "256.0.0"
+version = "258.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3ad42723fc9222da007f05812a3249c9a4ee7af79d497fc2a2079579ad7efe6"
+checksum = "97f7defc7ecca8b19ac7f824598eadd0c53985ee00c74060d65051e9da5b58a1"
 dependencies = [
  "bumpalo",
  "leb128fmt",
@@ -7593,9 +7593,9 @@ dependencies = [
 
 [[package]]
 name = "wat"
-version = "1.256.0"
+version = "1.258.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37cc86c54d8011b3202e265bfebada440733ea3a788ffaf46d395f7d2fdeacfb"
+checksum = "7555c008cca87f2ac58d9f83ccda7e7b44611093ce28eb28f052e7c78024b9bf"
 dependencies = [
  "wast",
 ]
@@ -8038,9 +8038,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.7"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94b5c6b5976d66c1d703c4fd17d3f5e43c8cedaacf604961b171adc7130896d8"
+checksum = "bb0464e17806c1d976d5cba29399c7f08e516e279e2ba493f63123b5fca67dd8"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -8049,13 +8049,13 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f212a141d820099d57ffafb9569be9617a6f27d3dc881fbee8fb56642f917a9"
+checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3083,7 +3083,7 @@ dependencies = [
 
 [[package]]
 name = "ic-gateway"
-version = "0.2.0"
+version = "0.0.0-git"
 dependencies = [
  "ahash",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "ic-gateway"
-version = "0.2.0"
+# Version is set by a Github workflow from the git tag
+version = "0.0.0-git"
 description = "HTTP-to-IC gateway"
 edition = "2024"
 default-run = "ic-gateway"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -677,6 +677,10 @@ pub struct McpCli {
     #[clap(env, long, requires = "mcp_ii_instance")]
     pub mcp_public_url: Option<Url>,
 
+    /// URL to redirect to when a user requests the root of the MCP public URL
+    #[clap(env, long, default_value = "https://internetcomputer.org/mcp")]
+    pub mcp_root_redirect: Url,
+
     /// MCP URL path
     #[clap(env, long, default_value = "/mcp")]
     pub mcp_url_path: String,

--- a/src/core.rs
+++ b/src/core.rs
@@ -348,8 +348,9 @@ pub async fn main(
             cli.mcp.mcp_public_url.as_ref().unwrap(),
         );
 
-        let (router, mcp) = crate::mcp::setup_mcp(&cli.mcp, ic_agent.clone(), gateway_router)
-            .context("unable to set up MCP")?;
+        let (router, mcp) =
+            crate::mcp::setup_mcp(&cli.mcp, ic_agent.clone(), gateway_router, &registry)
+                .context("unable to set up MCP")?;
         (router, Some(mcp))
     } else {
         (gateway_router, None)

--- a/src/core.rs
+++ b/src/core.rs
@@ -278,7 +278,7 @@ pub async fn main(
         )) as Arc<dyn ProvidesCustomDomains>);
     }
 
-    // Create IC Agent for use by RoutingTableManager / SMTP
+    // Create IC Agent for use by RoutingTableManager / SMTP / MCP
     let ic_agent = create_agent(cli, http_service_ll, route_provider.clone())
         .await
         .context("unable to create agent for subnets info fetcher")?;
@@ -322,6 +322,8 @@ pub async fn main(
         health_manager.clone(),
         http_client.clone(),
         http_client_hyper_ll,
+        #[cfg(feature = "mcp")]
+        ic_agent.clone(),
         route_provider.clone(),
         &registry,
         shutdown_token.clone(),
@@ -338,22 +340,6 @@ pub async fn main(
         gateway_router.clone()
     } else {
         Router::new().fallback(redirect_to_https)
-    };
-
-    // Inject MCP router if configured
-    #[cfg(feature = "mcp")]
-    let (gateway_router, mcp) = if let Some(v) = cli.mcp.mcp_ii_instance {
-        warn!(
-            "Starting MCP at {} (II {v})",
-            cli.mcp.mcp_public_url.as_ref().unwrap(),
-        );
-
-        let (router, mcp) =
-            crate::mcp::setup_mcp(&cli.mcp, ic_agent.clone(), gateway_router, &registry)
-                .context("unable to set up MCP")?;
-        (router, Some(mcp))
-    } else {
-        (gateway_router, None)
     };
 
     // Create HTTP server
@@ -460,11 +446,6 @@ pub async fn main(
     #[cfg(feature = "smtp")]
     if let Some(v) = vector_smtp {
         v.stop().await;
-    }
-
-    #[cfg(feature = "mcp")]
-    if let Some(v) = mcp {
-        v.shutdown();
     }
 
     Ok(())

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -1,6 +1,12 @@
-use anyhow::{Error, anyhow};
-use axum::Router;
-use imcp2::{Agent, IiInstance, McpConfig, McpServer, SharedClients, auth_callbacks_router};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use anyhow::{Context, Error, anyhow};
+use axum::{Router, middleware::from_fn_with_state};
+use imcp2::{
+    Agent, IiInstance, McpConfig, McpServer, SharedClients, auth_callbacks_router,
+    metrics::{Metrics, write_request_metrics},
+};
+use prometheus::Registry;
 use strum::{Display, EnumString};
 
 #[derive(EnumString, Clone, Copy, Display)]
@@ -13,7 +19,12 @@ pub enum IiType {
 use crate::cli::McpCli;
 
 /// Inject MCP routes into Router
-pub fn setup_mcp(cli: &McpCli, agent: Agent, router: Router) -> Result<(Router, McpServer), Error> {
+pub fn setup_mcp(
+    cli: &McpCli,
+    agent: Agent,
+    router: Router,
+    registry: &Registry,
+) -> Result<(Router, McpServer), Error> {
     let ii_instance = match cli.mcp_ii_instance.as_ref().unwrap() {
         IiType::Beta => IiInstance::beta(),
         IiType::Prod => IiInstance::prod(),
@@ -44,11 +55,23 @@ pub fn setup_mcp(cli: &McpCli, agent: Agent, router: Router) -> Result<(Router, 
     let mcp = McpServer::new(config);
     mcp.spawn_session_reaper();
 
+    let metrics = Metrics::new(
+        registry,
+        env!("CARGO_PKG_VERSION"),
+        option_env!("GIT_SHA").unwrap_or("unknown"),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_or(0, |d| d.as_secs()),
+        &[&mcp],
+    )
+    .context("unable to create MCP metrics")?;
+
     let router = router
         .nest_service(mcp.mcp_path(), mcp.mcp_router())
         .merge(mcp.well_known_router())
         .merge(mcp.root_well_known_router())
-        .merge(auth_callbacks_router(&[&mcp]));
+        .merge(auth_callbacks_router(&[&mcp]))
+        .layer(from_fn_with_state(metrics, write_request_metrics));
 
     Ok((router, mcp))
 }

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -1,13 +1,19 @@
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::{
+    sync::Arc,
+    time::{SystemTime, UNIX_EPOCH},
+};
 
 use anyhow::{Context, Error, anyhow};
-use axum::{Router, middleware::from_fn_with_state};
+use async_trait::async_trait;
+use axum::{Router, middleware::from_fn_with_state, response::Redirect};
+use ic_bn_lib::tasks::{Run, TaskManager};
 use imcp2::{
     Agent, IiInstance, McpConfig, McpServer, SharedClients, auth_callbacks_router,
     metrics::{Metrics, write_request_metrics},
 };
 use prometheus::Registry;
 use strum::{Display, EnumString};
+use tokio_util::sync::CancellationToken;
 
 #[derive(EnumString, Clone, Copy, Display)]
 #[strum(serialize_all = "snake_case")]
@@ -18,13 +24,25 @@ pub enum IiType {
 
 use crate::cli::McpCli;
 
+struct McpWrapper(McpServer);
+
+#[async_trait]
+impl Run for McpWrapper {
+    async fn run(&self, token: CancellationToken) -> Result<(), Error> {
+        self.0.spawn_session_reaper();
+        token.cancelled().await;
+        self.0.shutdown();
+        Ok(())
+    }
+}
+
 /// Inject MCP routes into Router
 pub fn setup_mcp(
     cli: &McpCli,
     agent: Agent,
-    router: Router,
     registry: &Registry,
-) -> Result<(Router, McpServer), Error> {
+    tasks: &mut TaskManager,
+) -> Result<Router, Error> {
     let ii_instance = match cli.mcp_ii_instance.as_ref().unwrap() {
         IiType::Beta => IiInstance::beta(),
         IiType::Prod => IiInstance::prod(),
@@ -53,7 +71,6 @@ pub fn setup_mcp(
     };
 
     let mcp = McpServer::new(config);
-    mcp.spawn_session_reaper();
 
     let metrics = Metrics::new(
         registry,
@@ -66,12 +83,16 @@ pub fn setup_mcp(
     )
     .context("unable to create MCP metrics")?;
 
-    let router = router
+    let mcp_redirect_url = cli.mcp_root_redirect.to_string();
+    let router = Router::new()
         .nest_service(mcp.mcp_path(), mcp.mcp_router())
         .merge(mcp.well_known_router())
         .merge(mcp.root_well_known_router())
         .merge(auth_callbacks_router(&[&mcp]))
+        .fallback(|| async move { Redirect::permanent(&mcp_redirect_url) })
         .layer(from_fn_with_state(metrics, write_request_metrics));
 
-    Ok((router, mcp))
+    tasks.add("mcp", Arc::new(McpWrapper(mcp)));
+
+    Ok(router)
 }

--- a/src/routing/mod.rs
+++ b/src/routing/mod.rs
@@ -577,7 +577,7 @@ pub async fn setup_router(
                 // Check if MCP is enabled & the request's host matches MCP hostname
                 #[cfg(feature = "mcp")]
                 if let (Some((mcp_router, mcp_hostname)), Some(host)) = (mcp, extract_host(host))
-                    && host == mcp_hostname
+                    && host.eq_ignore_ascii_case(&mcp_hostname)
                 {
                     return mcp_router.oneshot(request).await;
                 }
@@ -834,16 +834,31 @@ mod test {
 
     #[cfg(feature = "mcp")]
     #[tokio::test]
-    async fn test_mcp_redirect() {
-        fn request_to(host: &str) -> Request {
+    async fn test_mcp() {
+        use http::header::{
+            ACCESS_CONTROL_ALLOW_METHODS, AUTHORIZATION, CACHE_CONTROL, LOCATION, WWW_AUTHENTICATE,
+        };
+
+        const MCP_HOST: &str = "mcp.ic0.app";
+        const ISSUER: &str = "https://mcp.ic0.app/mcp";
+        const PROTECTED_RESOURCE_URL: &str =
+            "https://mcp.ic0.app/.well-known/oauth-protected-resource/mcp";
+
+        fn request(method: Method, host: &str, path_and_query: &str) -> Request {
             let mut req = Request::new(Body::from(""));
-            *req.uri_mut() = Uri::try_from(format!("http://{host}/")).unwrap();
+            *req.method_mut() = method;
+            *req.uri_mut() = Uri::try_from(format!("http://{host}{path_and_query}")).unwrap();
             let conn_info = Arc::new(ConnInfo {
                 remote_addr: Addr::Tcp(SocketAddr::from_str("127.0.0.1:12345").unwrap()),
                 ..Default::default()
             });
             req.extensions_mut().insert(conn_info);
             req
+        }
+
+        async fn json_body(resp: axum::response::Response) -> serde_json::Value {
+            let body = to_bytes(resp.into_body(), 8192).await.unwrap();
+            serde_json::from_slice(&body).unwrap()
         }
 
         let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
@@ -866,16 +881,196 @@ mod test {
         .await;
         tasks.start();
 
-        // A request to the MCP hostname should be redirected to the MCP root redirect URL.
-        let resp = router.call(request_to("mcp.ic0.app")).await.unwrap();
-        assert_eq!(resp.status(), StatusCode::PERMANENT_REDIRECT);
+        // Any request to the MCP hostname that doesn't match a real MCP/OAuth/well-known
+        // route falls through to a permanent redirect to the configured root-redirect URL —
+        // regardless of method, path, or query string (the fallback matches on path only).
+        for (method, path) in [
+            (Method::GET, "/"),
+            (Method::POST, "/"),
+            (Method::GET, "/?foo=bar"),
+            (Method::GET, "/some/unknown/path"),
+            (Method::GET, "/MCP"), // path matching is case-sensitive: doesn't hit the /mcp mount
+        ] {
+            let resp = router.call(request(method, MCP_HOST, path)).await.unwrap();
+            assert_eq!(resp.status(), StatusCode::PERMANENT_REDIRECT, "path {path}");
+            assert_eq!(
+                resp.headers().get(LOCATION).unwrap(),
+                "https://internetcomputer.org/mcp",
+                "path {path}",
+            );
+        }
+
+        // A request to some other hostname is untouched by MCP entirely: it falls through to
+        // the ordinary gateway logic instead (here, the base-domain-root dashboard redirect).
+        let resp = router
+            .call(request(Method::GET, "ic0.app", "/"))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::TEMPORARY_REDIRECT);
         assert_eq!(
-            resp.headers().get(http::header::LOCATION).unwrap(),
-            "https://internetcomputer.org/mcp",
+            resp.headers().get(LOCATION).unwrap(),
+            "https://dashboard.internetcomputer.org/",
         );
 
-        // A request to some other hostname should not be redirected.
-        let resp = router.call(request_to("ic0.app")).await.unwrap();
-        assert_ne!(resp.status(), StatusCode::PERMANENT_REDIRECT);
+        // -- Discovery documents (RFC 8414 authorization-server metadata, RFC 9728
+        // protected-resource metadata) --
+
+        // Root discovery documents (this is the only/default MCP instance on the origin).
+        let resp = router
+            .call(request(
+                Method::GET,
+                MCP_HOST,
+                "/.well-known/oauth-authorization-server",
+            ))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = json_body(resp).await;
+        assert_eq!(body["issuer"], ISSUER);
+        assert_eq!(
+            body["authorization_endpoint"],
+            format!("{ISSUER}/oauth/authorize")
+        );
+        assert_eq!(body["token_endpoint"], format!("{ISSUER}/oauth/token"));
+        assert_eq!(
+            body["registration_endpoint"],
+            format!("{ISSUER}/oauth/register")
+        );
+
+        let resp = router
+            .call(request(
+                Method::GET,
+                MCP_HOST,
+                "/.well-known/oauth-protected-resource",
+            ))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = json_body(resp).await;
+        assert_eq!(body["resource"], ISSUER);
+        assert_eq!(body["authorization_servers"], serde_json::json!([ISSUER]));
+
+        // Path-inserted authorization-server metadata: both the RFC 8414 location and the
+        // OIDC-style alternate living inside the /mcp mount serve the same document.
+        for well_known in [
+            "/.well-known/oauth-authorization-server/mcp",
+            "/mcp/.well-known/oauth-authorization-server",
+        ] {
+            let resp = router
+                .call(request(Method::GET, MCP_HOST, well_known))
+                .await
+                .unwrap();
+            assert_eq!(resp.status(), StatusCode::OK, "well-known {well_known}");
+            let body = json_body(resp).await;
+            assert_eq!(body["issuer"], ISSUER, "well-known {well_known}");
+        }
+
+        let resp = router
+            .call(request(
+                Method::GET,
+                MCP_HOST,
+                "/.well-known/oauth-protected-resource/mcp",
+            ))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = json_body(resp).await;
+        assert_eq!(body["resource"], ISSUER);
+
+        // II's connect-callback allow-list (dfinity/internet-identity#4091): must declare
+        // this instance's callback verbatim and forbid caching by any intermediary.
+        let resp = router
+            .call(request(
+                Method::GET,
+                MCP_HOST,
+                "/.well-known/ii-auth-callbacks",
+            ))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(resp.headers().get(CACHE_CONTROL).unwrap(), "no-store");
+        let body = json_body(resp).await;
+        assert_eq!(
+            body["callbacks"],
+            serde_json::json!([format!("{ISSUER}/oauth/connect/callback")]),
+        );
+
+        // A wrong method on a GET-only discovery route is a plain 405 — the redirect
+        // fallback only fires for paths that match no route at all.
+        let resp = router
+            .call(request(
+                Method::POST,
+                MCP_HOST,
+                "/.well-known/oauth-authorization-server",
+            ))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::METHOD_NOT_ALLOWED);
+
+        // -- The bearer-gated MCP resource itself --
+
+        // No Authorization header at all: 401 with a bare WWW-Authenticate challenge (no
+        // `error=`, per RFC 6750 — that's reserved for a token that WAS presented but is
+        // bad). Both the bare mount path and its trailing-slash form hit the same gate
+        // rather than the redirect fallback.
+        for path in ["/mcp", "/mcp/"] {
+            let resp = router
+                .call(request(Method::GET, MCP_HOST, path))
+                .await
+                .unwrap();
+            assert_eq!(resp.status(), StatusCode::UNAUTHORIZED, "path {path}");
+            let challenge = resp
+                .headers()
+                .get(WWW_AUTHENTICATE)
+                .unwrap()
+                .to_str()
+                .unwrap()
+                .to_string();
+            assert!(
+                challenge.contains(&format!("resource_metadata=\"{PROTECTED_RESOURCE_URL}\"")),
+                "path {path}: {challenge}"
+            );
+            assert!(!challenge.contains("error="), "path {path}: {challenge}");
+        }
+
+        // A bad bearer token: still 401, but now the challenge carries
+        // `error="invalid_token"` so a client can tell "expired/invalid -> reconnect" apart
+        // from "no token yet -> just authenticate".
+        let mut req = request(Method::GET, MCP_HOST, "/mcp");
+        req.headers_mut().insert(
+            AUTHORIZATION,
+            HeaderValue::from_static("Bearer bogus-token"),
+        );
+        let resp = router.call(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+        let challenge = resp
+            .headers()
+            .get(WWW_AUTHENTICATE)
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .to_string();
+        assert!(challenge.contains("error=\"invalid_token\""), "{challenge}");
+        assert!(
+            challenge.contains(&format!("resource_metadata=\"{PROTECTED_RESOURCE_URL}\"")),
+            "{challenge}"
+        );
+
+        // CORS preflight is answered before authentication: an OPTIONS request never
+        // reaches the bearer gate, even with no token and no Origin header at all.
+        let resp = router
+            .call(request(Method::OPTIONS, MCP_HOST, "/mcp"))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert!(resp.headers().get(WWW_AUTHENTICATE).is_none());
+        assert!(
+            resp.headers()
+                .get(ACCESS_CONTROL_ALLOW_METHODS)
+                .unwrap()
+                .to_str()
+                .unwrap()
+                .contains("POST")
+        );
     }
 }

--- a/src/routing/mod.rs
+++ b/src/routing/mod.rs
@@ -524,6 +524,15 @@ pub async fn setup_router(
         .layer(option_layer(prerender_mw));
 
     let api_hostname = cli.api.api_hostname.clone().map(|x| x.to_string());
+    #[cfg(feature = "mcp")]
+    let mcp_hostname = cli
+        .mcp
+        .mcp_public_url
+        .as_ref()
+        .and_then(|url| url.host_str())
+        .map(|s| s.to_string());
+    #[cfg(feature = "mcp")]
+    let mcp_redirect_url = cli.mcp.mcp_root_redirect.clone().to_string();
 
     let custom_domains_router = custom_domains_router.map(|x| {
         Router::new()
@@ -548,6 +557,20 @@ pub async fn setup_router(
                 let Some(host) = extract_authority(&request) else {
                     return Ok(ErrorCause::Client(ClientError::NoAuthority).into_response());
                 };
+
+                // Check if the request's host matches MCP hostname.
+                // We end up in the fallback handler only if the request didn't match any of the MCP API routes,
+                // so we can safely redirect if the hosts match.
+                #[cfg(feature = "mcp")]
+                {
+                    if mcp_hostname
+                        .as_ref()
+                        .zip(extract_host(host))
+                        .is_some_and(|(a, b)| a == b)
+                    {
+                        return Ok(Redirect::permanent(&mcp_redirect_url).into_response());
+                    }
+                }
 
                 // Check if the request's host matches API hostname
                 if api_hostname

--- a/src/routing/mod.rs
+++ b/src/routing/mod.rs
@@ -35,7 +35,7 @@ use ic_bn_lib::{
         },
     },
     hval,
-    ic_agent::agent::route_provider::RouteProvider,
+    ic_agent::{Agent, agent::route_provider::RouteProvider},
     tasks::TaskManager,
     vector::client::Vector,
 };
@@ -195,6 +195,7 @@ pub async fn setup_router(
     health_manager: Arc<HealthManager>,
     http_client: Arc<dyn Client>,
     http_client_hyper: Arc<dyn ClientHttp<Full<Bytes>>>,
+    #[cfg(feature = "mcp")] ic_agent: Agent,
     route_provider: Arc<dyn RouteProvider>,
     registry: &Registry,
     shutdown_token: CancellationToken,
@@ -524,15 +525,30 @@ pub async fn setup_router(
         .layer(option_layer(prerender_mw));
 
     let api_hostname = cli.api.api_hostname.clone().map(|x| x.to_string());
+
     #[cfg(feature = "mcp")]
-    let mcp_hostname = cli
-        .mcp
-        .mcp_public_url
-        .as_ref()
-        .and_then(|url| url.host_str())
-        .map(|s| s.to_string());
-    #[cfg(feature = "mcp")]
-    let mcp_redirect_url = cli.mcp.mcp_root_redirect.clone().to_string();
+    let mcp = if let Some(v) = cli.mcp.mcp_ii_instance {
+        warn!(
+            "Starting MCP at {} (II {v})",
+            cli.mcp.mcp_public_url.as_ref().unwrap(),
+        );
+
+        let mcp_hostname = cli
+            .mcp
+            .mcp_public_url
+            .clone()
+            .unwrap()
+            .host_str()
+            .unwrap()
+            .to_string();
+
+        let router = crate::mcp::setup_mcp(&cli.mcp, ic_agent.clone(), registry, &mut *tasks)
+            .context("unable to set up MCP")?;
+
+        Some((router, mcp_hostname))
+    } else {
+        None
+    };
 
     let custom_domains_router = custom_domains_router.map(|x| {
         Router::new()
@@ -558,18 +574,12 @@ pub async fn setup_router(
                     return Ok(ErrorCause::Client(ClientError::NoAuthority).into_response());
                 };
 
-                // Check if the request's host matches MCP hostname.
-                // We end up in the fallback handler only if the request didn't match any of the MCP API routes,
-                // so we can safely redirect if the hosts match.
+                // Check if MCP is enabled & the request's host matches MCP hostname
                 #[cfg(feature = "mcp")]
+                if let (Some((mcp_router, mcp_hostname)), Some(host)) = (mcp, extract_host(host))
+                    && host == mcp_hostname
                 {
-                    if mcp_hostname
-                        .as_ref()
-                        .zip(extract_host(host))
-                        .is_some_and(|(a, b)| a == b)
-                    {
-                        return Ok(Redirect::permanent(&mcp_redirect_url).into_response());
-                    }
+                    return mcp_router.oneshot(request).await;
                 }
 
                 // Check if the request's host matches API hostname

--- a/src/routing/mod.rs
+++ b/src/routing/mod.rs
@@ -663,6 +663,8 @@ mod test {
     use tower::Service;
 
     use crate::test::setup_test_router;
+    #[cfg(feature = "mcp")]
+    use crate::test::{TestClient, setup_test_router_with_http_client};
 
     use super::*;
 
@@ -818,5 +820,52 @@ mod test {
         let body = resp.into_body();
         let body = to_bytes(body, 1024).await.unwrap();
         assert_eq!(body, b"X".repeat(512));
+    }
+
+    #[cfg(feature = "mcp")]
+    #[tokio::test]
+    async fn test_mcp_redirect() {
+        fn request_to(host: &str) -> Request {
+            let mut req = Request::new(Body::from(""));
+            *req.uri_mut() = Uri::try_from(format!("http://{host}/")).unwrap();
+            let conn_info = Arc::new(ConnInfo {
+                remote_addr: Addr::Tcp(SocketAddr::from_str("127.0.0.1:12345").unwrap()),
+                ..Default::default()
+            });
+            req.extensions_mut().insert(conn_info);
+            req
+        }
+
+        let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
+        let mut tasks = TaskManager::new();
+        let (mut router, _domains) = setup_test_router_with_http_client(
+            &mut tasks,
+            Arc::new(TestClient(512)),
+            &[
+                "--mcp-ii-instance",
+                "prod",
+                "--mcp-public-url",
+                "https://mcp.ic0.app",
+                "--mcp-state-dir",
+                "/tmp/ic-gateway-test-mcp-state",
+                "--mcp-root-redirect",
+                "https://internetcomputer.org/mcp",
+            ],
+        )
+        .await;
+        tasks.start();
+
+        // A request to the MCP hostname should be redirected to the MCP root redirect URL.
+        let resp = router.call(request_to("mcp.ic0.app")).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::PERMANENT_REDIRECT);
+        assert_eq!(
+            resp.headers().get(http::header::LOCATION).unwrap(),
+            "https://internetcomputer.org/mcp",
+        );
+
+        // A request to some other hostname should not be redirected.
+        let resp = router.call(request_to("ic0.app")).await.unwrap();
+        assert_ne!(resp.status(), StatusCode::PERMANENT_REDIRECT);
     }
 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -18,7 +18,10 @@ use ic_bn_lib::{
     custom_domains::{CustomDomain, ProvidesCustomDomains},
     health::HealthManager,
     http::{Client, ClientHttp, Error as HttpError},
-    ic_agent::agent::{ReplyResponse, route_provider::RoundRobinRouteProvider},
+    ic_agent::{
+        Agent,
+        agent::{ReplyResponse, route_provider::RoundRobinRouteProvider},
+    },
     ic_transport_types::QueryResponse,
     principal,
     tasks::TaskManager,
@@ -189,6 +192,8 @@ pub async fn setup_test_router_with_http_client(
         health_manager,
         http_client,
         http_client_hyper,
+        #[cfg(feature = "mcp")]
+        Agent::builder().with_url("https://foo").build().unwrap(),
         Arc::new(route_provider),
         &Registry::new(),
         CancellationToken::new(),

--- a/src/test.rs
+++ b/src/test.rs
@@ -112,14 +112,17 @@ impl LooksUpSubnetType for TestSubnetTypeLookuperEmpty {
 
 /// Creates a test router with some defaults and returns it along with a list of random custom domains that it serves
 pub async fn setup_test_router(tasks: &mut TaskManager) -> (Router, Vec<String>) {
-    setup_test_router_with_http_client(tasks, Arc::new(TestClient(512))).await
+    setup_test_router_with_http_client(tasks, Arc::new(TestClient(512)), &[]).await
 }
 
 /// Same as [`setup_test_router`] but allows supplying a custom client for the requests that
 /// the router proxies upstream (e.g. to inspect the headers it was called with).
+///
+/// `extra_args` are appended to the CLI arguments used to build the router (e.g. to enable MCP).
 pub async fn setup_test_router_with_http_client(
     tasks: &mut TaskManager,
     http_client_hyper: Arc<dyn ClientHttp<Full<Bytes>>>,
+    extra_args: &[&str],
 ) -> (Router, Vec<String>) {
     // SmallRng is Send which we require
     let mut rng = rand::rngs::SmallRng::from_entropy();
@@ -153,7 +156,10 @@ pub async fn setup_test_router_with_http_client(
         "test_data/GeoLite2-Country.mmdb",
         "--log-vector-url",
         "http://127.0.0.1/vector",
-    ];
+    ]
+    .into_iter()
+    .chain(extra_args.iter().copied())
+    .collect::<Vec<_>>();
     let cli = Cli::parse_from(args);
 
     let custom_domains = domains


### PR DESCRIPTION
This allows us to redirect people who open the MCP base domain w/o path to an MCP landing page.

* Restrict MCP feature to MCP domain
* Also use git tag as a version for cargo